### PR TITLE
Backport PR#161 from AAP-516 feature branch to 2.0 ea (Modularize Operator installation content)

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -7,7 +7,7 @@ See also the complementary step on the last line of this file.
 ifdef::context[:parent-context: {context}]
 
 
-[id="installing-contr-operator-external"]
+[id="installing-controller-operator-external"]
 = Installing {ControllerName} on {OCP} with an external database
 
 
@@ -21,36 +21,16 @@ You can use these instructions to install the {ControllerName} operator on {OCP}
 
 == Prerequisites
 
-* You have installed the :PlatformName: catalog in Operator Hub.
+* You have installed the {PlatformName} catalog in Operator Hub.
 
 == Installing the {ControllerName} operator
 
-. Log in to {OCP}.
-. Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} operator and click *Create Instance*.
-+
-[NOTE]
-====
-{OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
-====
-+
-. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
-.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*
-. Locate the {ControllerName} operator and click *Create instance*.
+include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
 
-.Optional - Configure your {ControllerName} operator route options
-. Click *Advanced configuration*.
-. Under *Tower Ingress type*, click the drop-down menu and select *Route*.
-. Under *Route DNS host*, enter a common host name that the route answers to.
-. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
-. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
+With the {PlatformName} operator installed, locate the *Automation controller* entry and click *Create instance*.
 
-
-.Optional - Configure the Ingress type for your {ControllerName} operator
-. Click *Advanced Configuration*.
-. Under *Tower Ingress type*, click the drop-down menu and select *Ingress*.
-. Under *Tower Ingress annotations*, enter any annotations to add to the ingress.
-. Under *Tower Ingress TLS secret*, click the drop-down menu and select a secret from the list.
+include::platform/proc-controller-route-options.adoc[leveloffset=+2]
+include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 
 Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -10,9 +10,7 @@ ifdef::context[:parent-context: {context}]
 [id="installing-hub-operator-external"]
 = Installing {HubName} on {OCP} with an external database
 
-
 :context: installing-hub-operator-external
-
 
 [role="_abstract"]
 You can use these instructions to install the {HubName} operator on {OCP} with an external PostgreSQL 12 database and route, as well as specify customer resources.
@@ -21,50 +19,22 @@ You can use these instructions to install the {HubName} operator on {OCP} with a
 
 == Prerequisites
 
-* You have installed the :PlatformName: catalog in Operator Hub.
+* You have installed the {PlatformName} catalog in Operator Hub.
 
 == Installing the {HubName} operator
 
-. Log in to {OCP}.
-. Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} operator and click on it.
-. Click *Install*
-+
-.Instantiating an instance of {HubName}
-[NOTE]
-====
-{OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
-====
-. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
-.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*
-. Locate the {HubName} operator and click *Create instance*.
+include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
 
-.Optional - Configure your {HubName} operator route options
-. Click *Advanced configuration*.
-. Under *Ingress type*, click the drop-down menu and select *Route*.
-. Under *Route DNS host*, enter a common host name that the route answers to.
-. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
-. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
+With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
 
-
-.Optional - Configure the Ingress type for your {HubName} operator
-. Click *Advanced Configuration*.
-. Under *Ingress type*, click the drop-down menu and select *Ingress*.
-. Under *Ingress annotations*, enter any annotations to add to the ingress.
-. Under *Ingress TLS secret*, click the drop-down menu and select a secret from the list.
+include::platform/proc-hub-route-options.adoc[leveloffset=+2]
+include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 
 Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 
 * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
 
-== Accessing the {HubName} user interface
-
-You can access the {HubName} interface once all pods have successfully launched.
-
-. Navigate to *Networking* -> *Routes*.
-. Under *Location*, click on the URL for your {HubName} instance.
-
-The {HubName} user interface will launch, You can sign in with the admin credentials specified during the operator configuration process.
+include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 
 
 

--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -16,31 +16,10 @@ OpenShift operators help install and automate day-2 operations of complex, distr
 
 You can use this section to help plan your {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
 
-== About {OperatorPlatform}
-
-The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment. 
-The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub. It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments. 
-
-Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments. 
-
-You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
-
-== Supported installation scenarios for {OCP}
-
-You can install the {PlatformName} operator following one of the below workflows:
-
-* {ControllerNameStart} and customer resources first, then {HubName} and customer resources;
-* {HubNameStart} and customer resources first, then {ControllerName} and customer resources;
-* {ControllerNameStart} and customer resources;
-* {HubNameStart} and custom resources.
-
-== Custom resources
-
-You can define custom resources for each primary installation workflows.
-[role="_additional-resources"]
-== Additional resources
-
-* See link:https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learning more OpenShift Container Platform OperatorHub.
+include::platform/con-about-operator.adoc[leveloffset=2]
+include::platform/con-ocp-supported-install.adoc[leveloffset=2]
+include::platform/con-operator-custom-resources.adoc[leveloffset=2]
+include::platform/con-operator-additional-resources.adoc[leveloffset=2]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/modules/platform/con-about-operator.adoc
+++ b/downstream/modules/platform/con-about-operator.adoc
@@ -1,0 +1,11 @@
+[id="con-about-operator_{context}"]
+
+= About {OperatorPlatform}
+
+[role="_abstract"]
+The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
+The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub. It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments. 
+
+Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments.
+
+You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -1,0 +1,10 @@
+[id="con-ocp-supported-install_{context}"]
+
+= Supported installation scenarios for {OCP}
+
+You can install the {PlatformName} operator following one of the below workflows:
+
+* {ControllerNameStart} and customer resources first, then {HubName} and customer resources;
+* {HubNameStart} and customer resources first, then {ControllerName} and customer resources;
+* {ControllerNameStart} and customer resources;
+* {HubNameStart} and custom resources.

--- a/downstream/modules/platform/con-operator-additional-resources.adoc
+++ b/downstream/modules/platform/con-operator-additional-resources.adoc
@@ -1,0 +1,5 @@
+[id="con-operator-additional-resources_{context}"]
+
+= Additional resources
+
+* See link:https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learning more OpenShift Container Platform OperatorHub.

--- a/downstream/modules/platform/con-operator-custom-resources.adoc
+++ b/downstream/modules/platform/con-operator-custom-resources.adoc
@@ -1,0 +1,5 @@
+[id="con-operator-custom-resources_{context}"]
+
+= Custom resources
+
+You can define custom resources for each primary installation workflows.

--- a/downstream/modules/platform/proc-access-hub-operator-ui.adoc
+++ b/downstream/modules/platform/proc-access-hub-operator-ui.adoc
@@ -1,0 +1,10 @@
+[id="proc-access-hub-operator-ui_{context}"]
+
+= Accessing the {HubName} user interface
+
+You can access the {HubName} interface once all pods have successfully launched.
+
+. Navigate to *Networking* -> *Routes*.
+. Under *Location*, click on the URL for your {HubName} instance.
+
+The {HubName} user interface will launch, You can sign in with the admin credentials specified during the operator configuration process.

--- a/downstream/modules/platform/proc-controller-ingress-options.adoc
+++ b/downstream/modules/platform/proc-controller-ingress-options.adoc
@@ -1,0 +1,10 @@
+[id="proc-controller-ingress-options_{context}"]
+
+= Configure the Ingress type for your {ControllerName} operator
+
+The {PlatformName} operator installation form allows you to further configure your {ControllerName} operator Ingress under *Advanced configuration*.
+
+. Click *Advanced Configuration*.
+. Under *Tower Ingress type*, click the drop-down menu and select *Ingress*.
+. Under *Tower Ingress annotations*, enter any annotations to add to the ingress.
+. Under *Tower Ingress TLS secret*, click the drop-down menu and select a secret from the list.

--- a/downstream/modules/platform/proc-controller-route-options.adoc
+++ b/downstream/modules/platform/proc-controller-route-options.adoc
@@ -1,0 +1,11 @@
+[id="proc-controller-route-options_{context}"]
+
+= Configure your {ControllerName} operator route options
+
+The {PlatformName} operator installation form allows you to further configure your {ControllerName} operator route options under *Advanced configuration*.
+
+. Click *Advanced configuration*.
+. Under *Tower Ingress type*, click the drop-down menu and select *Route*.
+. Under *Route DNS host*, enter a common host name that the route answers to.
+. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
+. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.

--- a/downstream/modules/platform/proc-hub-ingress-options.adoc
+++ b/downstream/modules/platform/proc-hub-ingress-options.adoc
@@ -1,0 +1,10 @@
+[id="proc-hub-ingress-options_{context}"]
+
+= Configure the Ingress type for your {HubName} operator
+
+The {PlatformName} operator installation form allows you to further configure your {HubName} operator Ingress under *Advanced configuration*.
+
+. Click *Advanced Configuration*.
+. Under *Ingress type*, click the drop-down menu and select *Ingress*.
+. Under *Ingress annotations*, enter any annotations to add to the ingress.
+. Under *Ingress TLS secret*, click the drop-down menu and select a secret from the list.

--- a/downstream/modules/platform/proc-hub-route-options.adoc
+++ b/downstream/modules/platform/proc-hub-route-options.adoc
@@ -1,0 +1,11 @@
+[id="proc-hub-route-options_{context}"]
+
+= Configure your {HubName} operator route options
+
+The {PlatformName} operator installation form allows you to further configure your {HubName} operator route options under *Advanced configuration*.
+
+. Click *Advanced configuration*.
+. Under *Ingress type*, click the drop-down menu and select *Route*.
+. Under *Route DNS host*, enter a common host name that the route answers to.
+. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
+. Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -1,0 +1,14 @@
+[id="proc-install-aap-operator{context}"]
+
+. Log in to {OCP}.
+. Navigate to *Operators* -> *Operator Hub*.
+. Locate the {PlatformName} operator and click on it.
+> Click *Install*.
++
+
+[NOTE]
+====
+{OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
+====
+. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
+.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*


### PR DESCRIPTION
Modularized the aap operation installation content that we have prior to SME feedback.
Preview here (VPN required): http://file.rdu.redhat.com/kevchin/operator/operator-procs2/tmp/en-US/html-single/

Files added to the following assemblies:

assembly-operator-install-planning.adoc
-- platform/con-about-operator.adoc
-- platform/con-ocp-supported-install.adoc
-- platform/con-operator-custom-resources.adoc
-- platform/con-operator-additional-resources.adoc

assembly-installed-hub-operator-external.adoc
-- platform/proc-install-aap-operator.adoc
-- platform/proc-hub-route-options.adoc
-- platform/proc-hub-ingress-options.adoc
-- platform/proc-access-hub-operator-ui.adoc

assembly-installing-controller-operator-external.adoc
-- platform/proc-install-aap-operator.adoc
-- platform/proc-controller-route-options.adoc
-- platform/proc-hub-ingress-options.adoc
(cherry picked from commit 3faeab47e85d913bd4716271e4afb725ed1189ed)