### PR TITLE
Fix typo in worker module

### DIFF
--- a/downstream/modules/catalog/proc-preparing-worker-installer.adoc
+++ b/downstream/modules/catalog/proc-preparing-worker-installer.adoc
@@ -85,10 +85,10 @@ servicescatalog_controller_password: password
 # vi inventory
 -----
 +
-. Add the `host_vars` for each host under `[servicecatalog_workers]`:
+. Add the `host_vars` for each host under `[servicescatalog_workers]`:
 +
 ----
-[servicecatalog_workers]
+[servicescatalog_workers]
 finance
 marketing
 ----


### PR DESCRIPTION
@TarikFD  would you mind taking a look and approving this PR?

Fixing  typo in the Catalog worker installation doc per [AAP-1222](https://issues.redhat.com/browse/AAP-1222)

Preview: http://file.rdu.redhat.com/cbudzilo/worker/build/tmp/en-US/html-single/