### PR TITLE
AAP-1388 Remove isolated node content on AAP installation guide

### DIFF
--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -58,9 +58,6 @@ automationhub_pg_sslmode='prefer'
 # and automationhub_ssl_key, one should toggle that value to True.
 #
 # automationhub_ssl_validate_certs = False
-# Isolated Tower nodes automatically generate an RSA key for authentication;
-# To disable this behavior, set this value to false
-# isolated_key_generation=true
 # SSL-related variables
 # If set, this will install a custom CA certificate to the system trust store.
 # custom_ca_cert=/path/to/ca.crt

--- a/downstream/modules/platform/ref-platform-non-inst-database-inventory.adoc
+++ b/downstream/modules/platform/ref-platform-non-inst-database-inventory.adoc
@@ -55,9 +55,6 @@ automationhub_pg_sslmode='prefer'
 # and automationhub_ssl_key, one should toggle that value to True.
 #
 # automationhub_ssl_validate_certs = False
-# Isolated Tower nodes automatically generate an RSA key for authentication;
-# To disable this behavior, set this value to false
-# isolated_key_generation=true
 # SSL-related variables
 # If set, this will install a custom CA certificate to the system trust store.
 # custom_ca_cert=/path/to/ca.crt


### PR DESCRIPTION
Relevant JIRA ticket: https://issues.redhat.com/browse/AAP-1388

Removed references to isolated nodes as it is replaced by automation mesh.

Title affected: `titles/aap-installation-guide/`