### PR TITLE
Revise mesh plane desciptions and complex example

### DIFF
--- a/downstream/assemblies/platform/assembly-example-topologies.adoc
+++ b/downstream/assemblies/platform/assembly-example-topologies.adoc
@@ -9,16 +9,16 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 The automation mesh topologies in this setion are intended to provide examples you can use to design a mesh deployment in your environment. Examples range from a single, hydrid node deployment to a complex pattern that deploys numerous {ControllerName}s, employing several execution and hop nodes.
 
-== Prerequisites
+.Prerequisites
 * You reviewed conceptual information on node types and relationsips
 
-include::platform/ref-single-hybrid-node-only.adoc[leveloffset=3]
-include::platform/ref-multiple-hybrid-nodes.adoc[leveloffset=3]
-include::platform/ref-single-node-control-plane-single-execution-node.adoc[leveloffset=3]
-include::platform/ref-control-plane-execution-nodes-fully-connected.adoc[leveloffset=3]
-include::platform/ref-control-plane-with-single-egress.adoc[leveloffset=3]
-include::platform/ref-control-plane-execution-topo-hop-nodes.adoc[leveloffset=3]
-include::platform/ref-complex-mesh-topology.adoc[leveloffset=3]
+include::platform/ref-single-hybrid-node-only.adoc[leveloffset=2]
+include::platform/ref-multiple-hybrid-nodes.adoc[leveloffset=2]
+include::platform/ref-single-node-control-plane-single-execution-node.adoc[leveloffset=2]
+include::platform/ref-control-plane-execution-nodes-fully-connected.adoc[leveloffset=2]
+include::platform/ref-control-plane-with-single-egress.adoc[leveloffset=2]
+include::platform/ref-control-plane-execution-topo-hop-nodes.adoc[leveloffset=2]
+include::platform/ref-complex-mesh-topology.adoc[leveloffset=2]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
@@ -1,0 +1,22 @@
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="installing-automation-mesh"]
+= Installing {AutomationMesh}
+
+
+:context: installing-automation-mesh
+
+
+[role="_abstract"]
+You can install an {AutomationMesh} using the instructions found in the {PlatformName} Installation Guide. {PlatformNameShort} installations are seperated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment. Review the systems requirements for each component and {AutomationMesh} node type before proceeding with your installation.
+
+
+[role="_additional-resources"]
+== Additional resources
+
+* See the {PlatformName} Reference Architecture for additional information before installing.
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-migrating-to-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-migrating-to-mesh.adoc
@@ -1,0 +1,22 @@
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="installing-automation-mesh"]
+= Migrating to {AutomationMesh}
+
+
+:context: automation-mesh-migrating
+
+
+[role="_abstract"]
+You can install an {AutomationMesh} using the instructions found in the {PlatformName} Installation Guide. {PlatformNameShort} installations are seperated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment. Review the systems requirements for each component and {AutomationMesh} node type before proceeding with your installation.
+
+
+[role="_additional-resources"]
+== Additional resources
+
+* See the {PlatformName} Reference Architecture for additional information before installing.
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-automation-mesh-node-types.adoc
+++ b/downstream/modules/platform/con-automation-mesh-node-types.adoc
@@ -16,7 +16,7 @@ The *control plane* consists of hybrid and control nodes. Instances in the contr
 
 == Execution plane
 
-The *execution plane* consists of execution nodes that execute automation on behalf of the control plane and have no control functions and hop nodes to communicate. Nodes in the *execution plane* only run user-space jobs, and may be geographically separated, with high latency, from the control plane.
+The *execution plane* consists of execution nodes that execute automation on behalf of the control plane and have no control functions. Hop nodes serve to communicate. Nodes in the *execution plane* only run user-space jobs, and may be geographically separated, with high latency, from the control plane.
 
 * *Execution nodes* -  Execution nodes run jobs under `ansible-runner` with `podman` isolation. This node type is similar to isolated nodes.
 

