### PR TITLE
Platform operator concept content

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -4,6 +4,7 @@
 :PlatformName: Red Hat Ansible Automation Platform
 :PlatformNameShort: Ansible Automation Platform
 
+
 // Automation services catalog
 :CatalogName: automation services catalog
 :CatalogNameStart: Automation services catalog

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -4,6 +4,11 @@
 :PlatformName: Red Hat Ansible Automation Platform
 :PlatformNameShort: Ansible Automation Platform
 
+// Operators
+:OperatorPlatform: Ansible Automation Platform Operator
+:OperatorHub: OpenShift private automation hub operator 
+:OperatorController: OpenShift automation controller operator
+:OperatorResource: OpenShift Ansible Automation Platform resource operator
 
 // Automation services catalog
 :CatalogName: automation services catalog


### PR DESCRIPTION
Platform operator concept content - describes the Platform Operator that deploys Automation Platform on OpenShift.

- Attribute values for operator per [Ansible Automation Platform product component and feature naming](https://docs.google.com/spreadsheets/d/1l8YLUY-AFHYgxQKNe2NvRtk85-MenYcr-BaMAYFZjfs/edit#gid=0) Google Sheet
- The Platform operator modules and assemblies are in the `platform` directories
- This PR affects the `/titles/aap-operator-installation` book.