### PR TITLE
AAP-597 Add procedure to install AAP operator on CLI 

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -20,27 +20,23 @@ Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPS
 == Prerequisites
 
 * Access to {OCP} using an account with operator installation permissions.
-* The {OCPShort} CLI `oc` command is installed on your local system.
+* The {OCPShort} CLI `oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
 
 
 == Installing the {HubName} operator
 
-include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
+include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]
 
-With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
-
-include::platform/proc-hub-route-options.adoc[leveloffset=+2]
-include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
-
-Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
-
-* View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
-
-include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
-
-
-
-
+// With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
+// 
+// include::platform/proc-hub-route-options.adoc[leveloffset=+2]
+// include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
+// 
+// Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+// 
+// * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+// 
+// include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -1,3 +1,5 @@
+// Used in
+// titles/aap-operator-installation/
 ////
 Retains the context of the parent assembly if this assembly is nested within another assembly.
 For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
@@ -5,7 +7,6 @@ See also the complementary step on the last line of this file.
 ////
 
 ifdef::context[:parent-context: {context}]
-
 
 [id="installing-aap-operator-cli"]
 = Installing {OperatorPlatform} from the {OCPShort} CLI
@@ -15,28 +16,18 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI), `oc`.
 
-// mirrors AWX operator flow
-
 == Prerequisites
 
 * Access to {OCP} using an account with operator installation permissions.
-* The {OCPShort} CLI `oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
+* The {OCPShort} CLI `oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
 
-
-== Installing the {HubName} operator
 
 include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]
 
-// With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
-// 
-// include::platform/proc-hub-route-options.adoc[leveloffset=+2]
-// include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
-// 
-// Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
-// 
-// * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
-// 
-// include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
+You can use the {OCPShort} CLI to fetch the web address and the password of the {ControllerNameStart} that you created. 
+
+include::platform/proc-cli-get-controller-pwd.adoc[leveloffset=+2]
+
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -14,17 +14,17 @@ ifdef::context[:parent-context: {context}]
 :context: installing-aap-operator-cli
 
 [role="_abstract"]
-Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI), `oc`.
+Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI) using the `*oc*` command.
 
 == Prerequisites
 
 * Access to {OCP} using an account with operator installation permissions.
-* The {OCPShort} CLI `oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
+* The {OCPShort} CLI `*oc*` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
 
 
 include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]
 
-You can use the {OCPShort} CLI to fetch the web address and the password of the {ControllerNameStart} that you created. 
+You can use the {OCPShort} CLI to fetch the web address and the password of the {ControllerNameStart} that you created.
 
 include::platform/proc-cli-get-controller-pwd.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -26,7 +26,7 @@ include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]
 
 You can use the {OCPShort} CLI to fetch the web address and the password of the {ControllerNameStart} that you created. 
 
-include::platform/proc-cli-get-controller-pwd.adoc[leveloffset=+2]
+include::platform/proc-cli-get-controller-pwd.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -7,34 +7,40 @@ See also the complementary step on the last line of this file.
 ifdef::context[:parent-context: {context}]
 
 
-[id="installing-controller-operator-external"]
-= Installing {ControllerName} on {OCP} web console with an external database
+[id="installing-aap-operator-cli"]
+= Installing {OperatorPlatform} from the {OCPShort} CLI
 
-
-:context: installing-contr-operator-external
-
+:context: installing-aap-operator-cli
 
 [role="_abstract"]
-You can use these instructions to install the {ControllerName} operator on {OCP} with an external PostgreSQL 12 database and route, as well as specify customer resources.
+Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI), `oc`.
 
 // mirrors AWX operator flow
 
 == Prerequisites
 
-* You have installed the {PlatformName} catalog in Operator Hub.
+* Access to {OCP} using an account with operator installation permissions.
+* The {OCPShort} CLI `oc` command is installed on your local system.
 
-== Installing the {ControllerName} operator
+
+== Installing the {HubName} operator
 
 include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
 
-With the {PlatformName} operator installed, locate the *Automation controller* entry and click *Create instance*.
+With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
 
