### PR TITLE
Updates to docs around roles and collections

### DIFF
--- a/downstream/assemblies/dev-guide/assembly-creating-content.adoc
+++ b/downstream/assemblies/dev-guide/assembly-creating-content.adoc
@@ -18,9 +18,9 @@ Use the guidelines in this section of the _Creator Guide_ to learn more about th
 
 include::dev-guide/proc-create-playbooks.adoc[leveloffset=+1]
 
-include::dev-guide/proc-create-role.adoc[leveloffset=+1]
-
 include::dev-guide/proc-create-collections.adoc[leveloffset=+1]
+
+include::dev-guide/proc-create-role.adoc[leveloffset=+1]
 
 include::dev-guide/proc-create-execution-environment.adoc[leveloffset=+1]
 

--- a/downstream/modules/automation-hub/con-about-automation-hub.adoc
+++ b/downstream/modules/automation-hub/con-about-automation-hub.adoc
@@ -6,10 +6,10 @@
 
 = About Automation Hub
 
- Automation Hub provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
+Automation Hub provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
 
- At a high level, Automation Hub provides an overview of all partners participating and providing certified, supported content.
+At a high level, Automation Hub provides an overview of all partners participating and providing certified, supported content.
 
- From a central view, users can dive deeper into each partner and check out the collections.
+From a central view, users can dive deeper into each partner and check out the collections.
 
- Additionally, a searchable overview of all available collections is available.
+Additionally, a searchable overview of all available collections is available.

--- a/downstream/modules/core/con-ansible-roles.adoc
+++ b/downstream/modules/core/con-ansible-roles.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 
-A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure.. Instead of creating huge playbooks with hundreds of plays, you can use roles to break the tasks apart into smaller, more discrete units of work.
+A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of plays, you can use roles to break the tasks apart into smaller, more discrete units of work.
 
 You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on Ansible Galaxy. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
 

--- a/downstream/modules/core/con-ansible-roles.adoc
+++ b/downstream/modules/core/con-ansible-roles.adoc
@@ -10,5 +10,5 @@ A role is Ansible’s way of bundling automation content as well as loading rela
 You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on Ansible Galaxy. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
 
 -----
-$ ansible-galaxy install username.rolename
+$ ansible-galaxy role install username.rolename
 -----

--- a/downstream/modules/core/con-ansible-roles.adoc
+++ b/downstream/modules/core/con-ansible-roles.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 
-A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of plays, you can use roles to break the tasks apart into smaller, more discrete units of work.
+A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of tasks, you can use roles to break the tasks apart into smaller, more discrete and composable units of work.
 
 You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on Ansible Galaxy. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
 

--- a/downstream/modules/core/con-content-collections.adoc
+++ b/downstream/modules/core/con-content-collections.adoc
@@ -8,27 +8,35 @@
 
 [role="_abstract"]
 
-An Ansible Content Collection is a ready-to-use toolkit for automation. It includes multiple types of content such as playbooks, roles, modules, and plugins all in one place. The diagram below shows the basic structure of collections:
+An Ansible Content Collection is a ready-to-use toolkit for automation. It includes multiple types of content such as playbooks, roles, modules, and plugins all in one place. The diagram below shows the basic structure of a collection:
 
 ....
-
-├── docs
+collection/
+├── docs/
 ├── galaxy.yml
-├── playbooks
-│   ├── files
-│   ├── tasks
-│   ├── templates
-│   └── vars
-├── plugins
-│   ├── modules
-│   │   ├── module1.py
-│   │   └── module2.py
-│   ├── lookups
-│   └── filters
-├── titles
-│   ├── role1
-│   └── role2
-└── tests
+├── meta/
+│   └── runtime.yml
+├── plugins/
+│   ├── modules/
+│   │   └── module1.py
+│   ├── inventory/
+│   ├── lookup/
+│   ├── filter/
+│   └── .../
+├── README.md
+├── roles/
+│   ├── role1/
+│   ├── role2/
+│   └── .../
+├── playbooks/
+│   ├── files/
+│   ├── vars/
+│   ├── templates/
+│   ├── playbook1.yml
+│   └── tasks/
+└── tests/
+    ├── integration/
+    └── unit/
 ....
 
 In {PlatformName}, {HubName} serves as the source for Ansible Certified Content Collections.

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -10,17 +10,16 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 
 [role="_abstract"]
 
-{ExecEnvNameStart} are consistent and shareable container images that serve as Ansible control nodes. {ExecEnvNameStart} remediates challenges with Ansible content requiring non-default dependencies.
+{ExecEnvNameStart} are consistent and shareable container images that serve as Ansible control nodes. {ExecEnvNameStart} reduce the challenge of sharing Ansible content that has external dependencies.
 
 {ExecEnvNameStart} contain:
 
-* Ansible
+* Ansible Core
 * Ansible Runner
 * Ansible Collections
-* Python and/or system dependencies
-** modules/plugins in collections
-** content in `ansible-core`
-** custom user needs
+* Python libraries
+* System dependencies
+* Custom user needs
 
 You can define and create an automation execution environment using {Builder}.
 

--- a/downstream/modules/dev-guide/proc-create-collections.adoc
+++ b/downstream/modules/dev-guide/proc-create-collections.adoc
@@ -15,7 +15,7 @@ You can create your own Collections locally with the Ansible Galaxy CLI tool. Al
 
 .Procedure
 
-. In your terminal, navigate to where you want your namespace root directory to be.
+. In your terminal, navigate to where you want your namespace root directory to be. For simplicity, this should be a path in link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths[COLLECTIONS_PATH] but that is not required.
 . Run the following command, replacing `my_namespace` and `my_collection_name` with the values you choose:
 +
 -----
