### PR TITLE
First draft of operator install procedures

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -21,32 +21,36 @@ You can use these instructions to install the {ControllerName} operator on {OCP}
 
 == Prerequisites
 
-* You have installed the catalog containing the {PlatformName} operators
+* You have installed the :PlatformName: catalog in Operator Hub.
 
 == Installing the {ControllerName} operator
 
 . Log in to {OCP}.
 . Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} catalog and click *Create Instance*.
-
+. Locate the {PlatformName} operator and click *Create Instance*.
++
 [NOTE]
 ====
 {OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
 ====
++
+. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
+.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*
+. Locate the {ControllerName} operator and click *Create instance*.
 
 .Optional - Configure your {ControllerName} operator route options
 . Click *Advanced configuration*.
-. Under “Tower Ingress type”, click the dropdown menu and select *Route*.
-. Under “Route DNS host”, enter a common host name that the route answers to.
-. Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
-. Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
+. Under *Tower Ingress type*, click the drop-down menu and select *Route*.
+. Under *Route DNS host*, enter a common host name that the route answers to.
+. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
+. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
 
 
 .Optional - Configure the Ingress type for your {ControllerName} operator
 . Click *Advanced Configuration*.
-. Under “Tower Ingress type”, click the dropdown menu and select *Ingress*.
-. Under “Tower Ingress annotations”, enter any annotations to add to the ingress.
-. Under “Tower Ingress TLS secret”, click the dropdown menu and select a secret from the list.
+. Under *Tower Ingress type*, click the drop-down menu and select *Ingress*.
+. Under *Tower Ingress annotations*, enter any annotations to add to the ingress.
+. Under *Tower Ingress TLS secret*, click the drop-down menu and select a secret from the list.
 
 Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 

--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -8,14 +8,14 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-contr-operator-external"]
-= Installing {ControllerName} on {OCP} with an external database and routed web traffic
+= Installing {ControllerName} on {OCP} with an external database
 
 
 :context: installing-contr-operator-external
 
 
 [role="_abstract"]
-You can use these instructions to install the {HubName} operator on {OCP} with an external PostgreSQL 12 database and route, as well as specify customer resources.
+You can use these instructions to install the {ControllerName} operator on {OCP} with an external PostgreSQL 12 database and route, as well as specify customer resources.
 
 // mirrors AWX operator flow
 
@@ -23,33 +23,34 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 
 * You have installed the catalog containing the {PlatformName} operators
 
-.Installing the {HubName} operator
+== Installing the {ControllerName} operator
 
 . Log in to {OCP}.
 . Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} catalog and click on it.
-. Click *Install*
-
-.Instantiating an instance of {HubName}
+. Locate the {PlatformName} catalog and click *Create Instance*.
 
 [NOTE]
 ====
 {OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
 ====
 
-. Navigate to *Operators* -> *Installed Operators*.
-. Locate the {HubName} operator and click on it.
-. Click *Create Instance*.
-. Use either the *Form View* or *YAML view* to configure the instance.
-.. Click *Advanced Configuration* to enter additional resource information.
-
-/////
-include::modules/TEMPLATE_CONCEPT_explaining_a_concept.adoc[leveloffset=+1]
+.Optional - Configure your {ControllerName} operator route options
+. Click *Advanced configuration*.
+. Under “Tower Ingress type”, click the dropdown menu and select *Route*.
+. Under “Route DNS host”, enter a common host name that the route answers for
+. Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
+. Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
 
 
-include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+2]
-include::modules/TEMPLATE_PROCEDURE_reference-material.adoc[leveloffset=2]
-/////
+.Optional - Configure the Ingress type for your {ControllerName} operator
+. Click *Advanced Configuration*.
+. Under “Tower Ingress type”, click the dropdown menu and select *Ingress*.
+. Under “Tower Ingress annotations”, enter any annotations to add to the ingress.
+. Under “Tower Ingress TLS secret”, click the dropdown menu and select a secret from the list.
+
+Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+
+* View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -37,7 +37,7 @@ You can use these instructions to install the {ControllerName} operator on {OCP}
 .Optional - Configure your {ControllerName} operator route options
 . Click *Advanced configuration*.
 . Under “Tower Ingress type”, click the dropdown menu and select *Route*.
-. Under “Route DNS host”, enter a common host name that the route answers for
+. Under “Route DNS host”, enter a common host name that the route answers to.
 . Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
 . Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -41,7 +41,7 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 .Optional - Configure your {HubName} operator route options
 . Click *Advanced configuration*.
 . Under “Ingress type”, click the dropdown menu and select *Route*.
-. Under “Route DNS host”, enter a common host name that the route answers for
+. Under “Route DNS host”, enter a common host name that the route answers to.
 . Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
 . Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -21,13 +21,13 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 
 == Prerequisites
 
