### PR TITLE
AAP - Central Authentication Install and Configuration Docs

### DIFF
--- a/downstream/assemblies/central-auth/assembly-assign-hub-admin-permissions.adoc
+++ b/downstream/assemblies/central-auth/assembly-assign-hub-admin-permissions.adoc
@@ -1,0 +1,18 @@
+[id="assembly-assign-hub-admin-permissions"]
+
+= Assigning {HubName} administrator permissions
+
+Hub administrative users will need to be assigned the role of _hubadmin_ in order to manage user permissions and groups. You can assign the role of _hubadmin_ to a user through the {AAPCentralAuth} client.
+
+.Prerequisites
+* A user storage provider (e.g., LDAP) has been added to your {CentralAuth}
+
+.Procedure
+. Navigate to the `ansible-automation-platform` realm on your SSO client.
+. Under the _Manage_ section on the side navigation bar, click *Users*.
+. Select a user from the list by clicking their ID.
+. Click the *Role Mappings* tab.
+. Using the dropdown menu under _Client Roles_, select *automation-hub*.
+. Click *hubadmin* from the _Available Roles_ field, then click *Add selected >*.
+
+The user is now a _hubadmin_. Repeat steps 3-6 to assign any additional users the _hubadmin_ role.

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -1,0 +1,25 @@
+[id="assembly-central-auth-add-user-storage"]
+
+= Adding a User Storage Provider (LDAP/Kerberos) to {AAPCentralAuth}
+
+{AAPCentralAuth} comes with a built-in LDAP/AD provider. You can add your LDAP provider to {CentralAuth} to be able to import user attributes from your LDAP database.
+
+.Prerequisites
+* You are logged in as an SSO admin user.
+
+.Procedure
+. Log in to {AAPCentralAuth} as an SSO admin user.
+. Under the Configure section on the side navigation bar, click *User Federation*.
+. Using the dropdown menu labeled _Add provider_, select your LDAP provider to proceed to the LDAP configuration page.
+
+The following table lists the available options for your LDAP configuration:
+[cols="a,a"]
+|===
+h|Configuration Option  h|Description
+|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#storage_mode[this section] for more information.
+|Edit mode| Determines the types of modifications that admins can make on user metadata. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#edit_mode[this section] for more information.
+|Console Display Name |Name used when this provider is referenced in the admin console
+|Priority |The priority of this provider when looking up users or adding a user
+|Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/authentication#kerberos[this section] for more information.
+|===

--- a/downstream/assemblies/central-auth/assembly-central-auth-group-perms.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-group-perms.adoc
@@ -1,0 +1,24 @@
+[id="assembly-central-auth-group-perms"]
+
+= Managing group permissions with {AAPCentralAuth}
+
+You can manage user access on the {PlatformNameShort} by assigning specific permissions to user groups. As users log in to the {PlatformNameShort} for the first time, their groups will appear in the user access page in {HubName}, allowing you to assign user access and permissions to each group.
+
+=== Assigning permissions to Groups
+
+You can assign permissions to groups in {HubName}that enable users to access specific features in the system.
+
+.Prerequisites
+You are signed in as a `hubadmin` user.
+
+.Procedure
+. Log in to your local {HubName}.
+. Navigate to *Groups*.
+. Click on a group name.
+. Click *Edit*.
+. Click in the field for the permission type and select permissions that appear in the list.
+. Click *Save* when finished assigning permissions.
+
+The group can now access features in {HubName} associated with their assigned permissions.
+
+include::automation-hub/ref-permissions.adoc[leveloffset=+2]

