### PR TITLE
AAP-2130 Copy 2.1 release notes to master branch from 2.1 branch

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -4,6 +4,11 @@ include::topics/platform-intro.adoc[leveloffset=+1]
 
 include::topics/upgrading.adoc[leveloffset=+1]
 
+[[anchor-december-2021-release]]
+== December 2021 release
+
+include::topics/aap-21.adoc[leveloffset=+2]
+
 [[anchor-october-2021-release]]
 == October 2021 release
 

--- a/release-notes/topics/aap-21.adoc
+++ b/release-notes/topics/aap-21.adoc
@@ -1,0 +1,21 @@
+[[aap-2.1-intro]]
+= Ansible Automation Platform 2.1
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements
+
+* Automation Mesh introduces separate execution capacity and update your cluster without downtime with Automation Mesh that connects the cluster with a flexible communication method using receptor
+* The platform installer can deploy a Highly Available (HA) Automation Hub cluster
+* Automation Hub connects instances to external Red Hat SSO instances and for the installer to deploy Red Hat SSO
+* Bundle installer provides the execution environment as part of the bundle
+* In the platform installer, rsync is not required anymore
+* The platform installer supports both with rsync and without rsync environment
+* Added support for `sshpass 1.09`
+* The platform operator has been upgraded to `operator-sdk 1.11`
+* Added support for OpenShift Container Platform 4.10
+* Added support for disconnected environment in the platform operator
+* Added support for SSO configuration for Hub in the platform operator
+* Added a must-gather container to help troubleshoot operator issues in the platform operator
+* Upgraded execution environment to ansible-core 2.12
+* Updated execution environment collections to `core-2.12` compatible collections

--- a/release-notes/topics/platform-intro.adoc
+++ b/release-notes/topics/platform-intro.adoc
@@ -8,8 +8,8 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 [cols="a,a,a,a,a"]
 |===
-| Ansible Automation Platform | Ansible Tower | Automation Hub | Automation Services Catalog | Insights for Ansible Automation Platform
+| Ansible Automation Platform | Automation controller | Automation hub | Automation services catalog | Insights for Ansible Automation Platform
 
-|1.2.0 | 3.8.0 | 4.2.0 | hosted service | hosted service
+|2.1.0 | 4.1.0 | 4.4.0 | hosted service | hosted service
 
 |===


### PR DESCRIPTION
**Issue:**
[Jira AAP-2130](https://issues.redhat.com/browse/AAP-2130)
The `2.1` branch in the AAP docs repo includes the [AAP 2.1 release notes](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_release_notes/anchor-december-2021-release).
The `master` branch in the AAP docs repo does not include the AAP 2.1 release notes.

**Action:** 

Add the 2.1 release notes to the main branch.