--- a/downstream/modules/platform/con-automation-mesh-node-types.adoc
+++ b/downstream/modules/platform/con-automation-mesh-node-types.adoc
@@ -1,19 +1,24 @@
 
 [id="con-automation-mesh-node-types"]
 
-= Automation mesh nodes
+= Control and execution planes
 
 [role="_abstract"]
-Automation mesh makes use of unique node types on both the control and execution plane. The control plane consists of hybrid and control nodes, while execution and hop nodes comprise the execution plane. You can define each node type in the {PlatformNameShort} installer inventory file, under the `[automationcontroller]` and `[execution_nodes]` groups or by specifying the node type under the `[automationcontroller:vars]` or `[execution_nodes:vars]` groups. Learn more about node types before graphing your automation mesh topology.
+Automation mesh makes use of unique node types to create both the *control* and *execution* plane.  Learn more about the control and execution plane and their node types before designing your automation mesh topology.
 
-== Control plane nodes
+== Control plane
+
+The *control plane* consists of hybrid and control nodes. Instances in the control plane run persistent {ControllerName} services such as the the web server and task dispatcher, in addition to project updates, and management jobs.
+
 * *Hybrid nodes* - this is the default node type for control plane nodes, responsible for {ControllerName} runtime functions like project updates, management jobs and `ansible-runner` task operations. Hybrid nodes are also used for automation execution.
 
 * *Control nodes* - control nodes run project and inventory updates and system jobs, but not regular jobs. Execution capabilities are disabled on these nodes.
 
-== Execution plane nodes
+== Execution plane
 
-* *Execution nodes* - these nodes execute automation on behalf of control plane nodes and have no control functions. Execution nodes run jobs under `ansible-runner` with `podman` isolation. This node type is similar to isolated nodes.
+The *execution plane* consists of execution nodes that execute automation on behalf of the control plane and have no control functions and hop nodes to communicate. Nodes in the *execution plane* only run user-space jobs, and may be geographically separated, with high latency, from the control plane.
+
+* *Execution nodes* -  Execution nodes run jobs under `ansible-runner` with `podman` isolation. This node type is similar to isolated nodes.
 
 * *Hop nodes* -  similar to a jump host, hop nodes will route traffic to other execution nodes. Hop nodes cannot execute automation.
 

--- a/downstream/modules/platform/con-control-execution-planes.adoc
+++ b/downstream/modules/platform/con-control-execution-planes.adoc
@@ -19,4 +19,4 @@ The control plane consists of hybrid and control nodes, while execution and hop 
 
 == Peers
 
-Peer relationships define node-to-node connections. You can define peers within the `[automationcontroller]` and `[execution_nodes]` groups or using the `[automationcontroller:vars]` or `[execution_nodes:vars]` groups
+Peer relationships define node-to-node connections. You can define peers within the `[automationcontroller]` and `[execution_nodes]` groups or within the `[automationcontroller:vars]` or `[execution_nodes:vars]` groups.

--- a/downstream/modules/platform/con-control-execution-planes.adoc
+++ b/downstream/modules/platform/con-control-execution-planes.adoc
@@ -1,0 +1,22 @@
+
+[id="con-automation-mesh-node-types"]
+
+= Control and execution planes
+
+[role="_abstract"]
+The control plane consists of hybrid and control nodes, while execution and hop nodes comprise the execution plane. You can define each node type in the {PlatformNameShort} installer inventory file, under the `[automationcontroller]` and `[execution_nodes]` groups or by specifying the node type under the `[automationcontroller:vars]` or `[execution_nodes:vars]` groups. Learn more about node types before graphing your automation mesh topology.
+
+== Control plane nodes
+* *Hybrid nodes* - this is the default node type for control plane nodes, responsible for {ControllerName} runtime functions like project updates, management jobs and `ansible-runner` task operations. Hybrid nodes are also used for automation execution.
+
+* *Control nodes* - control nodes run project and inventory updates and system jobs, but not regular jobs. Execution capabilities are disabled on these nodes.
+
+== Execution plane nodes
+
+* *Execution nodes* - these nodes execute automation on behalf of control plane nodes and have no control functions. Execution nodes run jobs under `ansible-runner` with `podman` isolation. This node type is similar to isolated nodes.
+
+* *Hop nodes* -  similar to a jump host, hop nodes will route traffic to other execution nodes. Hop nodes cannot execute automation.
+
+== Peers
+
+Peer relationships define node-to-node connections. You can define peers within the `[automationcontroller]` and `[execution_nodes]` groups or using the `[automationcontroller:vars]` or `[execution_nodes:vars]` groups

