### PR TITLE
Added text file for writers to replace outdated feedback section in docinfo.xml

### DIFF
--- a/downstream/titles/snippets/docinfo-feedback.xml
+++ b/downstream/titles/snippets/docinfo-feedback.xml
@@ -1,0 +1,5 @@
+<!-- Copy the following text over the the <abstract> section of the docinfo.xml in each title -->
+<abstract>
+    <para><emphasis role="strong">Providing Feedback:</emphasis></para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
+</abstract>


### PR DESCRIPTION
Added the directory `downstream/titles/snippets` containing the text file named `docinfo-feedback.xml`. 

Due to the outdated text in the feedback section of every AAP title, writers need to replace that text with clearer and accurate instructions about leaving feedback on AAP docs. To aid with this, I created a text file called `docinfo-feedback.xml` that has text that writers can use to paste into the `docinfo.xml` of the title they're working on. 

The new feedback section reads:

>  If you have a suggestion to improve this documentation, or find an error, please contact technical support at https://access.redhat.com to create an issue on the Ansible Automation Platform Jira project using the Docs component.