--- a/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
@@ -1,0 +1,13 @@
+[id="assembly-central-auth-hub"]
+
+= {PlatformNameShort} Central Authentication for {HubName}
+
+To enable {AAPCentralAuth} for your {HubName}, start by downloading the {PlatformName} installer then proceed with the necessary set up procedures as detailed in this guide.
+
+[IMPORTANT]
+The installer in this guide will install {CentralAuth} for a basic standalone deployment. Standalone mode only runs one {CentralAuth} server instance, and thus will not be usable for clustered deployments. Standalone mode can be useful to test drive and play with the features of { CentralAuth}, but it is not recommended that you use standalone mode in production as you will only have a single point of failure.
+
+To install {CentralAuth} in a different deployment mode, please see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/operating-mode[this guide] for more deployment options.
+
+include::central-auth/con-central-auth-reqs.adoc[leveloffset=+1]
+include::assembly-install-central-auth-hub.adoc[leveloffset=+1]

--- a/downstream/assemblies/central-auth/assembly-central-auth-identity-broker.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-identity-broker.adoc
@@ -1,0 +1,34 @@
+[id="assembly-central-auth-identity-broker"]
+
+= Adding an identity broker to {AAPCentralAuth}
+
+{AAPCentralAuth} supports both social and protocol-based providers. You can add an identity broker to {CentralAuth} to enable social authentication for your realm, allowing users to log in using an existing social network account, such as Google, Facebook, GitHub etc.
+
+[NOTE]
+For a list of supported social networks and for more information to enable them, please see this https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/identity_broker#social_identity_providers[section].
+
+Protocol-based providers are those that rely on a specific protocol in order to authenticate and authorize users. They allow you to connect to any identity provider compliant with a specific protocol. {AAPCentralAuth} provides support for SAML v2.0 and OpenID Connect v1.0 protocols.
+
+.Procedure
+. Log in to {AAPCentralAuth}as an admin user.
+. Under the _Configure_ section on the side navigation bar, click *Identity Providers*.
+. Using the dropdown menu labeled _Add provider_, select your identity provider to proceed to the identity provider configuration page.
+
+The following table lists the available options for your identity provider configuration:
+
+.Identity Broker Configuration Options
+[cols="a,a"]
+|===
+h|Configuration Option  h|Description
+| Alias | The alias is a unique identifier for an identity provider. It is used to reference an identity provider internally. Some protocols such as `OpenID Connect` require a redirect URI or callback url in order to communicate with an identity provider. In this case, the alias is used to build the redirect URL.
+| Enabled | Turns the provider on/off.
+| Hide on Login Page | If enabled, this provider will not be shown as a login option on the login page. Clients can still request to use this provider by using the `kc_idp_hint` parameter in the URL they use to request a login.
+| Account Linking Only | If enabled, this provider cannot be used to login users and will not be shown as an option on the login page. Existing accounts can still be linked with this provider.
+| Store Tokens | Whether or not to store the token received from the identity provider.
+| Stored Tokens Readable | Whether or not users are allowed to retrieve the stored identity provider token. This also applies to the broker client-level role read token.
+| Trust Email | Whether an email address provided by the identity provider will be trusted. If the realm requires email validation, users that log in from this IDP will not have to go through the email verification process.
+| GUI Order | The order number that sorts how the available IDPs are listed on the login page.
+| First Login Flow | Select an authentication flow that will be triggered for users that log in to {CentralAuth} through this IDP for the first time.
+| Post Login Flow | Select an authentication flow that is triggered after the user finishes logging in with the external identity provider.
+
+|===

--- a/downstream/assemblies/central-auth/assembly-install-central-auth-hub.adoc
+++ b/downstream/assemblies/central-auth/assembly-install-central-auth-hub.adoc
@@ -1,0 +1,10 @@
+[id="install-central-auth-hub"]
+
+= Installing {AAPCentralAuth} for use with {HubName}
+
+The {AAPCentralAuth} installation will be included with your {PlatformName} installer. Install the {PlatformNameShort} using the following procedures, then configure the necessary parameters in your inventory file to successfully install both the {PlatformNameShort} and {CentralAuth}.
+
+include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
+include::central-auth/proc-aap-configure-centralauth.adoc[leveloffset=+1]
+include::central-auth/proc-running-aap-install.adoc[leveloffset=+1]
+include::central-auth/proc-login-centralauth.adoc[leveloffset=+1]

