### PR TITLE
Install navigator

### DIFF
--- a/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
+++ b/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
@@ -1,0 +1,39 @@
+
+ifdef::context[:parent-context: {context}]
+
+////
+ Base the file name and the ID on the assembly title. For example:
+* file name: assembly-my-user-story.adoc
+* ID: [id="assembly-my-user-story_{context}"]
+* Title: = My user story
+
+The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken. Include {context} in the ID so the assembly can be reused.
+////
+
+[id="assembly-installing_on_rhel_{context}"]
+= Installing Ansible content navigator on RHEL
+
+:context: assembly-keyword
+
+////
+The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
+////
+
+[role="_abstract"]
+You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) 8 with `pip`, a downloaded tarball, or a downloaded RPM.
+
+== Prerequisites
+
+* You have installed RHEL 8 or later.
+
+include::navigator/proc-installing-navigator-rhel-pip.adoc[leveloffset=+1]
+include::navigator/proc-installing-navigator-rhel-tar.adoc[leveloffset=+1]
+include::navigator/proc-installing-navigator-rhel-rpm.adoc[leveloffset=+1]
+
+You have now installed Ansible-navigator and can use this tool to evaluate your playbooks, view your collections and inventories, and delve into the module-level documentation.
+
+////
+Restore the context to what it was before this assembly.
+////
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
+++ b/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
@@ -7,18 +7,18 @@ ifdef::context[:parent-context: {context}]
 :context: install-navigator-rhel
 
 [role="_abstract"]
-You can install {Navigator} on Red Hat Enterprise Linux (RHEL) 8 with a downloaded RPM.
+You can install {Navigator} on Red Hat Enterprise Linux (RHEL) 8 with`pip`.
 
 == Prerequisites
 
 * You have installed RHEL 8 or later.
 
-////
- - only RPM supported for first release
 include::navigator/proc-installing-navigator-rhel-pip.adoc[leveloffset=+1]
-include::navigator/proc-installing-navigator-rhel-tar.adoc[leveloffset=+1]
 ////
+ - only pip supported for now
+include::navigator/proc-installing-navigator-rhel-tar.adoc[leveloffset=+1]
 include::navigator/proc-installing-navigator-rhel-rpm.adoc[leveloffset=+1]
+////
 
 You have now installed  {Navigator} and can use this tool to evaluate your playbooks, view your collections and inventories, and delve into the module-level documentation.
 

--- a/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
+++ b/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
@@ -13,7 +13,7 @@ The ID is an anchor that links to the module. Avoid changing it after the module
 [id="assembly-installing_on_rhel_{context}"]
 = Installing Ansible content navigator on RHEL
 
-:context: assembly-keyword
+:context: install-navigator-rhel
 
 ////
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.

--- a/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
+++ b/downstream/assemblies/navigator/assembly-installing-on-rhel.adoc
@@ -1,36 +1,26 @@
 
 ifdef::context[:parent-context: {context}]
 
-////
- Base the file name and the ID on the assembly title. For example:
-* file name: assembly-my-user-story.adoc
-* ID: [id="assembly-my-user-story_{context}"]
-* Title: = My user story
-
-The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken. Include {context} in the ID so the assembly can be reused.
-////
-
 [id="assembly-installing_on_rhel_{context}"]
-= Installing Ansible content navigator on RHEL
+= Installing  {Navigator} on RHEL
 
 :context: install-navigator-rhel
 
-////
-The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
-////
-
 [role="_abstract"]
-You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) 8 with `pip`, a downloaded tarball, or a downloaded RPM.
+You can install {Navigator} on Red Hat Enterprise Linux (RHEL) 8 with a downloaded RPM.
 
 == Prerequisites
 
 * You have installed RHEL 8 or later.
 
+////
+ - only RPM supported for first release
 include::navigator/proc-installing-navigator-rhel-pip.adoc[leveloffset=+1]
 include::navigator/proc-installing-navigator-rhel-tar.adoc[leveloffset=+1]
+////
 include::navigator/proc-installing-navigator-rhel-rpm.adoc[leveloffset=+1]
 
-You have now installed Ansible-navigator and can use this tool to evaluate your playbooks, view your collections and inventories, and delve into the module-level documentation.
+You have now installed  {Navigator} and can use this tool to evaluate your playbooks, view your collections and inventories, and delve into the module-level documentation.
 
 ////
 Restore the context to what it was before this assembly.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
