### PR TITLE
AAP-1625: (1.0) Update broken hub link

### DIFF
--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -7,7 +7,7 @@ You can edit the *community* remote repository to sync chosen collections from A
 
 .Prerequisites
 
-* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/managing-user-access/index[Managing user access in Automation Hub] for more information on permissions.
+* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/managing_user_access_in_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
 * You have a `requirements.yml` file that identifies those collections to sync from Ansible Galaxy. See example below.
 
 .Requirements.yml example


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-1625

Update a broken link. To be backported to the 1.0 version of the docs.

Titles affected: `hub/configuring-private-hub-rh-certified`