### PR TITLE
AAP-743: Revised subtitle and fixed broken jira link

### DIFF
--- a/downstream/titles/security-guide/docinfo.xml
+++ b/downstream/titles/security-guide/docinfo.xml
@@ -1,10 +1,10 @@
 <title>Red Hat Ansible Security Automation Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.0</productnumber>
-<subtitle>Firewall Policy Management with Ansible Security Automation.</subtitle>
+<productnumber>2.1</productnumber>
+<subtitle>This guide provides procedures for automating and streamlining various security processes needed to identify, triage, and respond to security events using Ansible.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-743

- Fixed the broken link in the docinfo.xml file. Should be `<link xlink:href="https://issues.redhat.com"></link>.`
- Revised subtitle to describe the purpose of the guide.