@@ -2,22 +2,22 @@
 [id="proc-installing-navigator-rhel-pip_{context}"]
 
 
-= Installing Ansible navigator on RHEL with pip
+= Installing {Navigator} on RHEL with pip
 
 
 [role="_abstract"]
 
-You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) with `pip`.
+You can install {Navigator} on Red Hat Enterprise Linux (RHEL) with `pip`.
 
 .Prerequisites
 
 * You have installed the prerequisites for RHEL.
-* You have Ansible or an Ansible execution environment installed.
+* You have Ansible or {ExecEnvNameStart} installed.
 
 
 .Procedure
 
-. Install Ansible-navigator:
+. Install {Navigator}:
 +
 ```
 $ pip install ansible-navigator
@@ -25,7 +25,7 @@ $ pip install ansible-navigator
 +
 
 . Alternately, for offline access:
-.. Download Ansible-navigator and copy the package to the offline system:
+.. Download {Navigator} and copy the package to the offline system:
 +
 ```
 $ pip3 download ansible-navigator -d
@@ -42,10 +42,10 @@ $ pip3 install --no-index --find-links /<install path>/ansible-navigator-x.y.z.t
 
 .Verification
 
-* Verify your Ansible-navigator installation:
+* Verify your {Navigator} installation:
 +
 ```
 $ ansible-navigator --help
 ```
 
