### PR TITLE
AAP-2853 Update Providing feedback info (#285)

### DIFF
--- a/downstream/titles/aap-installation-guide/docinfo.xml
+++ b/downstream/titles/aap-installation-guide/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for Red Hat Ansible Automation Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/aap-operator-installation/docinfo.xml
+++ b/downstream/titles/aap-operator-installation/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/analytics/automation-savings-planner/docinfo.xml
+++ b/downstream/titles/analytics/automation-savings-planner/docinfo.xml
@@ -3,7 +3,8 @@
 <productnumber>2.0-ea</productnumber>
 <subtitle>Plan your organization's automation initiatives, and get an accurate estimation of your time and monetary savings when switching to automation.</subtitle>
 <abstract>
-    <para>If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para><emphasis role="strong">Providing Feedback:</emphasis></para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services</orgname>

--- a/downstream/titles/builder/docinfo.xml
+++ b/downstream/titles/builder/docinfo.xml
@@ -4,7 +4,7 @@
   <subtitle>Execution environment builder to create consistent and reproducible automation execution environments for your Red Hat Ansible Automation Platform.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/dev-guide/docinfo.xml
+++ b/downstream/titles/dev-guide/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>This guide is intended for developers looking to learn how to use Ansible in creating content for automation.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Configure automation hub to deliver curated Red Hat Certified and Ansible Galaxy collections content to your users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/getting-started/docinfo.xml
+++ b/downstream/titles/hub/getting-started/docinfo.xml
@@ -5,7 +5,8 @@
 <abstract>
     <para>This guide walks you through the initial steps required to use Red Hat Automation Hub as the default source for certified Ansible collections content.</para>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
+</abstract>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/install/docinfo.xml
+++ b/downstream/titles/hub/install/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Installing an instance of Private Automation Hub or upgrading to a new version on online or offline Red Hat Enterprise Linux 7 and 8 physical or virtual machines.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/manage-containers/docinfo.xml
+++ b/downstream/titles/hub/manage-containers/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Administrator workflows and processes for configuring private automation hub container registry and repositories.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/managing-user-access/docinfo.xml
+++ b/downstream/titles/hub/managing-user-access/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Configure Automation Hub to support your organization by creating groups for your users and providing them with the level of system access they require.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/obtaining-token/docinfo.xml
+++ b/downstream/titles/hub/obtaining-token/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Creating an API Token</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/publishing-internal-content/docinfo.xml
+++ b/downstream/titles/hub/publishing-internal-content/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Use Automation Hub to publish content collections developed within your organization and intended for internal distribution and use.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/uploading-collections/docinfo.xml
+++ b/downstream/titles/hub/uploading-collections/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Uploading your collections to Automation Hub</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/uploading-internal-collections/docinfo.xml
+++ b/downstream/titles/hub/uploading-internal-collections/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Use namespaces to organize the collections created by automation developers in your organization. Create namespaces, upload collections and add additional information and resources that help your end users in their automation tasks.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Automation Hub (AAH)</emphasis> project and use the <emphasis role="strong">Documentation</emphasis> component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/migration/docinfo.xml
+++ b/downstream/titles/migration/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Configure Automation Hub to support your organization by creating groups for your users and providing them with the level of system access they require.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/navigator-guide/docinfo.xml
+++ b/downstream/titles/navigator-guide/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Using Ansible Navigator in the Ansible Creator Workflow.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/security-guide/docinfo.xml
+++ b/downstream/titles/security-guide/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Firewall Policy Management with Ansible Security Automation.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/upgrade/docinfo.xml
+++ b/downstream/titles/upgrade/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Upgrading to the latest version of Ansible Automation Platform and migrating legacy virtual environments to automation execution environments</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/worker-install/docinfo.xml
+++ b/downstream/titles/worker-install/docinfo.xml
@@ -4,7 +4,11 @@
 <subtitle>Extend your Red Hat Ansible Automation Platform to connect with automation services catalog on cloud.redhat.com using the Ansible Automation Platform 2.0 Setup or Setup Bundle Installers</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
+<<<<<<< HEAD
     <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
+=======
+    <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
+>>>>>>> be3d6ec... AAP-2853 Update Providing feedback info (#285) (#286)
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/worker-install/docinfo.xml
+++ b/downstream/titles/worker-install/docinfo.xml
@@ -4,11 +4,7 @@
 <subtitle>Extend your Red Hat Ansible Automation Platform to connect with automation services catalog on cloud.redhat.com using the Ansible Automation Platform 2.0 Setup or Setup Bundle Installers</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
-<<<<<<< HEAD
-    <para> If you have a suggestion to improve this documentation, or find an error, create an issue at <link xlink:href="https://issues.redhat.com(issues.redhat.com)">http://issues.redhat.com</link>. Select the <emphasis role="strong">Ansible Automation Platform</emphasis> project and use the <emphasis role="strong">Documentation</emphasis>component.</para>
-=======
     <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
->>>>>>> be3d6ec... AAP-2853 Update Providing feedback info (#285) (#286)
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Backport https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/285 to 2.0-ea
Jira issue: [AAP-2853](https://issues.redhat.com/browse/AAP-2853)
Affects all titles that have a Providing Feedback section.

Update the Providing Feedback section in docinfo.xml for all AAP docs: direct customers to raise issues with support.
Replace the old feedback section with the feedback snippet in titles/snippets/docinfo-feedback.xml in the docs repo.