--- a/downstream/assemblies/central-auth/automation-hub
+++ b/downstream/assemblies/central-auth/automation-hub
@@ -1,0 +1,1 @@
+../../modules/automation-hub/

--- a/downstream/assemblies/central-auth/central-auth
+++ b/downstream/assemblies/central-auth/central-auth
@@ -1,0 +1,1 @@
+../../modules/central-auth

--- a/downstream/assemblies/central-auth/platform
+++ b/downstream/assemblies/central-auth/platform
@@ -1,0 +1,1 @@
+../../modules/platform

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -3,10 +3,13 @@
 // Platform
 :PlatformName: Red Hat Ansible Automation Platform
 :PlatformNameShort: Ansible Automation Platform
+:AAPCentralAuth: Ansible Automation Platform Central Authentication
+:CentralAuthStart: Central authentication
+:CentralAuth: central authentication
 
 // Operators
 :OperatorPlatform: Ansible Automation Platform Operator
-:OperatorHub: OpenShift private automation hub operator 
+:OperatorHub: OpenShift private automation hub operator
 :OperatorController: OpenShift automation controller operator
 :OperatorResource: OpenShift Ansible Automation Platform resource operator
 

--- a/downstream/modules/central-auth/con-central-auth-reqs.adoc
+++ b/downstream/modules/central-auth/con-central-auth-reqs.adoc
@@ -1,0 +1,14 @@
+[id="con-central-auth-reqs"]
+
+= System Requirements
+
+There are several minimum requirements to install and run {AAPCentralAuth}:
+
+* Any operating system that runs Java
+* Java 8 JDK
+* zip or gzip and tar
+* At least 512mb of RAM
+* At least 1gb of disk space
+* A shared external database like PostgreSQL, MySQL, Oracle, etc. if you want to run {CentralAuth} in a cluster. Please see the https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/database-1[database configuration section of this guide] for more information.
+* Network multicast support on your machine if you want to run in a cluster. {CentralAuth} can be clustered without multicast, but this requires some configuration changes. Please see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/clustering[the clustering section of this guide] for more information.
+* On Linux, it is recommended to use `/dev/urandom` as a source of random data to prevent {CentralAuth} hanging due to lack of available entropy, unless `/dev/random` usage is mandated by your security policy. To achieve that on Oracle JDK 8 and OpenJDK 8, set the `*java.security.egd*` system property on startup to `*file:/dev/urandom*`.

--- a/downstream/modules/central-auth/platform
+++ b/downstream/modules/central-auth/platform
@@ -1,0 +1,1 @@
+../platform

--- a/downstream/modules/central-auth/proc-aap-configure-centralauth.adoc
+++ b/downstream/modules/central-auth/proc-aap-configure-centralauth.adoc
@@ -1,0 +1,29 @@
+[id="proc-aap-configure-centralauth"]
+
+= Configuring the {PlatformName} installer
+
+Before running the installer, edit the inventory file found in the installer package to configure the installation of {HubName} and {AAPCentralAuth}.
+
+[NOTE]
+Provide a reachable IP address for the [automationhub] host to ensure users can sync content from Private Automation Hub from a different node and push new images to the container registry.
+
+. Navigate to the installer directory:
+.. Online installer:
++
+-----
+$ cd ansible-automation-platform-setup-<latest-version>
+-----
++
+.. Bundled installer:
++
+-----
+$ cd ansible-automation-platform-setup-bundle-<latest-version>
+-----
++
+. Open the *inventory* file using a text editor.
+. Edit the inventory file parameters under `[automationhub]` to specify an installation of {HubName} host:
+.. Add group host information under `[automationhub]` using an IP address or FQDN for the {HubName} location.
+.. Enter passwords for `automationhub_admin_password`, `automation_pg_password`, and any additional parameters based on your installation specifications.
+. Enter a password in the `sso_keystore_password` field.
+. Edit the inventory file parameters under `[SSO]` to specify a host on which to install {centralauth}:
+.. Enter a password in the `sso_console_admin_password` field, and any additional parameters based on your installation specifications.