-You should see the help output describing the main functions of Ansible-navigator.
+You should see the help output describing the main functions of {Navigator}.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 
-You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) 8 with `pip`.
+You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) with `pip`.
 
 .Prerequisites
 

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
@@ -1,0 +1,51 @@
+
+[id="proc-installing-navigator-rhel-pip_{context}"]
+
+
+= Installing Ansible navigator on RHEL with pip
+
+
+[role="_abstract"]
+
+You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) 8 with `pip`.
+
+.Prerequisites
+
+* You have installed the prerequisites for RHEL.
+* You have Ansible or an Ansible execution environment installed.
+
+
+.Procedure
+
+. Install Ansible-navigator:
++
+```
+$ pip install ansible-navigator
+```
++
+
+. Alternately, for offline access:
+.. Download Ansible-navigator and copy the package to the offline system:
++
+```
+$ pip3 download ansible-navigator -d
+```
++
+
+.. Install on the offline system:
++
+```
+$ pip3 install --no-index --find-links /<install path>/ansible-navigator-x.y.z.tar.gz
+```
++
+
+
+.Verification
+
+* Verify your Ansible-navigator installation:
++
+```
+$ ansible-navigator --help
+```
+
+You should see the help output describing the main functions of Ansible-navigator.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-pip.adoc
@@ -28,14 +28,82 @@ $ pip install ansible-navigator
 .. Download {Navigator} and copy the package to the offline system:
 +
 ```
-$ pip3 download ansible-navigator -d
+$ pip3 download ansible-navigator -d .
+
+ansible-navigator-demo](main)$ pip3 download ansible-navigator -d .
+Collecting ansible-navigator
+ Using cached ansible_navigator-0.7.0-py3-none-any.whl (197 kB)
+Collecting onigurumacffi
+ Using cached onigurumacffi-1.1.0-cp36-abi3-manylinux1_x86_64.whl (536 kB)
+Collecting pyyaml
+ Using cached PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
+Collecting ansible-runner<3,>=2a
+ Using cached ansible_runner-2.0.0a4-py3-none-any.whl (98 kB)
+Collecting jinja2
+ Using cached Jinja2-3.0.1-py3-none-any.whl (133 kB)
+Collecting pexpect>=4.5
+ Using cached pexpect-4.8.0-py2.py3-none-any.whl (59 kB)
+Collecting python-daemon
+ Using cached python_daemon-2.3.0-py2.py3-none-any.whl (35 kB)
+Collecting six
+ Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
+Collecting ptyprocess>=0.5
+ Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
+Collecting MarkupSafe>=2.0
+ Using cached MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl (30 kB)
+Collecting cffi>=1
+ Using cached cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl (406 kB)
+Collecting pycparser
+ Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
+Collecting setuptools
+ Using cached setuptools-57.0.0-py3-none-any.whl (821 kB)
+Collecting lockfile>=0.10
+ Using cached lockfile-0.12.2-py2.py3-none-any.whl (13 kB)
+Collecting docutils
+ Using cached docutils-0.17.1-py2.py3-none-any.whl (575 kB)
+Saved ./ansible_navigator-0.7.0-py3-none-any.whl
+Saved ./ansible_runner-2.0.0a4-py3-none-any.whl
+Saved ./pexpect-4.8.0-py2.py3-none-any.whl
+Saved ./ptyprocess-0.7.0-py2.py3-none-any.whl
+Saved ./Jinja2-3.0.1-py3-none-any.whl
+Saved ./MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl
+Saved ./onigurumacffi-1.1.0-cp36-abi3-manylinux1_x86_64.whl
+Saved ./cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl
+Saved ./pycparser-2.20-py2.py3-none-any.whl
+Saved ./python_daemon-2.3.0-py2.py3-none-any.whl
+Saved ./lockfile-0.12.2-py2.py3-none-any.whl
+Saved ./docutils-0.17.1-py2.py3-none-any.whl
+Saved ./PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl
+Saved ./six-1.16.0-py2.py3-none-any.whl
+Saved ./setuptools-57.0.0-py3-none-any.whl
+Successfully downloaded ansible-navigator ansible-runner pexpect ptyprocess jinja2 MarkupSafe
+ onigurumacffi cffi pycparser python-daemon lockfile docutils pyyaml six setuptools
 ```
 +
 
 .. Install on the offline system:
 +
 ```
-$ pip3 install --no-index --find-links /<install path>/ansible-navigator-x.y.z.tar.gz
+$ pip3 install ./ansible_navigator-0.7.0-py3-none-any.whl
+
+Defaulting to user installation because normal site-packages is not writeable
+Processing ./ansible_navigator-0.7.0-py3-none-any.whl
+Requirement already satisfied: ansible-runner<3,>=2a in /home/samccann/.local/lib/python3.9/site-packages (from ansible-navigator==0.7.0) (2.0.0a4)
+Requirement already satisfied: jinja2 in /home/samccann/.local/lib/python3.9/site-packages (from ansible-navigator==0.7.0) (2.11.3)
+Requirement already satisfied: pyyaml in /home/samccann/.local/lib/python3.9/site-packages (from ansible-navigator==0.7.0) (5.4.1)
+Requirement already satisfied: onigurumacffi in /home/samccann/.local/lib/python3.9/site-packages (from ansible-navigator==0.7.0) (1.1.0)
+Requirement already satisfied: python-daemon in /home/samccann/.local/lib/python3.9/site-packages (from ansible-runner<3,>=2a->ansible-navigator==0.7.0) (2.3.0)
+Requirement already satisfied: six in /usr/lib/python3.9/site-packages (from ansible-runner<3,>=2a->ansible-navigator==0.7.0) (1.15.0)
+Requirement already satisfied: pexpect>=4.5 in /usr/lib/python3.9/site-packages (from ansible-runner<3,>=2a->ansible-navigator==0.7.0) (4.8.0)
+Requirement already satisfied: MarkupSafe>=0.23 in /usr/lib64/python3.9/site-packages (from jinja2->ansible-navigator==0.7.0) (1.1.1)
+Requirement already satisfied: cffi>=1 in /usr/lib64/python3.9/site-packages (from onigurumacffi->ansible-navigator==0.7.0) (1.14.5)
+Requirement already satisfied: pycparser in /usr/lib/python3.9/site-packages (from cffi>=1->onigurumacffi->ansible-navigator==0.7.0) (2.20)
+Requirement already satisfied: ply==3.11 in /usr/lib/python3.9/site-packages (from pycparser->cffi>=1->onigurumacffi->ansible-navigator==0.7.0) (3.11)
+Requirement already satisfied: setuptools in /home/samccann/.local/lib/python3.9/site-packages (from python-daemon->ansible-runner<3,>=2a->ansible-navigator==0.7.0) (56.2.0)
+Requirement already satisfied: docutils in /home/samccann/.local/lib/python3.9/site-packages (from python-daemon->ansible-runner<3,>=2a->ansible-navigator==0.7.0) (0.17.1)
+Requirement already satisfied: lockfile>=0.10 in /home/samccann/.local/lib/python3.9/site-packages (from python-daemon->ansible-runner<3,>=2a->ansible-navigator==0.7.0) (0.12.2)
+Installing collected packages: ansible-navigator
+Successfully installed ansible-navigator-0.7.0
 ```
 +
 

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -1,0 +1,38 @@
+
+[id="proc-installing-navigator-rhel-rpm_{context}"]
+
+
+= Installing Ansible navigator on RHEL from an RPM
+
+
+[role="_abstract"]
+
+You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) from an RPM.
+
+.Prerequisites
+
+* You have installed the prerequisites for RHEL.
+* You have Ansible or an Ansible execution environment installed.
+
+
+.Procedure
+
+. Download the RPM.
+
+. Install Ansible-navigator:
++
+```
+$ rpm -UVH ansible-navigator
+```
++
+
+
+.Verification
+
+* Verify your Ansible-navigator installation:
++
+```
+$ ansible-navigator --help
+```
+
+You should see the help output describing the main functions of Ansible-navigator.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -2,24 +2,24 @@
 [id="proc-installing-navigator-rhel-rpm_{context}"]
 
 
