### PR TITLE
AAP-1733 Update navigator example to 2.1 version

### DIFF
--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -26,7 +26,7 @@ $ subscription-manager attach --pool=<sku-pool-id>
 . Enable the repository for RHEL 8.
 +
 ----
-$ sudo subscription-manager repos --enable ansible-automation-platform-2.0-early-access-for-rhel-8-x86_64-rpms
+$ sudo subscription-manager repos --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
 ----
 
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-1733

Updated navigator instructions to download 2.1 version, rather than 2.0 ea

Titles affected: titles/navigator-guide