### PR TITLE
Delete inline image from hub delete-user procedure

### DIFF
--- a/downstream/modules/automation-hub/proc-delete-user.adoc
+++ b/downstream/modules/automation-hub/proc-delete-user.adoc
@@ -13,6 +13,8 @@ When you delete a user account, the name and email of the user are permanently r
 . Log in to {HubName}.
 . Expand the *User Access* menu.
 . Click *Users* to display a list of the current users.
-. Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
+. Click the action menu beside the user that you want to remove and click *Delete*.
 . Click *Delete* in the warning message to permenently delete the user.
+
+// . Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
 


### PR DESCRIPTION
Debugging: assembly including procedure containing an image is omitted from Pantheon builds, though local build is ok.