-* You have installed the catalog containing the {PlatformName} operators
+* You have installed the :PlatformName: catalog in Operator Hub.
 
 == Installing the {HubName} operator
 
 . Log in to {OCP}.
 . Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} catalog and click on it.
+. Locate the {PlatformName} operator and click on it.
 . Click *Install*
 +
 .Instantiating an instance of {HubName}
@@ -35,22 +35,23 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 ====
 {OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
 ====
-. Navigate to *Operators* -> *Installed Operators*.
-. Locate the {HubName} operator and click *Create AutomationHub*.
+. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
+.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*
+. Locate the {HubName} operator and click *Create instance*.
 
 .Optional - Configure your {HubName} operator route options
 . Click *Advanced configuration*.
-. Under “Ingress type”, click the dropdown menu and select *Route*.
-. Under “Route DNS host”, enter a common host name that the route answers to.
-. Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
-. Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
+. Under *Ingress type*, click the drop-down menu and select *Route*.
+. Under *Route DNS host*, enter a common host name that the route answers to.
+. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
+. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
 
 
 .Optional - Configure the Ingress type for your {HubName} operator
 . Click *Advanced Configuration*.
-. Under “Ingress type”, click the dropdown menu and select *Ingress*.
-. Under “Ingress annotations”, enter any annotations to add to the ingress.
-. Under “Ingress TLS secret”, click the dropdown menu and select a secret from the list.
+. Under *Ingress type*, click the drop-down menu and select *Ingress*.
+. Under *Ingress annotations*, enter any annotations to add to the ingress.
+. Under *Ingress TLS secret*, click the drop-down menu and select a secret from the list.
 
 Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-hub-operator-external"]
-= Installing {HubName} on {OCP} with an external database and routed web traffic
+= Installing {HubName} on {OCP} with an external database
 
 
 :context: installing-hub-operator-external
@@ -23,35 +23,51 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 
 * You have installed the catalog containing the {PlatformName} operators
 
-.Installing the {HubName} operator
+== Installing the {HubName} operator
 
 . Log in to {OCP}.
 . Navigate to *Operators* -> *Operator Hub*.
 . Locate the {PlatformName} catalog and click on it.
 . Click *Install*
-
++
 .Instantiating an instance of {HubName}
-
 [NOTE]
 ====
 {OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
 ====
-
 . Navigate to *Operators* -> *Installed Operators*.
-. Locate the {HubName} operator and click on it.
-. Click *Create Instance*.
-. Use either the *Form View* or *YAML view* to configure the instance.
-.. Click *Advanced Configuration* to enter additional resource information.
+. Locate the {HubName} operator and click *Create AutomationHub*.
+
+.Optional - Configure your {HubName} operator route options
+. Click *Advanced configuration*.
+. Under “Ingress type”, click the dropdown menu and select *Route*.
+. Under “Route DNS host”, enter a common host name that the route answers for
+. Under “Route TLS termination mechanism”, click the dropdown menu and select *Edge* or *Passthrough*.
+. Under “Route TLS credential secret”, click the dropdown menu and select a secret from the list.
 
 
-/////
-include::modules/TEMPLATE_CONCEPT_explaining_a_concept.adoc[leveloffset=+1]
+.Optional - Configure the Ingress type for your {HubName} operator
+. Click *Advanced Configuration*.
+. Under “Ingress type”, click the dropdown menu and select *Ingress*.
+. Under “Ingress annotations”, enter any annotations to add to the ingress.
+. Under “Ingress TLS secret”, click the dropdown menu and select a secret from the list.
+
+Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+
+* View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+
+== Accessing the {HubName} user interface
+
+You can access the {HubName} interface once all pods have successfully launched.
+
+. Navigate to *Networking* -> *Routes*.
+. Under *Location*, click on the URL for your {HubName} instance.
+
+The {HubName} user interface will launch, You can sign in with the admin credentials specified during the operator configuration process.
 
 
 
-include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+2]
-include::modules/TEMPLATE_PROCEDURE_reference-material.adoc[leveloffset=2]
-/////
+
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -17,6 +17,6 @@ This guide helps you to understand the installation requirements and processes b
 
 include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]
-
 include::platform/assembly-installing-hub-operator-external-db.adoc[leveloffset=+1]
+
+include::platform/assembly-installing-controller-operator-external-db.adoc[leveloffset=+1]


### PR DESCRIPTION
First draft of the platform operator installation procedures on OpenShift. I edited some of the assemblies that were created previously to reflect the TLS secrets and Ingress configurations in the form view. This draft encompasses both hub and controller installations.

Preview (VPN required to view): http://file.rdu.redhat.com/kevchin/operator/operator-procs/tmp/en-US/html-single/

Note: These drafts only reflect some of the installation scenarios we were tasked to do. Once we get a clearer understanding on how the procedures change on a external/local database, we can add those later.