### PR TITLE
AAP-1862 Release notes for AAP January and February 2022 release

### DIFF
--- a/release-notes/docinfo.xml
+++ b/release-notes/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Release Notes</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>1.2</productnumber>
+<productnumber>2.1</productnumber>
 <subtitle>New features, enhancements, and bug fix information</subtitle>
 <abstract>
     <para>A summary of new features, enhancements, and bug fix information for Red Hat Ansible Automation Platform.</para>

--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -4,6 +4,15 @@ include::topics/platform-intro.adoc[leveloffset=+1]
 
 include::topics/upgrading.adoc[leveloffset=+1]
 
+[[anchor-february-2022-release]]
+== February 2022 release
+
+include::topics/aap-211.adoc[leveloffset=+2]
+
+include::topics/hub-441.adoc[leveloffset=+2]
+
+include::topics/controller-411.adoc[leveloffset=+2]
+
 [[anchor-december-2021-release]]
 == December 2021 release
 

--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -16,7 +16,7 @@ include::topics/controller-411.adoc[leveloffset=+2]
 [[anchor-january-2022-release]]
 == January 2022 release
 
-include::topics/aap126.adoc[leveloffset=+2]
+include::topics/aap-126.adoc[leveloffset=+2]
 
 [[anchor-december-2021-release]]
 == December 2021 release

--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -13,6 +13,11 @@ include::topics/hub-441.adoc[leveloffset=+2]
 
 include::topics/controller-411.adoc[leveloffset=+2]
 
+[[anchor-january-2022-release]]
+== January 2022 release
+
+include::topics/aap126.adoc[leveloffset=+2]
+
 [[anchor-december-2021-release]]
 == December 2021 release
 

--- a/release-notes/topics/aap-126.adoc
+++ b/release-notes/topics/aap-126.adoc
@@ -5,7 +5,7 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 .Enhancements and bug fixes
 
-* Update openshift-clients package that ships with Ansible Tower 3.7 and 3.8
+* Updated openshift-clients package that ships with Ansible Tower 3.7 and 3.8
 * Modified database backup and restore logic to compress dump data
 * Added ability to provide custom secret key when running rekey.yml
 * Fixed a bug where the selinux-policy was not recognized during installation

--- a/release-notes/topics/aap-126.adoc
+++ b/release-notes/topics/aap-126.adoc
@@ -1,0 +1,11 @@
+[[aap-1.2.6-intro]]
+= Ansible Automation Platform 1.2.6
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements and bug fixes
+
+* Update openshift-clients package that ships with Ansible Tower 3.7 and 3.8
+* Modified database backup and restore logic to compress dump data
+* Added ability to provide custom secret key when running rekey.yml
+* Fixed a bug where the selinux-policy was not recognized during installation

--- a/release-notes/topics/aap-211.adoc
+++ b/release-notes/topics/aap-211.adoc
@@ -7,10 +7,7 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 * Added OCP 4.10 compatibility
 * Added support for HTTP proxy when pushing execution environment images
-* Added changes to the billing operator to be cluster-scoped
 * Added ability to configure nginx headers on Controller
 * Changed the setup.log file to no longer be world readable
-* Fixed an imagePullBackoff error when pulling execution environment images during a Controller install on OCP
-* Fixed a bug where the installer loads incorrect bundles instead of the proper ee-supported-rhel8:latest bundle
 * Fixed an issue during controller deployment where the web-container will fail to start up, resulting in a failed installation
 * Fixed a Server Error 500 that occurs after an Operator upgrade on OCP

--- a/release-notes/topics/aap-211.adoc
+++ b/release-notes/topics/aap-211.adoc
@@ -1,0 +1,16 @@
+[[aap-2.1.1-intro]]
+= Ansible Automation Platform 2.1.1
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements and bug fixes
+
+* Added OCP 4.10 compatibility
+* Added support for HTTP proxy when pushing execution environment images
+* Added changes to the billing operator to be cluster-scoped
+* Added ability to configure nginx headers on Controller
+* Changed the setup.log file to no longer be world readable
+* Fixed an imagePullBackoff error when pulling execution environment images during a Controller install on OCP
+* Fixed a bug where the installer loads incorrect bundles instead of the proper ee-supported-rhel8:latest bundle
+* Fixed an issue during controller deployment where the web-container will fail to start up, resulting in a failed installation
+* Fixed a Server Error 500 that occurs after an Operator upgrade on OCP

--- a/release-notes/topics/controller-411.adoc
+++ b/release-notes/topics/controller-411.adoc
@@ -1,4 +1,4 @@
-[[controller-41-intro]]
+[[controller-411-intro]]
 = Automation controller 4.1.1
 
 Automation controller replaces Ansible Tower.

--- a/release-notes/topics/controller-411.adoc
+++ b/release-notes/topics/controller-411.adoc
@@ -1,0 +1,16 @@
+[[controller-41-intro]]
+= Automation controller 4.1.1
+
+Automation controller replaces Ansible Tower.
+Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
+The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
+
+Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
+
+.Enhancements and Bug fixes
+
+* Added the ability to specify additional nginx headers
+* Fixed analytics gathering to collect all the data the controller needed to collect
+* Fixed the controller to no longer break subsequent installer runs when deleting the demo organization
+
+See https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#release-notes-for-4-x[automation controller Release Notes for 4.x] for a full list of new features and enhancements.

--- a/release-notes/topics/hub-441.adoc
+++ b/release-notes/topics/hub-441.adoc
@@ -1,0 +1,11 @@
+[[hub-441-intro]]
+= Automation Hub 4.4.1
+
+Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
+
+.Enhancements and bug fixes
+
+* Added tasking system permissions so that users with the appropriate permissions can view and manage tasks
+* Added name, namespace name, and registry requirements when add/editing an execution environment
+* Fixed an error where certified collections will fail to install from a private hub
+* Fixed a bug where the registry sync status will not display on the remote registries page

--- a/release-notes/topics/platform-intro.adoc
+++ b/release-notes/topics/platform-intro.adoc
@@ -10,6 +10,6 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 |===
 | Ansible Automation Platform | Automation controller | Automation hub | Automation services catalog | Insights for Ansible Automation Platform
 
-|2.1.0 | 4.1.0 | 4.4.0 | hosted service | hosted service
+|2.1.1 | 4.1.1 | 4.4.1 | hosted service | hosted service
 
 |===

--- a/release-notes/topics/upgrading.adoc
+++ b/release-notes/topics/upgrading.adoc
@@ -11,4 +11,6 @@ Do not use `yum update` to run upgrades.
 
 Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
 
-See https://docs.ansible.com/ansible-tower/latest/html/quickinstall/index.html[Ansible Automation Platform Quick Installation Guide] for procedures on using the Ansible Automation Platform installer.
+See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade Guide] for information on upgrading your Ansible Automation Platform.
+
+See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] for procedures on using the Ansible Automation Platform installer.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-1862

Added release notes for the current latest release of AAP and it's components, consisting of AAP 2.1.1, automation hub 4.4.1, and automation controller 4.1.1 .

Also retroactively added release notes for AAP 1.2.6, as requested in https://issues.redhat.com/browse/AAP-2124 

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/release-notes-feb2022/build/tmp/en-US/html-single/