-include::platform/proc-controller-route-options.adoc[leveloffset=+2]
+include::platform/proc-hub-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 
-Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 
 * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+
+include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
+
+
+
+
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -14,12 +14,12 @@ ifdef::context[:parent-context: {context}]
 :context: installing-aap-operator-cli
 
 [role="_abstract"]
-Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI) using the `*oc*` command.
+Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI) using the [command]`oc` command.
 
 == Prerequisites
 
 * Access to {OCP} using an account with operator installation permissions.
-* The {OCPShort} CLI `*oc*` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
+* The {OCPShort} CLI [command]`oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
 
 
 include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-external-db.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-hub-operator-external"]
-= Installing {HubName} on {OCP} with an external database
+= Installing {HubName} on {OCP} web console with an external database
 
 :context: installing-hub-operator-external
 

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -93,3 +93,4 @@
 // OpenShift attributes
 :OCP: Red Hat OpenShift Container Platform
 :OCPShort: OpenShift Container Platform
+:OCPLatest: 4.9

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -92,3 +92,4 @@
 
 // OpenShift attributes
 :OCP: Red Hat OpenShift Container Platform
+:OCPShort: OpenShift Container Platform

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -5,7 +5,7 @@
 
 You can use the OperatorHub on the {OCP} web console to install {OperatorPlatform}.
 
-Alternatively, you can install {OperatorPlatform} from the CLI, using the `oc` command.
+Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-line interface (CLI), `oc`.
 
 Follow one of the workflows below to install the {OperatorPlatform} and use it to install the components of {PlatformNameShort} that you require.
 

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -2,7 +2,9 @@
 
 = Supported installation scenarios for {OCP}
 
-You can install the {PlatformName} operator following one of the below workflows:
+You can install {OperatorPlatform} from the {OCP} user interface or from the command line.
+
+Follow one of the workflows below to install the {OperatorPlatform} and use it to install the components of {PlatformNameShort} that you require.
 
 * {ControllerNameStart} and customer resources first, then {HubName} and customer resources;
 * {HubNameStart} and customer resources first, then {ControllerName} and customer resources;

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -2,7 +2,10 @@
 
 = Supported installation scenarios for {OCP}
 
-You can install {OperatorPlatform} from the {OCP} user interface or from the command line.
+
+You can use the OperatorHub on the {OCP} web console to install {OperatorPlatform}.
+
+Alternatively, you can install {OperatorPlatform} from the CLI, using the `oc` command.
 
 Follow one of the workflows below to install the {OperatorPlatform} and use it to install the components of {PlatformNameShort} that you require.
 

--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -1,0 +1,76 @@
+// Used in 
+// assemblies/platform/assembly-installing-aap-operator-cli.adoc
+// titles/aap-operator-installation/
+
+[id="proc-cli-get-controller-pwd{context}"]
+
+= Fetching {ControllerNameStart} login details from the {OCPShort} CLI
+
+To login to the {ControllerNameStart}, you need the web address and the password.
+
+== Fetching the {ControllerName} web address
+
+A {OCP} route exposes a service at a host name, so that external clients can reach it by name.
+When you created the {ControllerName} instance, a route was created for it.
+The route inherits the name that you assigned to the {ControllerName} object in the YAML file.
+
+Use the following command to fetch the routes:
+
+-----
+oc get routes
+-----
+
+In the following example, the value for `name` in the `AutomationController` YAML definition is `example`.
+
+-----
+$ oc get routes
+
+NAME      HOST/PORT                                              PATH   SERVICES          PORT   TERMINATION     WILDCARD
+example   example-ansible-automation-platform.apps-crc.testing          example-service   http   edge/Redirect   None
+-----
+
+The address for the {ControllerName} instance is example-ansible-automation-platform.apps-crc.testing.
+
+== Fetching the {ControllerName} password
+
+The YAML block for the {ControllerName} instance assigns values to the `name` and `admin_user` keys.
+Use these values in the following command to fetch the password for the {ControllerName} instance.
+
+-----
+oc get secret/<controller_name>-<admin_user>-password -o yaml 
+-----
+
+
+In the following example, the value for `name` is `example` and the value assigned to the `admin_user` key is `admin`.
+
+-----
+oc get secret/example-admin-password -o yaml 
+-----
+
+The password for the {ControllerName} instance is listed in the `metadata` field in the output:
+
+-----
+$ oc get secret/example-admin-password -o yaml
+
+apiVersion: v1
+data:
+  password: ODhLSzJVanByTXVtVEdmUmVQMzdxZXJXazByT3VYUDM=
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"v1","kind":"Secret","metadata":{"labels":{"app.kubernetes.io/component":"automationcontroller","app.kubernetes.io/managed-by":"automationcontroller-operator","app.kubernetes.io/name":"example","app.kubernetes.io/operator-version":"","app.kubernetes.io/part-of":"example"},"name":"example-admin-password","namespace":"ansible-automation-platform"},"stringData":{"password":"88KK2UjprMumTGfReP37qerWk0rOuXP3"}}'
+  creationTimestamp: "2021-12-03T00:02:24Z"
+  labels:
+    app.kubernetes.io/component: automationcontroller
+    app.kubernetes.io/managed-by: automationcontroller-operator
+    app.kubernetes.io/name: example
+    app.kubernetes.io/operator-version: ""
+    app.kubernetes.io/part-of: example
+  name: example-admin-password
+  namespace: ansible-automation-platform
+  resourceVersion: "185013"
+  uid: 391b22f0-52a2-4240-b942-665f1f589359
+
+-----
+
+For this example, the password is `88KK2UjprMumTGfReP37qerWk0rOuXP3`.

--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -15,13 +15,13 @@ When you created the {ControllerName} instance, a route was created for it.
 The route inherits the name that you assigned to the {ControllerName} object in the YAML file.
 
 Use the following command to fetch the routes:
-+
+
 [subs="+quotes"]
 -----
 oc get routes -n __<controller_namespace>__
 -----
 
-In the following example, the value for _name_ in the `AutomationController` YAML definition is `_example_`.
+In the following example, the `_example_` {ControllerName} is running in the `_ansible-automation-platform_` namespace.
 
 -----
 $ oc get routes -n ansible-automation-platform

--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -15,15 +15,16 @@ When you created the {ControllerName} instance, a route was created for it.
 The route inherits the name that you assigned to the {ControllerName} object in the YAML file.
 
 Use the following command to fetch the routes:
-
++
+[subs="+quotes"]
 -----
-oc get routes
+oc get routes -n __<controller_namespace>__
 -----
 
 In the following example, the value for _name_ in the `AutomationController` YAML definition is `_example_`.
 
 -----
-$ oc get routes
+$ oc get routes -n ansible-automation-platform
 
 NAME      HOST/PORT                                              PATH   SERVICES          PORT   TERMINATION     WILDCARD
 example   example-ansible-automation-platform.apps-crc.testing          example-service   http   edge/Redirect   None
@@ -33,15 +34,16 @@ The address for the {ControllerName} instance is `example-ansible-automation-pla
 
 == Fetching the {ControllerName} password
 
