### PR TITLE
AAP-1731 Clarifying subscriptions requirements for installing AAP

### DIFF
--- a/downstream/modules/platform/proc-attaching-subscriptions.adoc
+++ b/downstream/modules/platform/proc-attaching-subscriptions.adoc
@@ -5,10 +5,9 @@
 = Attaching your {PlatformName} subscription
 
 [role="_abstract"]
-You *must* have valid subscriptions attached before installing {PlatformName}. Attaching an {PlatformNameShort} subscription enables {HubName} repositories.
+You *must* have valid subscriptions attached on all nodes before installing {PlatformName}. Attaching your {PlatformNameShort} subscription allows you to access subcription-only resources, such as {HubName} repositories.
 
-A valid subscription needs to be attached to the {HubName} node only. Other nodes do not need to have a valid subscription attached, even if the `[automationhub]` group is blank, given this is done at the `repos_el` role level and that this role is run on both `[automationcontroller] and `[automationhub]` hosts.
-
+To attach subscriptions to all your {PlatformNameShort} nodes, start by obtaining the `pool_id` of your Red Hat subscription, then run the `*subscription-manager attach*` command.
 
 .Procedure
 
@@ -18,7 +17,8 @@ A valid subscription needs to be attached to the {HubName} node only. Other node
 # subscription-manager list --available --all | grep "Ansible Automation Platform" -B 3 -A 6
 -----
 +
-The command returns the following:
+.Example
+An example output of the `*subsciption-manager list*` command. Obtain the `pool_id` as seen in the `Pool ID:` section:
 +
 -----
 Subscription Name: Red Hat Ansible Automation, Premium (5000 Managed Nodes)
@@ -26,7 +26,7 @@ Subscription Name: Red Hat Ansible Automation, Premium (5000 Managed Nodes)
   Red Hat Ansible Automation Platform
   SKU: MCT3695
   Contract: ````
-  Pool ID: ``````````
+  Pool ID: <pool_id>
   Provides Management: No
   Available: 4999
   Suggested: 1
@@ -38,12 +38,20 @@ Subscription Name: Red Hat Ansible Automation, Premium (5000 Managed Nodes)
 # subscription-manager attach --pool=<pool_id>
 -----
 
-All nodes will have {PlatformName} attached and find the {HubName} repositories.
+You have now attached your {PlatformName} subscriptions to all nodes.
 
 .Verification
 
-. Verify the subscription was successfully attached:
+* Verify the subscription was successfully attached:
 
 -----
 # subscription-manager list --consumed
 -----
+
+.Troubleshooting
+
+* If you are unable to locate certain packages that came bundled with the {PlatformNameShort} installer, or if you are seeing a `_Repositories disabled by configuration_` message, try enabling the repository using the command:
++
+----
+subscription-manager repos --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
+----

--- a/downstream/modules/platform/proc-attaching-subscriptions.adoc
+++ b/downstream/modules/platform/proc-attaching-subscriptions.adoc
@@ -5,7 +5,7 @@
 = Attaching your {PlatformName} subscription
 
 [role="_abstract"]
-You *must* have valid subscriptions attached on all nodes before installing {PlatformName}. Attaching your {PlatformNameShort} subscription allows you to access subcription-only resources, such as {HubName} repositories.
+You *must* have valid subscriptions attached on all nodes before installing {PlatformName}. Attaching your {PlatformNameShort} subscription allows you to access subcription-only resources necessary to proceed with the installation.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-attaching-subscriptions.adoc
+++ b/downstream/modules/platform/proc-attaching-subscriptions.adoc
@@ -7,8 +7,6 @@
 [role="_abstract"]
 You *must* have valid subscriptions attached on all nodes before installing {PlatformName}. Attaching your {PlatformNameShort} subscription allows you to access subcription-only resources, such as {HubName} repositories.
 
-To attach subscriptions to all your {PlatformNameShort} nodes, start by obtaining the `pool_id` of your Red Hat subscription, then run the `*subscription-manager attach*` command.
-
 .Procedure
 
 . Obtain the `pool_id` for your {PlatformName} subscription:

--- a/downstream/titles/aap-installation-guide/docinfo.xml
+++ b/downstream/titles/aap-installation-guide/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for Red Hat Ansible Automation Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-1731

Requirements have been updating so that all nodes require a red hat subscription for the AAP installer to work. Edited the concept module to clarify this point, and added a troubleshooting step at the end as per Satoe's notes.

See section 1.3 of the preview below
Preview link (VPN required): http://file.rdu.redhat.com/kevchin/aap_sub/tmp/en-US/html-single/#proc-attaching-subscriptions_planning

Titles affected: `titles/aap-installation-guide`