### PR TITLE
(2.0) AAP-1865 Update supported RHEL version in installer docs

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -17,7 +17,7 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid Red Hat Ansible Automation Platform |
 
-h| OS | Red Hat Enterprise Linux 8.2 or later 64-bit (x86) |
+h| OS | Red Hat Enterprise Linux 8.3 or later 64-bit (x86) |
 
 h| Ansible | version 2.9 required |
 


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/AAP-1865

Updated the supported RHEL version of the 2.0ea AAP installer to the correct 8.3 version