### PR TITLE
Fix operator modules

### DIFF
--- a/downstream/modules/platform/con-operator-additional-resources.adoc
+++ b/downstream/modules/platform/con-operator-additional-resources.adoc
@@ -2,4 +2,4 @@
 
 = Additional resources
 
-* See link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learning more OpenShift Container Platform OperatorHub.
+* See link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-understanding-operatorhub.html#olm-understanding-operatorhub[Understanding OperatorHub] to learn more about OpenShift Container Platform OperatorHub.

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -3,7 +3,7 @@
 . Log in to {OCP}.
 . Navigate to *Operators* -> *Operator Hub*.
 . Locate the {PlatformName} operator and click on it.
-> Click *Install*.
+. Click *Install*.
 +
 
 [NOTE]


### PR DESCRIPTION
Fixed a grammar error and a formatting error.
Affects operator doc section [2.2](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_operator_installation_guide/installing-hub-operator#installing_the_automation_hub_operator) and [1.4](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_operator_installation_guide/operator-install-planning#con-operator-additional-resources_operator-install-planning).