### PR TITLE
AAP-2328 Configuring external database for hub/controller on a AAP operator

### DIFF
--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -1,0 +1,19 @@
+
+
+ifdef::context[:parent-context: {context}]
+
+
+
+[id="assembly-install-aap-operator"]
+= Installing the {PlatformName} operator on {OCP}
+
+[role="_abstract"]
+
+.Prerequisites
+* You have installed the {PlatformName} catalog in Operator Hub.
+
+include::platform/proc-install-aap-operator.adoc[leveloffset=+2]
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -8,14 +8,14 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-controller-operator"]
-= Installing {ControllerName} on {OCP} web console
+= Installing and configuring {ControllerName} on {OCP} web console
 
 
 :context: installing-contr-operator
 
 
 [role="_abstract"]
-You can use these instructions to install the {ControllerName} operator on {OCP}, as well as specify customer resources.
+You can use these instructions to install the {ControllerName} operator on {OCP}, specify custom resources, as well as deploying {PlatformNameShort} with an external database.
 
 // mirrors AWX operator flow
 
@@ -25,9 +25,10 @@ You can use these instructions to install the {ControllerName} operator on {OCP}
 
 == Installing the {ControllerName} operator
 
-include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
+. Navigate to *Operators* > *Installed Operators*, then click on the *Ansible Automation Platform* operator.
+. Locate the *Automation controller* tab, then click *Create instance*.
 
-With the {PlatformName} operator installed, locate the *Automation controller* entry and click *Create instance*.
+You can proceed to configure the instance using either the Form View or YAML view.
 
 include::platform/proc-controller-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
@@ -35,6 +36,8 @@ include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.
 
 * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
