### PR TITLE
bugfix: Asciidoc artefact visible in rendered Automation Mesh guide

### DIFF
--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -13,7 +13,7 @@ include::attributes/attributes.adoc[]
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
 This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
- 
+
 include::platform/assembly-planning-mesh.adoc[leveloffset=+1]
 
 include::platform/assembly-example-topologies.adoc[leveloffset=+1]
@@ -21,3 +21,4 @@ include::platform/assembly-example-topologies.adoc[leveloffset=+1]
 include::platform/assembly-deprovisioning-mesh.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-automation-mesh.adoc[leveloffset=+1]
+


### PR DESCRIPTION
**Problem:**

At the end of the preface in the [Automation Mesh Guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/pr01), an artefact from Asciidoc (`:leveloffset:+1`) is visible in the published docs.

We think this is caused by a hidden character in the blank line between the preface and the first included assembly.

**Solution:**
Deleted the blank line and added in another one.
Also added a blank line at the end of of the doc, as Git didn't detect a diff when the blank line that was causing the problem was replaced.


Before:
![image](https://user-images.githubusercontent.com/44700011/149226139-acb07465-4784-4bc8-a7c7-3fca7207a5b3.png)

After:
![image](https://user-images.githubusercontent.com/44700011/149226213-e2c84ae8-f043-4c95-8a43-e34dccd71c3d.png)



