### PR TITLE
AAP-1856 Fixed AAP operator install doc titles for clarity

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-controller-operator-local-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator-local-db.adoc
@@ -15,7 +15,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-You can use these instructions to install the {HubName} operator on {OCP} with an external PostgreSQL 12 database and route, as well as specify customer resources.
+You can use these instructions to install the {HubName} operator on {OCP} with routed web traffic using the advanced configuration options in the *Form View*.
 
 // mirrors AWX operator flow
 

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -1,0 +1,45 @@
+////
+Retains the context of the parent assembly if this assembly is nested within another assembly.
+For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
+See also the complementary step on the last line of this file.
+////
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="installing-controller-operator"]
+= Installing {ControllerName} on {OCP} web console
+
+
+:context: installing-contr-operator
+
+
+[role="_abstract"]
+You can use these instructions to install the {ControllerName} operator on {OCP}, as well as specify customer resources.
+
+// mirrors AWX operator flow
+
+== Prerequisites
+
+* You have installed the {PlatformName} catalog in Operator Hub.
+
+== Installing the {ControllerName} operator
+
+include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
+
+With the {PlatformName} operator installed, locate the *Automation controller* entry and click *Create instance*.
+
+include::platform/proc-controller-route-options.adoc[leveloffset=+2]
+include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
+
+Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+
+* View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+
+[role="_additional-resources"]
+== Additional resources
+
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -1,0 +1,49 @@
+////
+Retains the context of the parent assembly if this assembly is nested within another assembly.
+For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
+See also the complementary step on the last line of this file.
+////
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="installing-hub-operator"]
+= Installing {HubName} on {OCP} web console
+
+:context: installing-hub-operator
+
+[role="_abstract"]
+You can use these instructions to install the {HubName} operator on {OCP}, as well as specify customer resources.
+
+// mirrors AWX operator flow
+
+== Prerequisites
+
+* You have installed the {PlatformName} catalog in Operator Hub.
+
+== Installing the {HubName} operator
+
+include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
+
+With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
+
+include::platform/proc-hub-route-options.adoc[leveloffset=+2]
+include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
+
+Once you have configured your {HubName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
+
+* View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+
+include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
+
+
+
+
+
+[role="_additional-resources"]
+== Additional resources
+
+* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-operator-additional-resources.adoc
+++ b/downstream/modules/platform/con-operator-additional-resources.adoc
@@ -2,4 +2,4 @@
 
 = Additional resources
 
-* See link:https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learning more OpenShift Container Platform OperatorHub.
+* See link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learning more OpenShift Container Platform OperatorHub.

--- a/downstream/titles/aap-operator-installation/docinfo.xml
+++ b/downstream/titles/aap-operator-installation/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -17,8 +17,12 @@ This guide helps you to understand the installation requirements and processes b
 
 include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-hub-operator-external-db.adoc[leveloffset=+1]
+include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-controller-operator-external-db.adoc[leveloffset=+1]
+include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]
+
+include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
+
+include::platform/assembly-installing-controller-operator-local-db.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-1856

Received a suggestion to remove references to external dbs until we figure the steps to connect an external db before a hub/controller operator install. 

Also added modules that were omitted from the previous publish cycle, as well as a fix to docinfo.xml

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/operator2/tmp/en-US/html-single/

Titles affected: `titles/aap-operator-installation`