### PR TITLE
AAP-1740 Update hub version in hub lifecycle doc

### DIFF
--- a/downstream/titles/hub/lifecycle/master.adoc
+++ b/downstream/titles/hub/lifecycle/master.adoc
@@ -23,7 +23,8 @@ Customers are expected to upgrade their Automation Hub environments to the most 
 |===
 | Red Hat Automation Hub Release | General Availability | Full support ends |Maintenance Support 1 ends | End of Life
 
-|4.4.0 | November, 18, 2020 | May 17, 2021 | November 18, 2021 | November 18, 2022
+|4.4 | December 2, 2021 | June 2, 2022 | December 2, 2022 | June 2, 2023
+|4.2 | November, 18, 2020 | May 17, 2021 | November 18, 2021 | November 18, 2022
 
 |===
 

--- a/downstream/titles/hub/lifecycle/master.adoc
+++ b/downstream/titles/hub/lifecycle/master.adoc
@@ -23,7 +23,7 @@ Customers are expected to upgrade their Automation Hub environments to the most 
 |===
 | Red Hat Automation Hub Release | General Availability | Full support ends |Maintenance Support 1 ends | End of Life
 
-|4.2 | November, 18, 2020 | May 17, 2021 | November 18, 2021 | November 18, 2022
+|4.4.0 | November, 18, 2020 | May 17, 2021 | November 18, 2021 | November 18, 2022
 
 |===
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-1740

Update the [lifecycle doc for automation hub](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/private_automation_hub_life_cycle/life_cycle_dates).

Automation hub version 4.4.0 is shipped with with AAP 2.1
