### PR TITLE
AAP-1337: AAP upgrade guide

### DIFF
--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -14,7 +14,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer and configure it with the same parameters you have used in previous installations, configure any new parameters, then run the installer.
+To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer. Configure it with the same parameters you have used in previous installations, configure any new parameters, then run the installer.
 
 The following guide details these steps in more detail.
 

--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -14,7 +14,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer and configure it with the same parameters you have used in previous installations, then run the installer.
+To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer and configure it with the same parameters you have used in previous installations, configure any new parameters, then run the installer.
 
 The following guide details these steps in more detail.
 

--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -5,7 +5,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="upgrading-platform"]
-= Upgrading to {PlatformName}
+= Upgrading your {PlatformName}
 
 
 :context: upgrading-platform
@@ -13,23 +13,11 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-{HubNameStart} acts as a content provider for {ControllerName}, which requires both an {ControllerName} deployment and an {HubName} deployment running alongside each other. The {PlatformName} installer contains both of these. This section covers each component of the upgrading process:
 
-* Upgrade planning
-* Obtaining the installer
-* Setting up the inventory file
-* Running the setup playbook
-* Migrating from virtual environments to {ExecEnvName}
+To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer and configure it with the same parameters you have used in previous installations, then run the installer.
 
-[NOTE]
-====
-All upgrades should be no more than two major versions behind what you are currently upgrading to. For example, in order to upgrade to {ControllerName} 4.0, you must first be on version 3.8.x. There is no direct upgrade path from version 3.7.x or earlier. Refer to the article, link:https://access.redhat.com/articles/4098921[Recommended upgrade path] on the Red Hat customer portal for more information.
+The following guide details these steps in more detail.
 
-In order to run {ControllerName} 4.0, you must also have Ansible 2.10.
-====
-
-
-include::platform/con-upgrade-planning.adoc[leveloffset=+1]
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]
 include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-to-aap.adoc
@@ -16,7 +16,7 @@ ifdef::context[:parent-context: {context}]
 
 To upgrade your {PlatformName} to the later version, download the desired version of the {PlatformNameShort} installer. Configure it with the same parameters you have used in previous installations, configure any new parameters, then run the installer.
 
-The following guide details these steps in more detail.
+The following guide describes these steps in more detail.
 
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -5,7 +5,7 @@
 
 = Setting up the inventory file
 
-To upgrade using the {PlatformName} installer, edit the `inventory` file found in the installer to match your desired configuration. When editing the `inventory` file, you can use the same `inventory` file parameters from your previous {PlatformNameShort} setup to keep the same configuration as before. You can also enable any new parameters in the `inventory` file that was introduced in the new version of the {PlatformName}.
+To upgrade using the {PlatformName} installer, edit the `inventory` file found in the installer to match your desired configuration. When editing the `inventory` file, you can use the `inventory` file parameters from your previous {PlatformNameShort} setup to keep the same configuration as before. You can also enable any new parameters in the `inventory` file that was introduced in the new version of the {PlatformName}.
 
 .Procedure
 . Navigate to the installer:

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -5,9 +5,7 @@
 
 = Setting up the inventory file
 
-To upgrade using the {PlatformName} installer, edit the inventory file found in the installer using the same parameters as used in your previous {PlatformName} setup.
-
-NOTE: To review information about the inventory file requirements for your specific intsallation scenario, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide].
+To upgrade using the {PlatformName} installer, edit the `inventory` file found in the installer to match your desired configuration. When editing the `inventory` file, you can use the same `inventory` file parameters from your previous {PlatformNameShort} setup to keep the same configuration as before. You can also enable any new parameters in the `inventory` file that was introduced in the new version of the {PlatformName}.
 
 .Procedure
 . Navigate to the installer:
@@ -25,3 +23,8 @@ $ cd ansible-automation-platform-setup-<latest-version>
 +
 . Open the `inventory` file with a text editor.
 . Edit the `inventory` file parameters to match the `inventory` file in your previous version of {PlatformName}.
++
+NOTE: To review information about the inventory file requirements for your specific intsallation scenario, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide].
+. Optional: Edit the `inventory` file parameters to enable any new features introduced in the new version of the {PlatformName}.
++
+NOTE: For more information about any new features and how to enable them, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Product Documentation for {PlatformName}] to search for specific features and their configurations. Review the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_release_notes/index[{PlatformName} Release Notes] for a full list of features in each version release.

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -10,4 +10,4 @@ include::attributes/attributes.adoc[]
 = Red Hat Ansible Automation Platform Upgrade and Migration Guide
 
 include::platform/assembly-upgrading-to-aap.adoc[leveloffset=+1]
-include::platform/assembly-migrate-legacy-venv-to-ee.adoc[leveloffset=+1]
+//include::platform/assembly-migrate-legacy-venv-to-ee.adoc[leveloffset=+1]


### PR DESCRIPTION
Issue link: https://issues.redhat.com/browse/AAP-1337

Developed procedure on upgrading AAP to a later version. 

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/upgrade/tmp/en-US/html-single/