--- a/downstream/modules/platform/ref-complex-mesh-topology.adoc
+++ b/downstream/modules/platform/ref-complex-mesh-topology.adoc
@@ -2,7 +2,7 @@
 
 [id="ref-complex-mesh-topology"]
 
-= Complex automation mesh design pattern example Three controllers, 2 exec nodes + multi hops with exec nodes
+= Complex automation mesh design example
 
 
 [role="_abstract"]
@@ -22,42 +22,42 @@ This example inventory demonstrates a complex automation mesh design pattern tha
 
 -----
 [automationcontroller]
-aapc1.local ansible_connection=local
-aapc2.local
-aapc3.local
+control-plane-1.example.com ansible_connection=local
+control-plane-2.example.com
+control-plane-3.example.com
 
 [automationcontroller:vars]
 peers=instance_group_directconnected
 node_type=control
 
 [execution_nodes]
-aape1.local
-aape2.local
-aape3.local peers=local_hop
-aape4.local peers=remote_hop
-aaph1.local node_type=hop
-aaph2.local node_type=hop
-aaph3.local node_type=hop
+execution-node-1.example.com
+execution-node-2.example.com
+execution-node-2.example.com peers=local_hop
+execution-node-4.example.com peers=remote_hop
+hop-node-1.example.com node_type=hop
+hop-node-2.example.com node_type=hop
+hop-node-3.example.com node_type=hop
 
 [instance_group_directconnected]
-aape1.local
-aape2.local
+execution-node-1.example.com
+execution-node-2.example.com
 
 [instance_group_localhop]
-aape3.local
+execution-node-3.example.com
 
 [instance_group_multihop]
-aape4.local
+execution-node-4.example.com
 
 [local_hop]
-aaph1.local
-aaph2.local
+hop-node-1.example.com
+hop-node-2.example.com
 
 [local_hop:vars]
 peers=automationcontroller
 
 [remote_hop]
-aaph3.local
+hop-node-3.example.com
 
 [remote_hop:vars]
 peers=local_hop

--- a/downstream/modules/platform/ref-complex-mesh-topology.adoc
+++ b/downstream/modules/platform/ref-complex-mesh-topology.adoc
@@ -6,7 +6,7 @@
 
 
 [role="_abstract"]
-This example inventory demonstrates a complex automation mesh design pattern that uses groups to associate nodes of the same type in order to reduce noise in the installer configuration. It deploys three {AutomaionController}s, 2 execution nodes and multi hops with execution nodes.
+This example inventory demonstrates a complex automation mesh design pattern that uses groups to associate nodes of the same type in order to reduce noise in the installer configuration. It deploys three {ControllerName}s, two execution nodes and multiple hops with execution nodes.
 
 [NOTE]
 ====

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -19,3 +19,5 @@ include::platform/assembly-planning-mesh.adoc[leveloffset=+1]
 include::platform/assembly-example-topologies.adoc[leveloffset=+1]
 
 include::platform/assembly-deprovisioning-mesh.adoc[leveloffset=+1]
+
+include::platform/assembly-installing-automation-mesh.adoc[leveloffset=+1]


### PR DESCRIPTION
This update revises the description of the control and execution plane, nesting the node types beneath those descriptions. 

The complex mesh design is also updated to unify the example node types as they appear in all other reference inventory files, as suggested by Roger Lopez. 

Preview: http://file.rdu.redhat.com/cbudzilo/mesh/build/tmp/en-US/html-single/#ref-complex-mesh-topology