-= Installing Ansible navigator on RHEL from an RPM
+= Installing {Navigator}r on RHEL from an RPM
 
 
 [role="_abstract"]
 
-You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) from an RPM.
+You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from an RPM.
 
 .Prerequisites
 
 * You have installed the prerequisites for RHEL.
-* You have Ansible or an Ansible execution environment installed.
+* You have Ansible or {ExecEnvNameStart} installed.
 
 
 .Procedure
 
 . Download the RPM.
 
-. Install Ansible-navigator:
+. Install {Navigator}:
 +
 ```
 $ rpm -UVH ansible-navigator
@@ -29,10 +29,10 @@ $ rpm -UVH ansible-navigator
 
 .Verification
 
-* Verify your Ansible-navigator installation:
+* Verify your {Navigator} installation:
 +
 ```
 $ ansible-navigator --help
 ```
 
-You should see the help output describing the main functions of Ansible-navigator.
+You should see the help output describing the main functions of {Navigator}.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-tar.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-tar.adoc
@@ -2,24 +2,24 @@
 [id="proc-installing-navigator-rhel-tar_{context}"]
 
 
-= Installing Ansible navigator on RHEL from a tarball
+= Installing {Navigator} on RHEL from a tarball
 
 
 [role="_abstract"]
 
-You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) from a tarball.
+You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from a tarball.
 
 .Prerequisites
 
 * You have installed the prerequisites for RHEL.
-* You have Ansible or an Ansible execution environment installed.
+* You have Ansible or {ExecEnvNameStart} installed.
 
 
 .Procedure
 
 . Download the tarball.
 
-. Install Ansible-navigator:
+. Install {Navigator}:
 +
 ```
 $ tar -zxvf  ansible-navigator
@@ -29,10 +29,10 @@ $ tar -zxvf  ansible-navigator
 
 .Verification
 
-* Verify your Ansible-navigator installation:
+* Verify your {Navigator} installation:
 +
 ```
 $ ansible-navigator --help
 ```
 
-You should see the help output describing the main functions of Ansible-navigator.
+You should see the help output describing the main functions of {Navigator}.

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-tar.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-tar.adoc
@@ -1,0 +1,38 @@
+
+[id="proc-installing-navigator-rhel-tar_{context}"]
+
+
+= Installing Ansible navigator on RHEL from a tarball
+
+
+[role="_abstract"]
+
+You can install Ansible content navigator on Red Hat Enterprise Linux (RHEL) from a tarball.
+
+.Prerequisites
+
+* You have installed the prerequisites for RHEL.
+* You have Ansible or an Ansible execution environment installed.
+
+
+.Procedure
+
+. Download the tarball.
+
+. Install Ansible-navigator:
++
+```
+$ tar -zxvf  ansible-navigator
+```
++
+
+
+.Verification
+
+* Verify your Ansible-navigator installation:
++
+```
+$ ansible-navigator --help
+```
+
+You should see the help output describing the main functions of Ansible-navigator.


### PR DESCRIPTION
At this point, only pip install is supported. Leave the other two procedures in the repo but not in the assembly. (as in they won't show up in the documentation for now).