### PR TITLE
AAP Installer - Enable API-access Logs + installer config module

### DIFF
--- a/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
@@ -17,6 +17,7 @@ You can use these instructions to install a standalone {ControllerName} server o
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]
 include::platform/ref-standalone-controller-ext-db.adoc[leveloffset=3]
+include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
@@ -18,6 +18,7 @@ You can use these instructions to install a standalone instance of {ControllerNa
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]
 include::platform/ref-single-node-inventory.adoc[leveloffset=3]
+include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
@@ -18,6 +18,7 @@ You can use these instructions to install a standalone instance of {HubName} wit
 include::platform/ref-platform-install-settings.adoc[leveloffset=3]
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]
 include::platform/ref-standalone-hub-ext-database-inventory.adoc[leveloffset=3]
+include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
@@ -19,6 +19,7 @@ You can use these instructions to install a standalone instance of {HubName} wit
 include::platform/ref-platform-install-settings.adoc[leveloffset=3]
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]
 include::platform/ref-standalone-hub-inventory.adoc[leveloffset=3]
+include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-hub-installation.adoc[leveloffset=3]

--- a/downstream/modules/platform/ref-additional-inv-configs.adoc
+++ b/downstream/modules/platform/ref-additional-inv-configs.adoc
@@ -1,0 +1,26 @@
+
+= Additional inventory file variables
+
+[role="_abstract"]
+You can further configure your {PlatformName} installation by including additional variables to the inventory file. These configurations adds various optional features for managing your {PlatformName}. Add these variables by editing the `inventory` file using a text editor.
+
+
+.Additional inventory file variables
+[options="header"]
+|====
+|Variable|Description|Default
+|`GALAXY_ENABLE_API_ACCESS_LOG` | When set to `True`, creates a log file at `/var/log/galaxy_api_access.log` that logs all user actions made to the platform, including their username and IP address  | `False`
+|====
+
+.Example
+
+* To enable the api access log, add the variable to the inventory and flag as `true`:
+-----
+[all:vars:]
+admin_password = 'password'
+
+pg_host=''
+pg_port=''
+
+GALAXY_ENABLE_API_ACCESS_LOG=true
+-----

--- a/downstream/modules/platform/ref-additional-inv-configs.adoc
+++ b/downstream/modules/platform/ref-additional-inv-configs.adoc
@@ -2,7 +2,7 @@
 = Additional inventory file variables
 
 [role="_abstract"]
-You can further configure your {PlatformName} installation by including additional variables to the inventory file. These configurations adds various optional features for managing your {PlatformName}. Add these variables by editing the `inventory` file using a text editor.
+You can further configure your {PlatformName} installation by including additional variables to the inventory file. These configurations add various optional features for managing your {PlatformName}. Add these variables by editing the `inventory` file using a text editor.
 
 
 .Additional inventory file variables

--- a/downstream/modules/platform/ref-setup-script-args.adoc
+++ b/downstream/modules/platform/ref-setup-script-args.adoc
@@ -1,14 +1,9 @@
-
-
 // [id="ref-reference-material_{context}"]
 
-= Flags and extra vars
-
+= Setup script flags and extra variables
 
 [role="_abstract"]
-You can pass flags and extra variables when installing {ControllerName}.
-
-:
+You can also pass flags and extra variables when running the setup script to install {ControllerName}:
 
 .Flags
 [options="header"]
@@ -69,8 +64,4 @@ $ ./setup.sh -e bundle_install=false
 * To specify a non-default path when restoring from a backup file:
 -----
 ./setup.sh -e 'restore_backup_file=/path/to/nondefault/location' -r
------
-*
------
-To override an inventory file used by passing it as an argument to the setup script:
 -----


### PR DESCRIPTION
JIRA request: https://issues.redhat.com/browse/AAP-1620

Adds content about enabling api logs to an AAP install. In doing so, added a reference module to house any future configurations to the inventory file.

See section 2.1.4, 2.2.4, etc. of the preview link below

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/installer2/tmp/en-US/html-single/#additional_inventory_file_variables