+
+include::platform/proc-operator-external-db-controller.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -15,7 +15,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-You can use these instructions to install the {ControllerName} operator on {OCP}, specify custom resources, as well as deploying {PlatformNameShort} with an external database.
+You can use these instructions to install the {ControllerName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
 
 // mirrors AWX operator flow
 
@@ -28,7 +28,7 @@ You can use these instructions to install the {ControllerName} operator on {OCP}
 . Navigate to *Operators* > *Installed Operators*, then click on the *Ansible Automation Platform* operator.
 . Locate the *Automation controller* tab, then click *Create instance*.
 
-You can proceed to configure the instance using either the Form View or YAML view.
+You can proceed with configuring the instance using either the Form View or YAML view.
 
 include::platform/proc-controller-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -8,24 +8,23 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-hub-operator"]
-= Installing {HubName} on {OCP} web console
+= Installing and configuring {HubName} on {OCP} web console
 
 :context: installing-hub-operator
 
 [role="_abstract"]
-You can use these instructions to install the {HubName} operator on {OCP}, as well as specify customer resources.
+You can use these instructions to install the {HubName} operator on {OCP}, specify custom resources, as well as deploying {PlatformNameShort} with an external database.
 
 // mirrors AWX operator flow
 
 == Prerequisites
 
-* You have installed the {PlatformName} catalog in Operator Hub.
+* You have installed the {PlatformName} operator in Operator Hub.
 
 == Installing the {HubName} operator
 
-include::platform/proc-install-aap-operator.adoc[leveloffset=+1]
-
-With the {PlatformName} operator installed, locate the *Automation hub* entry and click *Create instance*.
+. Navigate to *Operators* > *Installed Operators*
+. Locate the *Automation hub* entry, then click *Create instance*.
 
 include::platform/proc-hub-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
@@ -35,6 +34,8 @@ Once you have configured your {HubName} operator, click *Create* at the bottom o
 * View progress by navigating to *Workloads* -> *Pods* and locating the newly created instance.
 
 include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
+
+include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
 
 
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -13,7 +13,7 @@ ifdef::context[:parent-context: {context}]
 :context: installing-hub-operator
 
 [role="_abstract"]
-You can use these instructions to install the {HubName} operator on {OCP}, specify custom resources, as well as deploying {PlatformNameShort} with an external database.
+You can use these instructions to install the {HubName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
 
 // mirrors AWX operator flow
 
@@ -23,7 +23,7 @@ You can use these instructions to install the {HubName} operator on {OCP}, speci
 
 == Installing the {HubName} operator
 
-. Navigate to *Operators* > *Installed Operators*
+. Navigate to *Operators* > *Installed Operators*.
 . Locate the *Automation hub* entry, then click *Create instance*.
 
 include::platform/proc-hub-route-options.adoc[leveloffset=+2]

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -1,14 +1,16 @@
-[id="proc-install-aap-operator{context}"]
-
-. Log in to {OCP}.
-. Navigate to *Operators* -> *Operator Hub*.
-. Locate the {PlatformName} operator and click on it.
-. Click *Install*.
-+
+[id="proc-install-aap-operator"]
 
 [NOTE]
 ====
 {OCP} clusters running on AWS do not support ReadWriteMany without adding NFS or other storage.
 ====
-. Upon successful installation of the platform operator, click on the *View operator* button on the installation confirmation message.
-.. You may also find the installed operator by navigating to *Operators* -> *Installed Operators*
+.Procedure
+. Log in to {OCP}.
+. Navigate to *Operators* -> *OperatorHub*.
+. Search for the {PlatformName} operator and click *Install*.
+. Select an *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
+. Click *Install*.
+
+The installation process will begin. When installation is complete a modal will appear notifying you that the {PlatformName} operator is installed in the specified namespace.
+
+* Click *View Operator* to view your newly installed {PlatformName} operator.

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -11,6 +11,6 @@
 . Select an *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
 . Click *Install*.
 
-The installation process will begin. When installation is complete a modal will appear notifying you that the {PlatformName} operator is installed in the specified namespace.
+The installation process will begin. When installation is complete, a modal will appear notifying you that the {PlatformName} operator is installed in the specified namespace.
 
 * Click *View Operator* to view your newly installed {PlatformName} operator.

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -11,7 +11,7 @@ By default, the {PlatformName} operator automatically creates and configures a m
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
 
-NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12
+NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12.
 
 .Procedure
 
@@ -35,9 +35,9 @@ stringData:
   type: unmanaged
 type: Opaque
 ----
-<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to
-<2> The resolvable hostname for your database node
-<3> External port defaults to `5432`
+<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to.
+<2> The resolvable hostname for your database node.
+<3> External port defaults to `5432`.
 <4> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
 <5> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {ControllerName} on {PlatformNameShort} operator.
+By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {ControllerName} on a {PlatformNameShort} operator.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
@@ -36,7 +36,7 @@ stringData:
 type: Opaque
 ----
 <1> External port defaults to `5432`
-<2> Value for varaible `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<2> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
 <3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
 +

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {ControllerName} on a {PlatformNameShort} operator.
+By default, the {PlatformName} operator automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {ControllerName} on a {PlatformNameShort} operator.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
@@ -24,20 +24,22 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: external-postgres-configuration
-  namespace: <target_namespace>
+  namespace: <target_namespace> <1>
 stringData:
-  host: <external_ip_or_url_resolvable_by_the_cluster>
-  port: <external_port> <1>
+  host: <external_ip_or_url_resolvable_by_the_cluster> <2>
+  port: <external_port> <3>
   database: <desired_database_name>
   username: <username_to_connect_as>
-  password: <password_to_connect_with> <2>
-  sslmode: prefer <3>
+  password: <password_to_connect_with> <4>
+  sslmode: prefer <5>
   type: unmanaged
 type: Opaque
 ----
-<1> External port defaults to `5432`
-<2> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
-<3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
+<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to
+<2> The resolvable hostname for your database node
+<3> External port defaults to `5432`
+<4> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<5> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
 +
 ----

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -1,0 +1,55 @@
+
+[id="proc-operator-external-db-controller"]
+
+= Configuring an external database for {ControllerName} on {PlatformName} operator
+
+[role="_abstract"]
+For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
+
+By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {ControllerName} on {PlatformNameShort} operator.
+
+.Prerequisite
+The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
+
+NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12
+
+.Procedure
+
+The external postgres instance credentials and connection information will need to be stored in a secret, which will then be set on the {ControllerName} spec.
+
+. Create a `postgres_configuration_secret` .yaml file, following the template below:
++
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-postgres-configuration
+  namespace: <target_namespace>
+stringData:
+  host: <external_ip_or_url_resolvable_by_the_cluster>
+  port: <external_port> <1>
+  database: <desired_database_name>
+  username: <username_to_connect_as>
+  password: <password_to_connect_with> <2>
+  sslmode: prefer <3>
+  type: unmanaged
+type: Opaque
+----
+<1> External port defaults to `5432`
+<2> Value for varaible `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
+. Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
++
+----
+$ oc create -f external-postgres-configuration-secret.yml
+----
+. When creating your `AutomationController` custom resource object, specify the secret on your spec, following the example below:
++
+----
+apiVersion: awx.ansible.com/v1beta1
+kind: AutomationController
+metadata:
+  name: controller-dev
+spec:
+  postgres_configuration_secret: external-postgres-configuration
+----

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -11,7 +11,7 @@ By default, the {PlatformName} operator automatically creates and configures a m
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
 
-NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12
+NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12.
 
 .Procedure
 
@@ -35,9 +35,9 @@ stringData:
   type: unmanaged
 type: Opaque
 ----
-<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to
-<2> The resolvable hostname for your database node
-<3> External port defaults to `5432`
+<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to.
+<2> The resolvable hostname for your database node.
+<3> External port defaults to `5432`.
 <4> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
 <5> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -1,0 +1,55 @@
+
+[id="proc-operator-external-db-hub"]
+
+= Configuring an external database for {HubName} on {PlatformName} operator
+
+[role="_abstract"]
+For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
+
+By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {HubName} on {PlatformNameShort} operator.
+
+.Prerequisite
+The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
+
+NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12
+
+.Procedure
+
+The external postgres instance credentials and connection information will need to be stored in a secret, which will then be set on the {HubName} spec.
+
+. Create a `postgres_configuration_secret` .yaml file, following the template below:
++
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-postgres-configuration
+  namespace: <target_namespace>
+stringData:
+  host: <external_ip_or_url_resolvable_by_the_cluster>
+  port: <external_port> <1>
+  database: <desired_database_name>
+  username: <username_to_connect_as>
+  password: <password_to_connect_with> <2>
+  sslmode: prefer <3>
+  type: unmanaged
+type: Opaque
+----
+<1> External port defaults to `5432`
+<2> Value for varaible `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
+. Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
++
+----
+$ oc create -f external-postgres-configuration-secret.yml
+----
+. When creating your `AutomationHub` custom resource object, specify the secret on your spec, following the example below:
++
+----
+apiVersion: awx.ansible.com/v1beta1
+kind: AutomationHub
+metadata:
+  name: hub-dev
+spec:
+  postgres_configuration_secret: external-postgres-configuration
+----

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {HubName} on a {PlatformNameShort} operator.
+By default, the {PlatformName} operator automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {HubName} on a {PlatformNameShort} operator.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
@@ -24,20 +24,22 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: external-postgres-configuration
-  namespace: <target_namespace>
+  namespace: <target_namespace> <1>
 stringData:
-  host: <external_ip_or_url_resolvable_by_the_cluster>
-  port: <external_port> <1>
+  host: <external_ip_or_url_resolvable_by_the_cluster> <2>
+  port: <external_port> <3>
   database: <desired_database_name>
   username: <username_to_connect_as>
-  password: <password_to_connect_with> <2>
-  sslmode: prefer <3>
+  password: <password_to_connect_with> <4>
+  sslmode: prefer <5>
   type: unmanaged
 type: Opaque
 ----
-<1> External port defaults to `5432`
-<2> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
-<3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
+<1> Namespace to create the secret in. This should be the same namespace you wish to deploy to
+<2> The resolvable hostname for your database node
+<3> External port defaults to `5432`
+<4> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<5> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
 +
 ----

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {HubName} on {PlatformNameShort} operator.
+By default, the {PlatformName} operator automatically creates and configures a managed PostGreSQL pod in the same namespace as your {PlatformNameShort} deployment. A user may instead choose to use an external database if they prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks. The following section outlines the steps to configure an external database for your {HubName} on a {PlatformNameShort} operator.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
@@ -36,7 +36,7 @@ stringData:
 type: Opaque
 ----
 <1> External port defaults to `5432`
-<2> Value for varaible `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
+<2> Value for variable `password` should not contain single or double quotes (', ") or backslashes (\) to avoid any issues during deployment, backup or restoration.
 <3> The variable `sslmode` is valid for `external` databases only. The allowed values are: `*prefer*`, `*disable*`, `*allow*`, `*require*`, `*verify-ca*`, and `*verify-full*`.
 . Apply `external-postgres-configuration-secret.yml` to your cluster using the `oc create` command.
 +

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -19,11 +19,11 @@ include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
 include::platform/assembly-install-aap-operator.adoc[leveloffset=+1]
 
+include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
+
 include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 // include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]
-
-include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
 
 // include::platform/assembly-installing-controller-operator-local-db.adoc[leveloffset=+1]
 

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -17,12 +17,14 @@ This guide helps you to understand the installation requirements and processes b
 
 include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
+include::platform/assembly-install-aap-operator.adoc[leveloffset=+1]
+
 include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]
+// include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-controller-operator-local-db.adoc[leveloffset=+1]
+// include::platform/assembly-installing-controller-operator-local-db.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-2328

Added instructions to configure an external database when installing hub/controller on a AAP operator. Also restructured some of the operator content to consolidate procedures. See sections 3.4 and 4.3 in the preview below for the external DB content:

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/operator4/tmp/en-US/html-single/