--- a/downstream/modules/central-auth/proc-login-centralauth.adoc
+++ b/downstream/modules/central-auth/proc-login-centralauth.adoc
@@ -1,0 +1,10 @@
+[id="proc-login-centralauth"]
+
+= Log in as a {centralauth} admin user
+
+With {PlatformName} installed, log in as an admin user to the {centralauth} server using the admin credentials that you specified in your inventory file.
+
+. Navigate to your {AAPCentralAuth} instance.
+. Login using the admin credentials you specified in your inventory file, in the `sso_console_admin_username` and `sso_console_admin_password fields`.
+
+With {AAPCentralAuth} successfully installed, and the admin user logged in, you can proceed by adding a user storage provider (such as LDAP) using the following procedures.

--- a/downstream/modules/central-auth/proc-running-aap-install.adoc
+++ b/downstream/modules/central-auth/proc-running-aap-install.adoc
@@ -1,0 +1,11 @@
+[id="proc-running-aap-install"]
+
+= Running the {PlatformName} installer
+
+With the inventory file updated, run the installer using the `setup.sh` playbook found in the installer package.
+
+. Run the `setup.sh` playbook:
++
+-----
+$ ./setup.sh -e aw_repo_url=https://releases.ansible.com/ansible-automation-platform-21-v9nabP7HPgI5K27U/ -e gpgcheck=0
+-----

--- a/downstream/titles/central-auth/attributes
+++ b/downstream/titles/central-auth/attributes
@@ -1,0 +1,1 @@
+../../attributes/

--- a/downstream/titles/central-auth/central-auth
+++ b/downstream/titles/central-auth/central-auth
@@ -1,0 +1,1 @@
+../../assemblies/central-auth

--- a/downstream/titles/central-auth/docinfo.xml
+++ b/downstream/titles/central-auth/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Installing and Configuring Central Authentication for the Ansible Automation Platform</title>
+<productname>Red Hat Ansible Automation Platform</productname>
+<productnumber>2.1</productnumber>
+  <subtitle>Enable central authentication functions for your Ansible Automation Platform</subtitle>
+<abstract>
+    <para><emphasis role="strong">Providing Feedback:</emphasis></para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat Customer Content Services </orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -1,0 +1,18 @@
+:imagesdir: images
+:numbered:
+:toclevels: 1
+
+:experimental:
+
+include::attributes/attributes.adoc[]
+
+// Book Title
+= Installing and Configuring Central Authentication for the {PlatformName}
+
+{AAPCentralAuth} is a third-party identity provider (idP) solution, allowing for a simplified single sign-on solution that can be used across the {PlatformNameShort}. Platform administrators can utilize {CentralAuth} to test connectivity and authentication, as well as onboard new users and manage user permissions by configuring and assigning them to groups. Along with OpenID Connect-based and LDAP support, {CentralAuth} also provides a supported REST API which can be used to bootstrap customer usage.
+
+include::central-auth/assembly-central-auth-hub.adoc[leveloffset=+1]
+include::central-auth/assembly-central-auth-add-user-storage.adoc[leveloffset=+1]
+include::central-auth/assembly-assign-hub-admin-permissions.adoc[leveloffset=+1]
+include::central-auth/assembly-central-auth-identity-broker.adoc[leveloffset=+1]
+include::central-auth/assembly-central-auth-group-perms.adoc[leveloffset=+1]


### PR DESCRIPTION
The first complete draft of the AAP central authentication guide (formerly the SSO docs)

Preview: http://file.rdu.redhat.com/kevchin/centralauth/build/tmp/en-US/html-single/
Relevant Jira tickets: https://issues.redhat.com/browse/AAH-892 , https://issues.redhat.com/browse/AAP-414