-The YAML block for the {ControllerName} instance assigns values to the _name_ and _admin_user_ keys.
+The YAML block for the {ControllerName} instance in [filename]`sub.yaml` assigns values to the _name_ and _admin_user_ keys.
 Use these values in the following command to fetch the password for the {ControllerName} instance.
 
 -----
 oc get secret/<controller_name>-<admin_user>-password -o yaml
 -----
 
+The default value for _admin_user_ is `_admin_`. Modify the command if you changed the admin username in [filename]`sub.yaml`.
 
-In the following example, the value for _name_ is `_example_` and the value assigned to the _admin_user_ key is `_admin_`.
+The following example retrieves the password for an {ControllerName} object called `_example_`: 
 
 -----
 oc get secret/example-admin-password -o yaml

--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -1,4 +1,4 @@
-// Used in 
+// Used in
 // assemblies/platform/assembly-installing-aap-operator-cli.adoc
 // titles/aap-operator-installation/
 
@@ -20,7 +20,7 @@ Use the following command to fetch the routes:
 oc get routes
 -----
 
-In the following example, the value for `name` in the `AutomationController` YAML definition is `example`.
+In the following example, the value for _name_ in the `AutomationController` YAML definition is `_example_`.
 
 -----
 $ oc get routes
@@ -29,22 +29,22 @@ NAME      HOST/PORT                                              PATH   SERVICES
 example   example-ansible-automation-platform.apps-crc.testing          example-service   http   edge/Redirect   None
 -----
 
