### PR TITLE
aap-1825 Change link to point to latest controller docs

### DIFF
--- a/downstream/modules/platform/con-cluster-platform-ext-database.adoc
+++ b/downstream/modules/platform/con-cluster-platform-ext-database.adoc
@@ -1,7 +1,7 @@
 
 [id="con-cluster-platform-ext-database_{context}"]
 
-= Mutli-machine cluster installation with an external managed database
+= Multi-machine cluster installation with an external managed database
 
 [role="_abstract"]
 This scenario includes installation of multiple {ControllerName} nodes and an {HubName} instance and configures communication with a remote PostgreSQL instance as its database. This remote PostgreSQL can be a server you manage, or can be provided by a cloud service such as Amazon RDS. In this scenario, all {ControllerName} are active and can execute jobs, and any node can receive HTTP requests.
@@ -9,7 +9,7 @@ This scenario includes installation of multiple {ControllerName} nodes and an {H
 [NOTE]
 ====
 * Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 12*.
-** See link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html#ag-clustering[Clustering] for more information on configuring a clustered setup.
+** See link:https://docs.ansible.com/automation-controller/latest/html/administration/clustering.html[Clustering] for more information on configuring a clustered setup.
 * Provide a reachable IP address for the `[automationhub]` host to ensure users can sync content from Private Automation Hub from a different node.
 ====
 


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/AAP-1825

In the Planning section of the Installation guide, modify link to point to latest version of Controller docs.
Corrected typo in title of module.
