### PR TITLE
simple comparison table for navigator vs ansible commands

### DIFF
--- a/downstream/modules/navigator/ref-navigator-command-comparison.adoc
+++ b/downstream/modules/navigator/ref-navigator-command-comparison.adoc
@@ -3,15 +3,15 @@
 = Ansible navigator command comparison
 
 [role="_abstract"]
-The Ansible navigator commands run familiar Ansible CLI commands in passthrough mode. You can use all of the subcommands and options allowed in the related Ansible CLI command. Use [command]`ansible-navigator --help` for details.
+The Ansible navigator commands run familiar Ansible CLI commands in passthrough mode. You can use all of the subcommands and options allowed in the related Ansible CLI command. Use `ansible-navigator --help` for details.
 
 .Comparing Ansible navigator and Ansible CLI commands table
 [options="header"]
 |====
 |Ansible navigator command|Ansible CLI command
-|[command]`ansible-navigator collections`|[command]`ansible-galaxy collection`
-|[command]`ansible-navigator config`|[command]`ansible-config`
-|[command]`ansible-navigator doc`|[command]`ansible-doc`
-|[command]`ansible-navigator inventory`|[command]`ansible-inventory`
-|[command]`ansible-navigator run`|[command]`ansible-playbook`
+|`ansible-navigator collections`|`ansible-galaxy collection`
+|`ansible-navigator config`|`ansible-config`
+|`ansible-navigator doc`|`ansible-doc`
+|`ansible-navigator inventory`|`ansible-inventory`
+|`ansible-navigator run`|`ansible-playbook`
 |====


### PR DESCRIPTION
First attempt at a reference table in asciidoc.

This table fulfills the developer guide section called:
reference table for command structure for Navigator and ansible core cli commands
as part of https://issues.redhat.com/browse/AAP-79

note: there will be separate modules for each navigator command at some point (as in this is not the only info we will give readers).  Downstream asciidoc content is written in small consumable chunks like this.