-The address for the {ControllerName} instance is example-ansible-automation-platform.apps-crc.testing.
+The address for the {ControllerName} instance is `example-ansible-automation-platform.apps-crc.testing`.
 
 == Fetching the {ControllerName} password
 
-The YAML block for the {ControllerName} instance assigns values to the `name` and `admin_user` keys.
+The YAML block for the {ControllerName} instance assigns values to the _name_ and _admin_user_ keys.
 Use these values in the following command to fetch the password for the {ControllerName} instance.
 
 -----
-oc get secret/<controller_name>-<admin_user>-password -o yaml 
+oc get secret/<controller_name>-<admin_user>-password -o yaml
 -----
 
 
-In the following example, the value for `name` is `example` and the value assigned to the `admin_user` key is `admin`.
+In the following example, the value for _name_ is `_example_` and the value assigned to the _admin_user_ key is `_admin_`.
 
 -----
-oc get secret/example-admin-password -o yaml 
+oc get secret/example-admin-password -o yaml
 -----
 
 The password for the {ControllerName} instance is listed in the `metadata` field in the output:

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -12,8 +12,8 @@
 oc new-project ansible-automation-platform
 -----
 +
-. Create a file called `sub.yaml`.
-. Add the following YAML code to the `sub.yaml` file.
+. Create a file called [filename]`sub.yaml`.
+. Add the following YAML code to the [filename]`sub.yaml` file.
 +
 -----
 ---
@@ -67,16 +67,27 @@ spec:
 
 -----
 +
-This file creates a `_Subscription_` object that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` Operator.
+This file creates a `Subscription` object called `_ansible-automation-platform_` that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` operator.
 +
-It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the _name_ key in the `metadata` block of the `AutomationController` object.
-. Run the `*oc apply*` command to create the objects specified in the `sub.yaml` file:
+It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace.
++
+To change the Automation controller name from `_example_`, edit the _name_ field in the `kind: AutomationController` section of [filename]`sub.yaml` and replace `_<automation_controller_name>_` with the name you want to use:
++   
+[subs="+quotes"]
+-----
+apiVersion: automationcontroller.ansible.com/v1beta1
+kind: AutomationController
+metadata:
+  name: __<automation_controller_name>__
+  namespace: ansible-automation-platform
+-----
+. Run the [command]`*oc apply*` command to create the objects specified in the [filename]`sub.yaml` file:
 +
 -----
 oc apply -f sub.yaml
 -----
 
