### PR TITLE
Backport PR#155 from AAP-516 feature branch to 2.0-ea

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -10,9 +10,19 @@ ifdef::context[:parent-context: {context}]
 :context: operator-install-planning
 
 [role="_abstract"]
-OpenShift operators help install and automate day-2 operations of complex, distributed software on OpenShift.
+{PlatformName} is supported on both Red Hat Enterprise Linux 8 and Red Hat Openshift.
 
-You can use this section to help plan your {PlatformName} operator installation. Before installing, review the individual scenarios to determine which meets your requirements.
+OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatform} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
+
+You can use this section to help plan {PlatformName} installation on your {OCP} environment. Before installing, review the individual scenarios to determine which meets your requirements.
+
+== About {OperatorPlatform}
+
+The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment. 
+The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub. It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments. 
+You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
+
+Deploying {PlatformNameShort} instances with a Kubernetes native operator offers advantages over launching instances from a playbook deployed on {OCP}. The {OperatorPlatform} supports upgrades and provides full lifecycle support for your {PlatformName} deployments. 
 
 == Supported installation scenarios for {OCP}
 

--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -14,15 +14,16 @@ ifdef::context[:parent-context: {context}]
 
 OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatform} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
 
-You can use this section to help plan {PlatformName} installation on your {OCP} environment. Before installing, review the individual scenarios to determine which meets your requirements.
+You can use this section to help plan {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
 
 == About {OperatorPlatform}
 
 The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment. 
 The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub. It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments. 
-You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
 
-Deploying {PlatformNameShort} instances with a Kubernetes native operator offers advantages over launching instances from a playbook deployed on {OCP}. The {OperatorPlatform} supports upgrades and provides full lifecycle support for your {PlatformName} deployments. 
+Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments. 
+
+You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
 
 == Supported installation scenarios for {OCP}
 

--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -14,7 +14,7 @@ ifdef::context[:parent-context: {context}]
 
 OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatform} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
 
-You can use this section to help plan {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
+You can use this section to help plan your {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
 
 == About {OperatorPlatform}
 

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -6,9 +6,9 @@
 
 // Operators
 :OperatorPlatform: Ansible Automation Platform Operator
-:OperatorHub: OpenShift private automation hub operator 
-:OperatorController: OpenShift automation controller operator
-:OperatorResource: OpenShift Ansible Automation Platform resource operator
+:OperatorHub: Ansible Automation Platform Hub Operator
+:OperatorController: Ansible Automation Platform Controller Operator
+:OperatorResource: Ansible Automation Platform Resource Operator
 
 // Automation services catalog
 :CatalogName: automation services catalog


### PR DESCRIPTION
Affects Operator installation title: downstream/titles/aap-operator-installation/master.adoc

Backported the following commits, comprising PR#155,  from the `AAP-516-operator-install-guide` feature branch to the `2.0-ea` release branch:
```
8624621 (origin/platform-operator-concept) Implement review comment
0335f55 Apply suggestions from review
b2f770e Add Platform operator concept content
c448f32 Update attribute values for operator components
```