@@ -36,7 +36,7 @@ Requirements from a Collection can be recognized in these ways:
 * A file `meta/execution-environment.yml` references the Python and/or `bindep` requirements files
 * A file named `requirements.txt`, which contains information on the Python dependencies and can sometimes be found at the root level of the Collection
 * A file named `bindep.txt`, which contains system-level dependencies and can be sometimes found in the root level of the Collection
-* If any of these files are in the `build_ignore` of the Collection, Ansible Builder will not pick up on these since this section is used to filter any files or directories that should not be included in the build artifact 
+* If any of these files are in the `build_ignore` of the Collection, Ansible Builder will not pick up on these since this section is used to filter any files or directories that should not be included in the build artifact
 
 Collection maintainers can verify that ansible-builder recognizes the requirements they expect by using the introspect command:
 

--- a/downstream/modules/dev-guide/proc-create-role.adoc
+++ b/downstream/modules/dev-guide/proc-create-role.adoc
@@ -5,36 +5,48 @@
 = Creating roles
 
 [role="_abstract"]
-Using the `ansible-galaxy` command line tool that comes bundled with Ansible, you can create a role with the `init` command.
+You can create roles using the Ansible Galaxy CLI tool. Role-specific commands can be accessed from the `roles` subcommand.
 
-As an example, the following command will create a role directory structure called `role_name` in the current working directory:
+Standalone roles outside of Collections are still supported, but new roles should be created inside of a Collection to take advantage of all the features {PlatformNameShort} has to offer.
+
+.Procedure
+
+. In your terminal, navigate to the `roles` directory inside a collection.
+. As an example, the following command will create a role directory structure called `role_name` inside the collection created previously:
+
++
+-----
+$ ansible-galaxy role init my_role
+-----
++
+
+The `my_role` directory will contain the following:
 
 -----
-$ ansible-galaxy init role_name
+~/.ansible/collections/ansible_collections/<my_namespace>/<my_collection_name>
+...
+└── roles/
+    └── my_role/
+        ├── .travis.yml
+        ├── README.md
+        ├── defaults/
+        │   └── main.yml
+        ├── files/
+        ├── handlers/
+        │   └── main.yml
+        ├── meta/
+        │   └── main.yml
+        ├── tasks/
+        │   └── main.yml
+        ├── templates/
+        ├── tests/
+        │   ├── inventory
+        │   └── test.yml
+        └── vars/
+            └── main.yml
 -----
 
- The `role_name` directory will contain the following:
-
------
-.travis.yml
-README.md
-defaults/
-    main.yml
-files/
-handlers/
-    main.yml
-meta/
-    main.yml
-tasks/
-    main.yml
-templates/
-tests/
-    inventory
-    test.yml
-vars/
-    main.yml
-
------
+A custom role skeleton can be supplied using the `--role-skeleton [PATH]` argument. This allows organizations to create standardized templates for new roles to suit their needs.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/dev-guide/proc-create-role.adoc
+++ b/downstream/modules/dev-guide/proc-create-role.adoc
@@ -7,12 +7,16 @@
 [role="_abstract"]
 You can create roles using the Ansible Galaxy CLI tool. Role-specific commands can be accessed from the `roles` subcommand.
 
+-----
+ansible-galaxy role init <role_name>
+-----
+
 Standalone roles outside of Collections are still supported, but new roles should be created inside of a Collection to take advantage of all the features {PlatformNameShort} has to offer.
 
 .Procedure
 
 . In your terminal, navigate to the `roles` directory inside a collection.
-. As an example, the following command will create a role directory structure called `role_name` inside the collection created previously:
+. Create a role called `role_name` inside the collection created previously:
 
 +
 -----
@@ -20,33 +24,36 @@ $ ansible-galaxy role init my_role
 -----
 +
 
-The `my_role` directory will contain the following:
+The collection now contains a role named `my_role` inside the `roles` directory:
 
------
-~/.ansible/collections/ansible_collections/<my_namespace>/<my_collection_name>
-...
-└── roles/
-    └── my_role/
-        ├── .travis.yml
-        ├── README.md
-        ├── defaults/
-        │   └── main.yml
-        ├── files/
-        ├── handlers/
-        │   └── main.yml
-        ├── meta/
-        │   └── main.yml
-        ├── tasks/
-        │   └── main.yml
-        ├── templates/
-        ├── tests/
-        │   ├── inventory
-        │   └── test.yml
-        └── vars/
-            └── main.yml
------
+    ~/.ansible/collections/ansible_collections/<my_namespace>/<my_collection_name>
+    ...
+    └── roles/
+        └── my_role/
+            ├── .travis.yml
+            ├── README.md
+            ├── defaults/
+            │   └── main.yml
+            ├── files/
+            ├── handlers/
+            │   └── main.yml
+            ├── meta/
+            │   └── main.yml
+            ├── tasks/
+            │   └── main.yml
+            ├── templates/
+            ├── tests/
+            │   ├── inventory
+            │   └── test.yml
+            └── vars/
+                └── main.yml
 
-A custom role skeleton can be supplied using the `--role-skeleton [PATH]` argument. This allows organizations to create standardized templates for new roles to suit their needs.
+. A custom role skeleton directory can be supplied using the `--role-skeleton` argument. This allows organizations to create standardized templates for new roles to suit their needs.
+
+    ansible-galaxy role init my_role --role-skeleton ~/role_skeleton
+
+This will create a role named `my_role` by copying the contents of `~/role_skeleton` into `my_role`. The contents of `role_skeleton` can be any files or folders that are valid inside a role directory.
+
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Standalone roles while still supported should be de-emphasized. Instead, creating roles inside of collections is the recommended approach.

Correct some problems with the example collections layout and add some more example content.