### PR TITLE
AAP-2054 Updating procedures regaring managing containers in private hub

### DIFF
--- a/downstream/assemblies/hub/assembly-container-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-container-user-access.adoc
@@ -18,6 +18,11 @@ Configure user access for container repositories in your private {HubName} to pr
 include::automation-hub/ref-container-permissions.adoc[leveloffset=+1]
 include::automation-hub/proc-create-groups.adoc[leveloffset=+1]
 include::automation-hub/proc-assigning-permissions.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See <<container-registry-group-permissions, Container registry group permissions>> to learn more about specific permissions.
+
 include::automation-hub/proc-add-user-to-group.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-delete-container.adoc
+++ b/downstream/assemblies/hub/assembly-delete-container.adoc
@@ -15,7 +15,7 @@ Delete a container repository from your local {HubName} to manage your disk spac
 include::automation-hub/proc-delete-container.adoc[leveloffset=+1]
 
 .Verification
-* Return to the *Container Repository* list view. The container repository should be removed from the list.
+* Return to the *Execution Environments* list view. The container repository should be removed from the list.
 
 
 

--- a/downstream/modules/automation-hub/proc-add-container-readme.adoc
+++ b/downstream/modules/automation-hub/proc-add-container-readme.adoc
@@ -25,10 +25,9 @@ Add a README to your container repository to provide instructions to your users 
 
 .Procedure
 
-. Navigate to *Container Registry*.
-
+. Navigate to *Execution Environments*.
 . Select your container repository.
-. On the *Details* tab, click *Add*.
+. On the *Detail* tab, click *Add*.
 . In the *Raw Markdown* text field, enter your README text in Markdown.
 . Click *Save* when finished.
 

--- a/downstream/modules/automation-hub/proc-add-container-readme.adoc
+++ b/downstream/modules/automation-hub/proc-add-container-readme.adoc
@@ -31,4 +31,4 @@ Add a README to your container repository to provide instructions to your users 
 . In the *Raw Markdown* text field, enter your README text in Markdown.
 . Click *Save* when finished.
 
-Once you add a README, you can edit it at any time by clicking *Edit* and repeating steps 3 and 4.
+Once you add a README, you can edit it at any time by clicking *Edit* and repeating steps 4 and 5.

--- a/downstream/modules/automation-hub/proc-add-group-to-container-repo.adoc
+++ b/downstream/modules/automation-hub/proc-add-group-to-container-repo.adoc
@@ -26,7 +26,7 @@ Provide access to your container repository to users who need to work the images
 
 . Navigate to *Execution Environments*.
 . Select your container repository.
-. Click *Edit*.
+. Click *Edit* at the top right of your window.
 . Under *Groups with access*, select a group or groups to grant access to.
 ** Optional: Add or remove permissions for a specific group using the drop down under that group name.
 . Click *Save*.

--- a/downstream/modules/automation-hub/proc-add-group-to-container-repo.adoc
+++ b/downstream/modules/automation-hub/proc-add-group-to-container-repo.adoc
@@ -20,19 +20,19 @@ Provide access to your container repository to users who need to work the images
 
 .Prerequisites
 
-* You have *change container namespace permissions*.
+* You have *change container namespace* permissions.
 
 .Procedure
 
-. Navigate to *Container Registry*.
-. Locate your container repository.
+. Navigate to *Execution Environments*.
+. Select your container repository.
 . Click *Edit*.
 . Under *Groups with access*, select a group or groups to grant access to.
-. [Optional] Add or remove permissions for a specific group using the drop down under that group name.
+** Optional: Add or remove permissions for a specific group using the drop down under that group name.
 . Click *Save*.
 
 
 [role="_additional-resources"]
 .Additional resources
 
-* See _Container registry group permissions_ to learn more about specific permissions.
+* See <<container-registry-group-permissions, Container registry group permissions>> to learn more about specific permissions.

--- a/downstream/modules/automation-hub/proc-add-user-to-group.adoc
+++ b/downstream/modules/automation-hub/proc-add-user-to-group.adoc
@@ -8,15 +8,15 @@ You can add users to groups when creating a group or manually add users to exist
 
 .Prerequisites
 
-* You have *groups* permissions and can create and manage group configuration and access in Automation Hub.  
+* You have *groups* permissions and can create and manage group configuration and access in Automation Hub.
 
 
 .Procedure
 
 . Log in to Automation Hub
-. Navigate to *Groups*.
-. Click the *Users* tab.
-. Click *Add*.
+. Navigate to *User Access* > *Groups*.
+. Click on a Group name.
+. Navigate to the *Users* tab, then click *Add*.
 . Select users to add from the list and click *Add*.
 
 

