### PR TITLE
AAP 2.0 - Dev Creator Guide: Replaced awx with ansible.controller

### DIFF
--- a/downstream/modules/dev-guide/proc-create-playbooks.adoc
+++ b/downstream/modules/dev-guide/proc-create-playbooks.adoc
@@ -21,14 +21,14 @@ Playbooks contain one or more plays. A basic play contains the following section
 
   tasks:
     - name: Create a Project
-      awx.awx.project:
+      ansible.controller.project:
         name: Job Template Test Project
         state: present
         scm_type: git
         scm_url: https://github.com/ansible/ansible-tower-samples.git
 
     - name: Create a Job Template
-      awx.awx.job_template:
+      ansible.controller.job_template:
         name: my-job-1
         project: Job Template Test Project
         inventory: Demo Inventory


### PR DESCRIPTION
Jira request: https://issues.redhat.com/browse/AAP-397

Replaced use of `awx.awx` with `ansible.controller` in the AAP creator guide.

Titles affected: `/titles/dev-guide`