### PR TITLE
Platform - Fixes to platform upgrade docs

### DIFF
--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -31,43 +31,8 @@ In order to run {ControllerName} 4.0, you must also have Ansible 2.10.
 
 include::platform/con-upgrade-planning.adoc[leveloffset=+1]
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
-
-== Setting up the inventory file
-
-To upgrade using the {PlatformName} installer, edit the inventory file found in the installer using the same parameters as used in your previous {PlatformName} setup.
-
-NOTE: To review information about the inventory file requirements for your specific intsallation scenario, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide].
-
-.Procedure
-. Navigate to the installer
-.. [bundled installer]
-+
------
-$ cd ansible-automation-platform-setup-bundle-<latest-version>
------
-+
-.. [online installer]
-+
------
-$ cd ansible-automation-platform-setup-<latest-version>
------
-+
-. Open the `inventory` file with a text editor.
-. Edit the `inventory` file parameters to match the `inventory` file in your previous version of {PlatformName}.
-
-== Running the {PlatformName} installer setup script
-
-You can run the setup script once you have finished updating the `inventory` file to match your previous {PlatformNameShort} installation.
-
-.Procedure
-
-. Run the `setup.sh` script
-+
------
-$ ./setup.sh
------
-
-The installation will begin.
+include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]
+include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]
 
 
 ////

--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -31,18 +31,53 @@ In order to run {ControllerName} 4.0, you must also have Ansible 2.10.
 
 include::platform/con-upgrade-planning.adoc[leveloffset=+1]
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
-include::platform/con-rbac-considerations.adoc[leveloffset=+1]
+
+== Setting up the inventory file
+
+To upgrade using the {PlatformName} installer, edit the inventory file found in the installer using the same parameters as used in your previous {PlatformName} setup.
+
+NOTE: To review information about the inventory file requirements for your specific intsallation scenario, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide].
+
+.Procedure
+. Navigate to the installer
+.. [bundled installer]
++
+-----
+$ cd ansible-automation-platform-setup-bundle-<latest-version>
+-----
++
+.. [online installer]
++
+-----
+$ cd ansible-automation-platform-setup-<latest-version>
+-----
++
+. Open the `inventory` file with a text editor.
+. Edit the `inventory` file parameters to match the `inventory` file in your previous version of {PlatformName}.
+
+== Running the {PlatformName} installer setup script
+
+You can run the setup script once you have finished updating the `inventory` file to match your previous {PlatformNameShort} installation.
+
+.Procedure
+
+. Run the `setup.sh` script
++
+-----
+$ ./setup.sh
+-----
+
+The installation will begin.
 
 
-
+////
 [role="_additional-resources"]
 == Additional resources (or Next steps)
-////
 Optional. Delete if not used.
-////
 * A bulleted list of links to other material closely related to the contents of the assembly, including xref links to other assemblies in your collection.
 * For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+////
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -1,0 +1,27 @@
+
+
+[id="proc-editing-inventory-file-for-updates_{context}"]
+
+
+= Setting up the inventory file
+
+To upgrade using the {PlatformName} installer, edit the inventory file found in the installer using the same parameters as used in your previous {PlatformName} setup.
+
+NOTE: To review information about the inventory file requirements for your specific intsallation scenario, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide].
+
+.Procedure
+. Navigate to the installer:
+Bundled installer::
++
+-----
+$ cd ansible-automation-platform-setup-bundle-<latest-version>
+-----
++
+Online installer::
++
+-----
+$ cd ansible-automation-platform-setup-<latest-version>
+-----
++
+. Open the `inventory` file with a text editor.
+. Edit the `inventory` file parameters to match the `inventory` file in your previous version of {PlatformName}.

--- a/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
+++ b/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
@@ -1,0 +1,16 @@
+// [id="proc-running-setup-script-for-updates_{context}"]
+
+= Running the {PlatformName} installer setup script
+
+[role="_abstract"]
+You can run the setup script once you have finished updating the `inventory` file to match your previous {PlatformNameShort} installation.
+
+.Procedure
+
+. Run the `setup.sh` script
++
+-----
+$ ./setup.sh
+-----
+
+The installation will begin.

--- a/downstream/titles/upgrade/docinfo.xml
+++ b/downstream/titles/upgrade/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Upgrading to the latest version of Ansible Automation Platform and migrating legacy virtual environments to automation execution environments</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Fixed several issues relating to the [AAP upgrade guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index):

Issue 1: Broken link to the jira page ([AAP-1397](https://issues.redhat.com/browse/AAP-1397))
- Fixed a broken link in docinfo.xml . Link works in the preview now.

Issue 2: Incomplete and wrong modules linked in the upgrade guide ([AAP-1594](https://issues.redhat.com/browse/AAP-1594))
- The current docs links to irrelevant modules from 1.3-1.4, and the guide is incomplete as a result. Added proper content about how to upgrade using the AAP installer, using information as gathered from productization team. 

Please see my changes and feel free to leave any feedback.
Preview link (VPN required): http://file.rdu.redhat.com/kevchin/aap_upgrade/tmp/en-US/html-single/