--- a/downstream/modules/automation-hub/proc-assigning-permissions.adoc
+++ b/downstream/modules/automation-hub/proc-assigning-permissions.adoc
@@ -14,7 +14,7 @@ You can assign permissions to groups in Automation Hub that enable users to acce
 . Log in to your local Automation Hub.
 . Navigate to *User Access* > *Groups*.
 . Click on a group name.
-. While in the *Permissions* tab, click *Edit*.
+. Select the *Permissions* tab, then click *Edit*.
 . Click in the field for each permission type and select permissions that appear in the list.
 . Click *Save* when finished assigning permissions.
 

--- a/downstream/modules/automation-hub/proc-assigning-permissions.adoc
+++ b/downstream/modules/automation-hub/proc-assigning-permissions.adoc
@@ -12,10 +12,10 @@ You can assign permissions to groups in Automation Hub that enable users to acce
 
 .Procedure
 . Log in to your local Automation Hub.
-. Navigate to *Groups*.
+. Navigate to *User Access* > *Groups*.
 . Click on a group name.
-. Click *Edit*.
-. Click in the field for the permission type and select permissions that appear in the list.
+. While in the *Permissions* tab, click *Edit*.
+. Click in the field for each permission type and select permissions that appear in the list.
 . Click *Save* when finished assigning permissions.
 
 The group can now access features in Automation Hub associated the their assigned permissions.

--- a/downstream/modules/automation-hub/proc-create-groups.adoc
+++ b/downstream/modules/automation-hub/proc-create-groups.adoc
@@ -12,7 +12,7 @@ You can create and assign permissions to a group in Automation Hub that enables 
 
 .Procedure
 . Log in to your local Automation Hub.
-. Navigate to *Groups*.
+. Navigate to *User Access* > *Groups*.
 . Click *Create*.
 . Provide a *Name* and click *Create*.
 

--- a/downstream/modules/automation-hub/proc-delete-container.adoc
+++ b/downstream/modules/automation-hub/proc-delete-container.adoc
@@ -7,7 +7,6 @@
 * You have permissions to manage repositories.
 
 .Procedure
-. Navigate to *Container Repository*.
-. Select the container repository you would like to delete.
-. Click image:images/more_actions.png[more actions] > *Delete*.
+. Navigate to *Execution Environments*.
+. On the container repository you would like to delete, click image:images/more_actions.png[more actions] > *Delete*.
 . When presented with the confirmation message, click the checkbox then click *Delete*.

--- a/downstream/modules/automation-hub/proc-obtain-images.adoc
+++ b/downstream/modules/automation-hub/proc-obtain-images.adoc
@@ -24,8 +24,9 @@ $ podman login registry.redhat.io
 . Enter your username and password at the prompts.
 . Pull a container image:
 +
+[subs="+quotes"]
 -----
-$ podman pull registry.redhat.io/<container image name>:<tag>
+$ podman pull registry.redhat.io/__<container_image_name>__:__<tag>__
 -----
 
 

--- a/downstream/modules/automation-hub/proc-pull-image.adoc
+++ b/downstream/modules/automation-hub/proc-pull-image.adoc
@@ -18,15 +18,11 @@ You can pull images from the {HubName} container registry to make a copy to your
 
 .Procedure
 
-. Navigate to *Container Registry*.
-
+. Navigate to *Execution Environments*.
 . Select your container repository.
-. Click *Copy to clipboard*.
+. In the *Pull this image* entry, click *Copy to clipboard*.
 . Paste and run the command in your terminal.
 
 
-
 .Verification
-
-
 . Run `podman images` to view images on your local machine.

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -19,13 +19,13 @@ You can push tagged container images to private {HubName} to create new containe
 . Log in to Podman using your {HubName} location and credentials:
 +
 -----
-$ podman login -u=[username] -p=[password] [automation-hub-url]
+$ podman login -u=<username> -p=<password> <automation_hub_url>
 -----
 +
 . Push your container image to your {HubName} container registry:
 +
 -----
-$ podman push [automation-hub-url]/[container image name] --remove-signatures
+$ podman push <automation_hub_url>/<container_image_name> --remove-signatures
 -----
 +
 NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. This may lead to image-layer digest changes and a failed push operation, resulting in `Error: Copying this image requires changing layer representation, which is not possible (image is signed or the destination specifies a digest)`.

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -20,14 +20,14 @@ You can push tagged container images to private {HubName} to create new containe
 +
 [subs="+quotes"]
 -----
-$ podman login -u=_<username>_ -p=_<password>_ _<automation_hub_url>_
+$ podman login -u=__<username>__ -p=__<password>__ __<automation_hub_url>__
 -----
 +
 . Push your container image to your {HubName} container registry:
 +
 [subs="+quotes"]
 -----
