### PR TITLE
AAP-1799 Update podman push command when pushing registry images

### DIFF
--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -25,8 +25,10 @@ $ podman login -u=[username] -p=[password] [automation-hub-url]
 . Push your container image to your {HubName} container registry:
 +
 -----
-$ podman push [automation-hub-url]/[container image name]
+$ podman push [automation-hub-url]/[container image name] --remove-signatures
 -----
++
+NOTE: The `--remove-signatures` flag is required when pushing registry.redhat.com images, as it prevents image recompression issues that causes the command to fail. 
 
 
 .Verification

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -28,8 +28,7 @@ $ podman login -u=[username] -p=[password] [automation-hub-url]
 $ podman push [automation-hub-url]/[container image name] --remove-signatures
 -----
 +
-NOTE: The `--remove-signatures` flag is required when pushing registry.redhat.io images, as it prevents image recompression issues that causes the command to fail. 
-
+NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. The `--remove-signatures` flag prevents possible image-layer digest changes during the `push` operation, which will cause the operation to fail.
 
 .Verification
 

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -28,7 +28,9 @@ $ podman login -u=[username] -p=[password] [automation-hub-url]
 $ podman push [automation-hub-url]/[container image name] --remove-signatures
 -----
 +
-NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. The `--remove-signatures` flag prevents possible image-layer digest changes during the `push` operation that will cause the operation to fail.
+NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. This may lead to image-layer digest changes and a failed push operation, resulting in `Error: Copying this image requires changing layer representation, which is not possible (image is signed or the destination specifies a digest)`.
+
+
 
 .Verification
 

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -28,7 +28,7 @@ $ podman login -u=[username] -p=[password] [automation-hub-url]
 $ podman push [automation-hub-url]/[container image name] --remove-signatures
 -----
 +
-NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. The `--remove-signatures` flag prevents possible image-layer digest changes during the `push` operation, which will cause the operation to fail.
+NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. The `--remove-signatures` flag prevents possible image-layer digest changes during the `push` operation that will cause the operation to fail.
 
 .Verification
 

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -28,7 +28,7 @@ $ podman login -u=[username] -p=[password] [automation-hub-url]
 $ podman push [automation-hub-url]/[container image name] --remove-signatures
 -----
 +
-NOTE: The `--remove-signatures` flag is required when pushing registry.redhat.com images, as it prevents image recompression issues that causes the command to fail. 
+NOTE: The `--remove-signatures` flag is required when pushing registry.redhat.io images, as it prevents image recompression issues that causes the command to fail. 
 
 
 .Verification


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-1799

When dealing with images from registry.redhat.io , users need to include a `--remove-signatures` flag in order for the `podman push` command to work. Updated the command on the docs plus a note briefly explaining the need for the flag.

See section 3.4 in the preview below

Preview (VPN required): http://file.rdu.redhat.com/kevchin/manage-containers/tmp/en-US/html-single/#push-containers