### PR TITLE
aap-2389 Add delete user module to controller

### DIFF
--- a/downstream/modules/automation-hub/proc-delete-user.adoc
+++ b/downstream/modules/automation-hub/proc-delete-user.adoc
@@ -13,8 +13,8 @@ When you delete a user account, the name and email of the user are permanently r
 . Log in to {HubName}.
 . Expand the *User Access* menu.
 . Click *Users* to display a list of the current users.
-. Click the action menu beside the user that you want to remove and click *Delete*.
-. Click *Delete* in the warning message to permenently delete the user.
+. Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
+. Click *Delete* in the warning message to permanently delete the user.
 
 // . Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
 

--- a/downstream/modules/controller/proc-controller-delete-user.adoc
+++ b/downstream/modules/controller/proc-controller-delete-user.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+[id="proc-delete-user"]
+
+= Deleting a user from {ControllerName}
+
+When you delete a user account, the name and email of the user are permanently removed from {ControllerName}.
+
+.Prerequisites
+
+* You have *user* permissions in {ControllerName}.  
+
+.Procedure
+. Log in to {ControllerName}.
+. Expand the *Access* menu.
+. Click *Users* to display a list of the current users.
+. Select the check box for the user that you want to remove and click *Delete*.
+. Click *Delete* in the warning message to permenently delete the user.
+

--- a/downstream/modules/controller/proc-controller-delete-user.adoc
+++ b/downstream/modules/controller/proc-controller-delete-user.adoc
@@ -14,5 +14,5 @@ When you delete a user account, the name and email of the user are permanently r
 . Expand the *Access* menu.
 . Click *Users* to display a list of the current users.
 . Select the check box for the user that you want to remove and click *Delete*.
-. Click *Delete* in the warning message to permenently delete the user.
+. Click *Delete* in the warning message to permanently delete the user.
 

--- a/downstream/modules/controller/proc-controller-delete-user.adoc
+++ b/downstream/modules/controller/proc-controller-delete-user.adoc
@@ -3,7 +3,7 @@
 
 = Deleting a user from {ControllerName}
 
-When you delete a user account, the name and email of the user are permanently removed from {ControllerName}.
+When you delete a user account, the user's name and email are permanently removed from {ControllerName}.
 
 .Prerequisites
 
@@ -13,6 +13,6 @@ When you delete a user account, the name and email of the user are permanently r
 . Log in to {ControllerName}.
 . Expand the *Access* menu.
 . Click *Users* to display a list of the current users.
-. Select the check box for the user that you want to remove and click *Delete*.
+. Select the checkbox for the user that you want to remove and click *Delete*.
 . Click *Delete* in the warning message to permanently delete the user.
 


### PR DESCRIPTION
Add instructions to delete user accounts from controller so that customers know how to delete users' private information.

The module currently is not included in any doc title.
Adding it to the controller module directory as it's a Privacy Information requirement for Ansible on Azure. The content will appear in the controller docs user guide on docs.ansible.com, but we may need to have the information in the downstream repo.

Jira: [AAP-2389](https://issues.redhat.com/browse/AAP-2389)