-$ podman push _<automation_hub_url>_/_<container_image_name>_ --remove-signatures
+$ podman push __<automation_hub_url>__/__<container_image_name>__ --remove-signatures
 -----
 +
 NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. This may lead to image-layer digest changes and a failed push operation, resulting in `Error: Copying this image requires changing layer representation, which is not possible (image is signed or the destination specifies a digest)`.

--- a/downstream/modules/automation-hub/proc-push-container.adoc
+++ b/downstream/modules/automation-hub/proc-push-container.adoc
@@ -18,14 +18,16 @@ You can push tagged container images to private {HubName} to create new containe
 
 . Log in to Podman using your {HubName} location and credentials:
 +
+[subs="+quotes"]
 -----
-$ podman login -u=<username> -p=<password> <automation_hub_url>
+$ podman login -u=_<username>_ -p=_<password>_ _<automation_hub_url>_
 -----
 +
 . Push your container image to your {HubName} container registry:
 +
+[subs="+quotes"]
 -----
-$ podman push <automation_hub_url>/<container_image_name> --remove-signatures
+$ podman push _<automation_hub_url>_/_<container_image_name>_ --remove-signatures
 -----
 +
 NOTE: The `--remove-signatures` flag is required when signed images from registry.redhat.io are pushed to the {HubName} container registry. The `push` operation re-compresses image layers during the upload, which is not guaranteed to be reproducible and is client implementation dependent. This may lead to image-layer digest changes and a failed push operation, resulting in `Error: Copying this image requires changing layer representation, which is not possible (image is signed or the destination specifies a digest)`.

--- a/downstream/modules/automation-hub/proc-tag-image.adoc
+++ b/downstream/modules/automation-hub/proc-tag-image.adoc
@@ -9,21 +9,18 @@ Tag images to add an additional name to images stored in your {HubName} containe
 
 .Prerequisites
 
-* You have `change image tags` permissions.
+* You have *change image tags* permissions.
 
 .Procedure
 
-. Navigate to *Container Registry*.
-
+. Navigate to *Execution Environments*.
 . Select your container repository.
 . Click the *Images* tab.
-. Click *More actions* > *Edit tags*.
+. Click image:images/more_actions.png[more actions] > *Manage tags*.
 . Add a new tag in the text field and click *Add*.
-. [Optional] Remove *current tags* by clicking the *x* on any of the tags for that image.
+** Optional: Remove *current tags* by clicking the *x* on any of the tags for that image.
 . Click *Save*.
 
 
 .Verification
-
-
 . Click the *Activity* tab and review the latest changes.

--- a/downstream/modules/automation-hub/proc-tag-pulled-image.adoc
+++ b/downstream/modules/automation-hub/proc-tag-pulled-image.adoc
@@ -17,8 +17,9 @@ After you pull images from a registry, tag them for use in your private {HubName
 
 * Tag a local image with the {HubName} container repository
 +
+[subs="+quotes"]
 -----
-$ podman tag registry.redhat.io/[container image name]:[tag] [automation hub URL]/[container image name]
+$ podman tag registry.redhat.io/__<container_image_name>__:__<tag>__ __<automation_hub_URL>__/__<container_image_name>__
 -----
 
 

--- a/downstream/modules/automation-hub/ref-container-permissions.adoc
+++ b/downstream/modules/automation-hub/ref-container-permissions.adoc
@@ -6,11 +6,29 @@
 [role="_abstract"]
 User access provides granular controls to how users can interact with containers managed in private {HubName}. Use the list of permissions below to create groups with the right privileges for your container registries.
 
-.Labeled list
-Create new containers:: Users can create new containers.
-Change container namespace permissions:: Users can change permissions on the container repository.
-Change container:: Users can change information on a container.
-Change image tags:: Users can modify image tags.
-Pull private containers:: Users can pull images from a private container.
-Push to existing container:: Users can push an image to an existing container.
-View private containers:: Users can view containers marked as private.
+.List of group permissions used to manage containers in private automation hub
+[cols="1,1"]
+|===
+|Permission name|Description
+
+|Create new containers
+|Users can create new containers
+
+|Change container namespace permissions
+|Users can change permissions on the container repository
+
+|Change container
+|Users can change information on a container
+
+|Change image tags
+|Users can modify image tags
+
+|Pull private containers
+|Users can pull images from a private container
+
+|Push to existing container
+|Users can push an image to an existing container
+
+|View private containers
+|Users can view containers marked as private
+|===

--- a/downstream/titles/hub/manage-containers/docinfo.xml
+++ b/downstream/titles/hub/manage-containers/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Administrator workflows and processes for configuring private automation hub container registry and repositories.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com"></link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-2054

Ticket pointed out an error in a procedure in the "Managing containers in private automation hub" title that was caused by UI changes. I noticed a few other procedures that were affected as well, so I went ahead and updated those:

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/hub_containers2/tmp/en-US/html-single/

Title affected: `titles/hub/manage-containers`