### PR TITLE
AAP-1398: Update link to operator product docs link

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -39,7 +39,7 @@ Once you have configured your {ControllerName} operator, click *Create* at the b
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the `Operators - Working with Operators in OpenShift Container Platform` guide.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-external-db.adoc
@@ -39,7 +39,7 @@ Once you have configured your {ControllerName} operator, click *Create* at the b
 [role="_additional-resources"]
 == Additional resources
 
-* See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/index[Working with Operators in OpenShift Container Platform] for more information on running operators on OpenShift Container Platform.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the `Operators - Working with Operators in OpenShift Container Platform` guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -43,7 +43,7 @@ include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the `Operators - Working with Operators in OpenShift Container Platform` guide.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -43,7 +43,7 @@ include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/index[Working with Operators in OpenShift Container Platform] for more information on running operators on OpenShift Container Platform.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the `Operators - Working with Operators in OpenShift Container Platform` guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
Problem was that old link linked to a specific version of the OCP product docs. Changed the paragraph so that the link led to the main product docs splash page, but included text to instruct users to find the operator docs so it'll always show the latest version.

Jira issue: https://issues.redhat.com/browse/AAP-1398