### PR TITLE
Update YAML examples and play description

### DIFF
--- a/downstream/assemblies/catalog/assembly-itsm-substitution.adoc
+++ b/downstream/assemblies/catalog/assembly-itsm-substitution.adoc
@@ -17,7 +17,6 @@ In this section we will demonstrate how to align data you expose to Automation S
 .Example playbook `before_order.yml` for *before order* process
 
 -----
----
 # This playbook prints a simple debug message and set_stats
 - name: Echo Hello, world!
   hosts: localhost
@@ -40,7 +39,6 @@ This example product playbook accepts a substituted variable for {{favorite_colo
 .Example playbook `product_order.yml`
 
 -----
----
 # This playbook prints a simple debug message with given information
 - name: Echo Hello, world!
   hosts: localhost
@@ -83,7 +81,6 @@ Use surveys to pass the 'product_order.yml' artifact `after_data` to `after_orde
 .Example playbook `after_order.yml` for *after order* product
 
 -----
----
 # This playbook prints a simple debug message with given information
 - name: Echo Hello, world!
   hosts: localhost

--- a/downstream/assemblies/catalog/assembly-itsm-substitution.adoc
+++ b/downstream/assemblies/catalog/assembly-itsm-substitution.adoc
@@ -22,10 +22,12 @@ In this section we will demonstrate how to align data you expose to Automation S
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="Hello, world!"
-  - set_stats:
-      data:
-        expose_to_cloud_redhat_com_favorite_color: "orange"
+    - debug:
+        msg: "Hello, world!"
+
+    - set_stats:
+        data:
+          expose_to_cloud_redhat_com_favorite_color: "orange"
 
 -----
 
@@ -44,10 +46,12 @@ This example product playbook accepts a substituted variable for {{favorite_colo
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="Hello, {{favorite_color}} world!"
-  - set_stats:
-      data:
-        expose_to_cloud_redhat_com_after_data: "{{favorite_color}}"
+    - debug:
+        msg: "Hello, {{favorite_color}} world!"
+
+    - set_stats:
+        data:
+          expose_to_cloud_redhat_com_after_data: "{{favorite_color}}"
 
 -----
 
@@ -86,7 +90,8 @@ Use surveys to pass the 'product_order.yml' artifact `after_data` to `after_orde
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="{{after_data}}"
+    - debug:
+        msg: "{{after_data}}"
 
 -----
 

--- a/downstream/modules/builder/con-definition-dependencies.adoc
+++ b/downstream/modules/builder/con-definition-dependencies.adoc
@@ -13,7 +13,6 @@ The content of a `requirements.yml` file may look like the following:
 [example]
 ====
 ----
----
 collections:
   - geerlingguy.java
   - kubernetes.core

--- a/downstream/modules/builder/proc-customize-ee-image.adoc
+++ b/downstream/modules/builder/proc-customize-ee-image.adoc
@@ -23,7 +23,6 @@ $ podman login -u="[username]" -p="[token/hash]" registry.redhat.io
 +
 ====
 ----
----
 collections:
   - kubernetes.core
 ----
@@ -35,7 +34,6 @@ collections:
 [example]
 ====
 ----
----
 version: 1
 
 build_arg_defaults:

--- a/downstream/modules/catalog/proc-edit-set-stats.adoc
+++ b/downstream/modules/catalog/proc-edit-set-stats.adoc
@@ -13,7 +13,6 @@ Use the playbook examples below to learn now about `set_stats` values and to pas
 This *before order* playbook returns to Automation Services Catalog `set_stats` values for a favorite color:
 
 -----
----
 # This playbook prints a simple debug message and set_stats
 - name: Echo Hello, world!
   hosts: localhost
@@ -31,7 +30,6 @@ This *before order* playbook returns to Automation Services Catalog `set_stats` 
 This playbook passes a substitutable value back to Automation Services Catalog as an artifact value.
 
 -----
----
 # This playbook prints a simple debug message with given information
 - name: Echo Hello, world!
   hosts: localhost
@@ -48,7 +46,6 @@ This playbook passes a substitutable value back to Automation Services Catalog a
 The after order playbook example below includes the artifact `after_data` value that was passed by the product playbook.
 
 -----
----
 # This playbook prints a simple debug message with given information
 - name: Echo Hello, world!
   hosts: localhost

--- a/downstream/modules/catalog/proc-edit-set-stats.adoc
+++ b/downstream/modules/catalog/proc-edit-set-stats.adoc
@@ -18,10 +18,12 @@ This *before order* playbook returns to Automation Services Catalog `set_stats` 
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="Hello, world!"
-  - set_stats:
-      data:
-        expose_to_cloud_redhat_com_favorite_color: "orange"
+    - debug:
+        msg: "Hello, world!"
+
+    - set_stats:
+        data:
+          expose_to_cloud_redhat_com_favorite_color: "orange"
 
 -----
 
@@ -35,10 +37,12 @@ This playbook passes a substitutable value back to Automation Services Catalog a
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="Hello, {{favorite_color}} world!"
-  - set_stats:
-      data:
-        expose_to_cloud_redhat_com_after_data: "{{favorite_color}}"
+    - debug:
+        msg: "Hello, {{favorite_color}} world!"
+
+    - set_stats:
+        data:
+          expose_to_cloud_redhat_com_after_data: "{{favorite_color}}"
 -----
 
 .Example after order playbook
@@ -51,7 +55,8 @@ The after order playbook example below includes the artifact `after_data` value 
   hosts: localhost
   gather_facts: yes
   tasks:
-  - debug: msg="{{after_data}}"
+    - debug:
+        msg: "{{after_data}}"
 ~
 
 -----

--- a/downstream/modules/dev-guide/proc-create-playbooks.adoc
+++ b/downstream/modules/dev-guide/proc-create-playbooks.adoc
@@ -5,7 +5,7 @@
 = Creating playbooks
 
 [role="_abstract"]
-Playbooks start with the three YAML dashes (---) followed by:
+Playbooks contain one or more plays. A basic play contains the following sections:
 
 * Name: a brief description of the overall function of the playbook, which assists in keeping it readable and organized for all users.
 * Hosts: identifies the target(s) for Ansible to run against.
@@ -15,7 +15,6 @@ Playbooks start with the three YAML dashes (---) followed by:
 .Example playbook
 
 -----
----
 - name: Set Up a Project and Job Template
   hosts: host.name.ip
   become: true

--- a/downstream/modules/dev-guide/proc-create-playbooks.adoc
+++ b/downstream/modules/dev-guide/proc-create-playbooks.adoc
@@ -9,8 +9,8 @@ Playbooks contain one or more plays. A basic play contains the following section
 
 * Name: a brief description of the overall function of the playbook, which assists in keeping it readable and organized for all users.
 * Hosts: identifies the target(s) for Ansible to run against.
-* Become statements: this optional statement can be set to `true`/`yes` to activate privilege escalation (e.g., sudo, su, pfexec, doas, pbrun, dzdo, ksu, etc.).
-* Tasks: this is where actions that get executed via a call to an Ansible module get listed.
+* Become statements: this optional statement can be set to `true`/`yes` to enable privilege escalation using a become plugin (such as `sudo`, `su`, `pfexec`, `doas`, `pbrun`, `dzdo`, `ksu`).
+* Tasks: this is the list actions that get executed against each host in the play.
 
 .Example playbook
 

--- a/downstream/modules/security/proc-creating-firewall-rule.adoc
+++ b/downstream/modules/security/proc-creating-firewall-rule.adoc
@@ -30,8 +30,6 @@ $ ansible-galaxy install ansible_security.acl_manager
 . Create a new playbook and set the following parameter. For example, source object, destination object, access rule between the two objects and the actual firewall you are managing, such as Check Point:
 +
 ----
----
-
 - name: block IP address
   hosts: checkpoint
   connection: httpapi

--- a/downstream/modules/security/proc-deleting-firewall-rule.adoc
+++ b/downstream/modules/security/proc-deleting-firewall-rule.adoc
@@ -30,8 +30,6 @@ $ ansible-galaxy install ansible_security.acl_manager
 . Using CLI, create a new playbook with the acl_manger role and set the parameters (e.g., source object, destination object, access rule between the two objects):
 +
 ----
----
-
 - name: delete block list entry
   hosts: checkpoint
   connection: httpapi


### PR DESCRIPTION
Ansible does not make use of multiple YAML documents, so the document separator can be omitted from examples.

Update descriptions of basic playbook components to be more accurate and avoid the use of latin phrases.