-To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` Operator, run the `*oc get subs*` command:
+To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` operator, run the [command]`*oc get subs*` command:
 
 -----
 $ oc get subs -n ansible-automation-platform

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -1,0 +1,85 @@
+// Used in 
+// assemblies/platform/assembly-installing-aap-operator-cli.adoc
+// titles/aap-operator-installation/
+
+[id="proc-install-cli-aap-operator{context}"]
+
+= Subscribing a namespace to an operator using the {OCPShort} CLI
+
+. Create a project for the operator
++
+-----
+oc new-project ansible-automation-platform
+-----
++
+. Create a file called `sub.yaml`.
+. Add the following YAML code to the `sub.yaml` file.
++
+-----
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: ansible-automation-platform
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ansible-automation-platform-operator
+  namespace: ansible-automation-platform
+spec:
+  targetNamespaces:
+    - ansible-automation-platform
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ansible-automation-platform
+  namespace: ansible-automation-platform
+spec:
+  channel: 'stable-2.1'
+  installPlanApproval: Automatic
+  name: ansible-automation-platform-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: automationcontroller.ansible.com/v1beta1
+kind: AutomationController
+metadata:
+  name: example
+  namespace: ansible-automation-platform
+spec:
+  create_preload_data: true
+  route_tls_termination_mechanism: Edge
+  garbage_collect_secrets: false
+  loadbalancer_port: 80
+  image_pull_policy: IfNotPresent
+  projects_storage_size: 8Gi
+  task_privileged: false
+  projects_storage_access_mode: ReadWriteMany
+  projects_persistence: false
+  replicas: 1
+  admin_user: admin
+  loadbalancer_protocol: http
+  nodeport_port: 30080 
+
+-----
++
+This file creates a `Subscription` object that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` Operator. 
++
+It then creates an `AutomationController` object called `example` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the `name` field in the `metadata` block of the `AutomationController` object.
+. Run the `oc apply` command to create the objects specified in the `sub.yaml` file:
+-----
+oc apply -f sub.yaml
+-----
+
+To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` Operator, run the `oc get subs` command:
+
+-----
+$ oc get subs -n ansible-automation-platform
+-----
+
+For further information about subscribing namespaces to operators, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.
+

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -69,8 +69,9 @@ spec:
 +
 This file creates a `Subscription` object that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` Operator. 
 +
-It then creates an `AutomationController` object called `example` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the `name` field in the `metadata` block of the `AutomationController` object.
+It then creates an `AutomationController` object called `example` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the `name` key in the `metadata` block of the `AutomationController` object.
 . Run the `oc apply` command to create the objects specified in the `sub.yaml` file:
++
 -----
 oc apply -f sub.yaml
 -----
@@ -81,5 +82,5 @@ To verify that the namespace has been successfully subscribed to the `ansible-au
 $ oc get subs -n ansible-automation-platform
 -----
 
-For further information about subscribing namespaces to operators, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.
+For further information about subscribing namespaces to operators, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.
 

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -1,4 +1,4 @@
-// Used in 
+// Used in
 // assemblies/platform/assembly-installing-aap-operator-cli.adoc
 // titles/aap-operator-installation/
 
@@ -63,24 +63,23 @@ spec:
   replicas: 1
   admin_user: admin
   loadbalancer_protocol: http
-  nodeport_port: 30080 
+  nodeport_port: 30080
 
 -----
 +
-This file creates a `Subscription` object that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` Operator. 
+This file creates a `_Subscription_` object that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` Operator.
 +
-It then creates an `AutomationController` object called `example` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the `name` key in the `metadata` block of the `AutomationController` object.
-. Run the `oc apply` command to create the objects specified in the `sub.yaml` file:
+It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace. To use a different name, modify the value for the _name_ key in the `metadata` block of the `AutomationController` object.
+. Run the `*oc apply*` command to create the objects specified in the `sub.yaml` file:
 +
 -----
 oc apply -f sub.yaml
 -----
 
-To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` Operator, run the `oc get subs` command:
+To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` Operator, run the `*oc get subs*` command:
 
 -----
 $ oc get subs -n ansible-automation-platform
 -----
 
 For further information about subscribing namespaces to operators, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.
-

--- a/downstream/titles/aap-operator-installation/docinfo.xml
+++ b/downstream/titles/aap-operator-installation/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Operator Installation Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.0-ea</productnumber>
+<productnumber>2.1</productnumber>
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -20,3 +20,5 @@ include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 include::platform/assembly-installing-hub-operator-external-db.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-controller-operator-external-db.adoc[leveloffset=+1]
+
+include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
**Jira issue:**
[AAP-597](https://issues.redhat.com/browse/AAP-597): Document how to call operator to install without using OCP UI
**Build preview:**
http://file.emea.redhat.com/~ariordan/docs/aap-operator-cli/build/tmp/en-US/html-single/

**Summary:**
Add instructions to the _RHAAP Operator Installation Guide_  describing how to install the AAP Operator using the OpenShift  CLI (`oc`)

so that

Users who do not have access to the OperatorHub on the OpenShift web console can install the AAP operator.

**Title affected:** 
`titles/aap-operator-installation/`

**Reference:** 
[Operators guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace) in OpenShift docs