### PR TITLE
AAH-920 Hub view-only mode

### DIFF
--- a/downstream/assemblies/hub/assembly-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-user-access.adoc
@@ -1,4 +1,4 @@
-[id="assembly-creating-tokens-in-automation-hub"]
+[id="assembly-user-access"]
 = Configuring user access for your local Automation Hub
 
 include::automation-hub/con-user-access.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-view-only-access.adoc
+++ b/downstream/assemblies/hub/assembly-view-only-access.adoc
@@ -1,0 +1,6 @@
+[id="assembly-view-only-access"]
+= Enabling view-only access for your private automation hub
+
+By enabling view-only access, you can grant access for users to view collections or namespaces on your private automation hub without the need for them to log in. View-only access allows you to share content with unauthorized users while restricting their ability to download and view source code or otherwise change anything on your private automation hub.
+
+include::automation-hub/con-enable-view-only.adoc[leveloffset=+1]

--- a/downstream/modules/automation-hub/con-enable-view-only.adoc
+++ b/downstream/modules/automation-hub/con-enable-view-only.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+// assembly-view-only-access.adoc
+
+
+[id="con-enable-view-only"]
+
+To enable view-only access for your private {HubName}, you will need to edit the inventory file found on your {PlatformName} installer, following the instructions below:
+
+.Procedure
+. Navigate to the installer.
+Bundled installer::
++
+-----
+$ cd ansible-automation-platform-setup-bundle-<latest-version>
+-----
++
+Online installer::
++
+-----
+$ cd ansible-automation-platform-setup-<latest-version>
+-----
++
+. Open the `inventory` file with a text editor.
+. Add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to the inventory file and set to `TRUE`, following the example below:
++
+----
+[all:vars]
+
+GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True
+----
+. Run the `setup.sh` script. The installer will now enable view-only access to your {HubName}.
+
+.Verification
+Once the installation completes, you can verify that you have view-only access on your private {HubName} by attempting to view content on your {HubName} without logging in.
+
+. Navigate to your private {HubName}.
+. On the login screen, click *View only mode*.
+
+Verify that you are able to view content on your {HubName}, such as namespaces or collections, without having to log in.

--- a/downstream/modules/automation-hub/con-enable-view-only.adoc
+++ b/downstream/modules/automation-hub/con-enable-view-only.adoc
@@ -4,7 +4,7 @@
 
 [id="con-enable-view-only"]
 
-To enable view-only access for your private {HubName}, you will need to edit the inventory file found on your {PlatformName} installer, following the instructions below:
+To enable view-only access for your private {HubName}, edit the inventory file found on your {PlatformName} installer, following the instructions below:
 
 .Procedure
 . Navigate to the installer.

--- a/downstream/modules/automation-hub/con-enable-view-only.adoc
+++ b/downstream/modules/automation-hub/con-enable-view-only.adoc
@@ -4,7 +4,10 @@
 
 [id="con-enable-view-only"]
 
-To enable view-only access for your private {HubName}, edit the inventory file found on your {PlatformName} installer, following the instructions below:
+Enable view-only access for your private {HubName} by editing the inventory file found on your {PlatformName} installer.
+
+* If you are installing a new instance of {PlatformNameShort}, follow these steps to add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to your `inventory` file along with your other installation configurations:
+* If you are updating an existing {PlatformNameShort} installation to include view-only access, add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to your `inventory` file then run the `setup.sh` script to apply the updates:
 
 .Procedure
 . Navigate to the installer.

--- a/downstream/titles/hub/managing-user-access/docinfo.xml
+++ b/downstream/titles/hub/managing-user-access/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Managing user access in Private Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.1</productnumber>
-<subtitle>Configure automation hub to support your organization by creating groups for your users to provide them with appropriate system permissions, or by allowing view-only access to unauthorized users.</subtitle>
+<subtitle>Create groups for your automation hub users to provide them with appropriate system permissions, or allow view-only access to unauthorized users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
     <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>

--- a/downstream/titles/hub/managing-user-access/docinfo.xml
+++ b/downstream/titles/hub/managing-user-access/docinfo.xml
@@ -1,10 +1,10 @@
 <title>Managing user access in Private Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>1.2</productnumber>
-<subtitle>Configure Automation Hub to support your organization by creating groups for your users and providing them with the level of system access they require.</subtitle>
+<productnumber>2.1</productnumber>
+<subtitle>Configure automation hub to support your organization by creating groups for your users to provide them with appropriate system permissions, or by allowing view-only access to unauthorized users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/managing-user-access/master.adoc
+++ b/downstream/titles/hub/managing-user-access/master.adoc
@@ -1,15 +1,19 @@
 = Managing user access in Private Automation Hub
 :imagesdir: images
 :numbered:
+include::attributes/attributes.adoc[]
 
-Configure user access in Automation Hub to provide the appropriate level of system permissions to groups in your organization.
+Configure user access in Automation Hub to provide the appropriate level of system permissions to groups in your organization, or provide view-only access to unauthorized users.
 
 include::hub/assembly-user-access.adoc[leveloffset=+1]
 
+include::hub/assembly-view-only-access.adoc[leveloffset=+1]
+
 == Conclusion
 
-Following the procedure above, you can:
+Following the procedures above, you can:
 
 * Create a group and add permissions to it;
 * Create users;
-* Add those users to your groups.
+* Add those users to your groups;
+* Enable view-only mode for unauthorized users.

--- a/downstream/titles/hub/managing-user-access/master.adoc
+++ b/downstream/titles/hub/managing-user-access/master.adoc
@@ -9,11 +9,4 @@ include::hub/assembly-user-access.adoc[leveloffset=+1]
 
 include::hub/assembly-view-only-access.adoc[leveloffset=+1]
 
-== Conclusion
 
-Following the procedures above, you can:
-
-* Create a group and add permissions to it;
-* Create users;
-* Add those users to your groups;
-* Enable view-only mode for unauthorized users.


### PR DESCRIPTION
Jira Ticket: https://issues.redhat.com/browse/AAH-920 

Hub allows for a view-only mode for unauthorized users (not logged in) to view collections and namespaces but not download or edit anything on hub. This PR adds content to the "user access" title about enabling and verifying view-only mode.

Technical verification is still pending for QE review, but while QE is working through their backlog, we'll merge this first and add any necessary changes at a later date.

Preview (VPN required): http://file.rdu.redhat.com/kevchin/viewonly-redo/tmp/en-US/html-single/

Titles affected: `titles/hub/managing-user-access`


