### PR TITLE
AAP-2329 AAP Installation Guide Improvements 

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-platform.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-platform.adoc
@@ -1,0 +1,10 @@
+ifdef::context[:parent-context: {context}]
+
+// [id="assembly-migrate-platform_{context}"]
+= Migrating data to {PlatformNameShort} {PlatformVers}
+
+For platform administrators looking to complete their upgrade to the {PlatformNameShort} {PlatformVers}, there may be additional steps for your to migrate your data to your new instance:
+
+include::platform/con-why-migrate-venvs-ee.adoc[leveloffset=+1]
+include::platform/con-why-migrate-ansible-29.adoc[leveloffset=+1]
+include::platform/con-why-migrate-ansible-core-212.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-multi-machine-install.adoc
+++ b/downstream/assemblies/platform/assembly-multi-machine-install.adoc
@@ -22,16 +22,11 @@ include::platform/ref-multi-node-cluster-installation.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-controller-configs.adoc[leveloffset=4]
+include::platform/proc-verify-hub-installation.adoc[leveloffset=3]
+include::platform/ref-hub-configs.adoc[leveloffset=4]
 
-
-[role="_additional-resources"]
-==  Next steps
-
-
-* Review _Configuring proxy support for {PlatformName}_ if setting up {ControllerName} with a proxy server.
-* See _Managing usability analytics and data collection from {ControllerName}_ for information on controlling what information you share with Red Hat.
-* See the link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Ansible Tower Quick Setup Guide] to learn more about using {ControllerName}.
-* For complete {HubName} configuration documentation, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/[Ansible Automation Platform] product documentation.
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -23,31 +23,31 @@ Red Hat supports the following installations scenarios for {PlatformName}
 
 include::platform/con-SM-standalone-contr-non-inst-database.adoc[leveloffset=+2]
 
-See "Installing {ControllerName} with a database on the same node" in _Installing {PlatformName} components on a single machine_ to get started.
+See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+2]
 
-See "Installing {ControllerName} with an external managed database" in _Installing {PlatformName} components on a single machine_ to get started.
+See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+2]
 
-See "Installing {HubName} with a database on the same node" in _Installing {PlatformName} components on a single machine_ to get started.
+See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-hub-ext-database.adoc[leveloffset=+2]
 
-See "Installing {HubName} with an external database" in _Installing {PlatformName} components on a single machine_ to get started.
+See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-platform-non-inst-database.adoc[leveloffset=+2]
 
-See "Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database" in _Installing {PlatformName}_ to get started.
+See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-platform-ext-database.adoc[leveloffset=+2]
 
-See "Installing {PlatformName} with an external managed database" in _Installing {PlatformName}_ to get started.
+See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-cluster-platform-ext-database.adoc[leveloffset=+2]
 
-See "Installing a multi-node {PlatformName} with an external managed database" in _Multi-machine cluster intallation_ to get started.
+See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster intallation_ to get started.
 
 
 

--- a/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
+++ b/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
@@ -22,14 +22,11 @@ include::platform/ref-example-platform-ext-database-inventory.adoc[leveloffset=3
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-controller-configs.adoc[leveloffset=4]
+include::platform/proc-verify-hub-installation.adoc[leveloffset=3]
+include::platform/ref-hub-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* See xref:assembly-configuring-proxy-support[] if setting up {ControllerName} with a proxy server.
-* See xref:assembly-controlling-data-collection to manage {ControllerName} data analytics you share with Red Hat.
-* See the link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Ansible Tower Quick Setup Guide] to learn more about using {ControllerName}.
-* For complete {HubName} configuration documentation, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/[Ansible Automation Platform] product documentation.
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
@@ -22,15 +22,11 @@ include::platform/ref-platform-non-inst-database-inventory.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-controller-configs.adoc[leveloffset=4]
 include::platform/proc-verify-hub-installation.adoc[leveloffset=3]
+include::platform/ref-hub-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* Review _Configuring proxy support for {PlatformName}_ if setting up {ControllerName} with a proxy server.
-* See _Managing usability analytics and data collection from {ControllerName}_ for information on controlling what information you share with Red Hat.
-* See the link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Ansible Tower Quick Setup Guide] to learn more about using {ControllerName}.
-* For complete {HubName} configuration documentation, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/[Ansible Automation Platform] product documentation.
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-platform-whats-next.adoc
+++ b/downstream/assemblies/platform/assembly-platform-whats-next.adoc
@@ -1,0 +1,14 @@
+ifdef::context[:parent-context: {context}]
+
+// [id="assembly-platform-whats-next_{context}"]
+= What's next with {PlatformNameShort} {PlatformVers}
+
+[role="_abstract"]
+Whether you are a new {PlatformNameShort} user looking to start automating, or an existing administrator looking to migrate old Ansible content to your latest installed version of {PlatformName}, explore the next steps to start leveraging the new features of {PlatformNameShort} {PlatformVers}:
+
+//isolated node migration
+//playbooks to download
+
+
+include::assembly-migrate-platform.adoc[leveloffset=+1]
+include::platform/con-why-automation-mesh.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
@@ -21,13 +21,9 @@ include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-controller-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* Review _Configuring proxy support for {PlatformName}_ if setting up {ControllerName} with a proxy server.
-* See _Managing usability analytics and data collection from {ControllerName}_ for information on controlling what information you share with Red Hat.
-* See the link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Ansible Tower Quick Setup Guide] to learn more about using {ControllerName}.
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
@@ -22,13 +22,9 @@ include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-controller-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* Review _Configuring proxy support for {PlatformName}_ if setting up {ControllerName} with a proxy server.
-* See _Managing usability analytics and data collection from {ControllerName}_ for information on controlling what information you share with Red Hat.
-* See the link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Ansible Tower Quick Setup Guide] to learn more about using {ControllerName}.
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
@@ -22,13 +22,9 @@ include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=3]
+include::platform/ref-hub-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* To configure user access for {HubName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}].
-* See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansiblre Galaxy collections in {HubName}] to learn how to add content to your {HubName}.
-* Learn more about publishing internally developed collections in your {HubName} in link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {Hub Name}].
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
@@ -23,13 +23,9 @@ include::platform/ref-additional-inv-configs.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]
 include::platform/proc-running-setup-script.adoc[leveloffset=3]
 include::platform/proc-verify-hub-installation.adoc[leveloffset=3]
+include::platform/ref-hub-configs.adoc[leveloffset=4]
 
-[role="_additional-resources"]
-==  Next steps
-
-* To configure user access for {HubName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}].
-* See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansiblre Galaxy collections in {HubName}] to learn how to add content to your {HubName}.
-* Learn more about publishing internally developed collections in your {HubName} in link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {Hub Name}].
+include::assembly-platform-whats-next.adoc[leveloffset=3]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -6,6 +6,7 @@
 :AAPCentralAuth: Ansible Automation Platform Central Authentication
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
+:PlatformVers: 2.1
 
 // AAP on Clouds
 :AAPonAzureName: Red Hat Ansible Automation Platform on Microsoft Azure

--- a/downstream/modules/platform/con-why-automation-mesh.adoc
+++ b/downstream/modules/platform/con-why-automation-mesh.adoc
@@ -1,0 +1,11 @@
+// [id="con-why-automation-mesh_{context}"]
+
+= Scale up your automation using {AutomationMesh}
+
+The {AutomationMesh} component of the {PlatformName} simplifies the process of distributing automation across multi-site deployments. For enterprises with multiple isolated IT environments, {AutomationMesh} provides a consistent and reliable way to deploy and scale up automation across your execution nodes using a peer-to-peer mesh communication network.
+
+When upgrading from version 1.x to the latest version of the {PlatformNameShort}, platform administrators will need to migrate the data from their legacy isolated nodes into execution nodes necessary for {AutomationMesh}. Platform administrators can implement {AutomationMesh} by planning out a network of hybrid and control nodes, then editing the inventory file found in the {PlatformNameShort} installer to assign mesh-related values to each of their execution nodes.
+
+For instructions on how to migrate from isolated nodes to execution nodes, see the *upgrade & migration guide*.
+
+For information about automation mesh and the ways you can design your automation mesh for your environment, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[Red Hat Ansible Automation Platform automation mesh guide].

--- a/downstream/modules/platform/con-why-migrate-ansible-29.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-29.adoc
@@ -1,0 +1,5 @@
+// [id="con-why-migrate-ansible-29_{context}"]
+
+= Migrating to Ansible Engine 2.9 images using {Builder}
+
+To migrate Ansible Engine 2.9 images for use with {PlatformNameShort} {PlatformVers}, the `ansible-builder` tool automates the process of rebuilding images (including its custom plugins and dependencies) for use with {ExecEnvName}. For more information on using Ansible Builder to build execution environments, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_builder_guide/index[Ansible Builder Guide].

--- a/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
@@ -1,0 +1,5 @@
+// [id="con-why-migrate-ansible-core-212_{context}"]
+
+= Migrating to Ansible Core 2.12
+
+When upgrading to Ansible Core 2.12, users will need to update their playbooks, plugins, or other parts of their Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.12 compatible, see the https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.12.html[Ansible-core 2.12 Porting Guide].

--- a/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
+++ b/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
@@ -1,0 +1,7 @@
+// [id="con-why-migrate-venvs-ee_{context}"]
+
+= Migrating from legacy virtual environments (venvs) to {ExecEnvName}
+
+{PlatformNameShort} {PlatformVers} moves users away from custom Python virtual environments (venvs) in favor of automation execution environments - containerized images that packages the necessary components needed to execute and scale your Ansible automation, including Ansible Core, Ansible Content Collections, Python dependencies, Red Hat Enterprise Linux UBI 8, and any additional package dependencies.
+
+Platform administrators who are looking to migrate their venvs to execution environments will (1) need to use the `awx-manage` command to list and export a list of venvs from your original instance, then (2) use `ansible-builder` to create execution environments. For more information, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/upgrading-to-ees[Upgrading to Automation Execution Environments guide] and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_builder_guide/index[Ansible Builder Guide].

--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -1,7 +1,3 @@
-
-
-
-
 // [id="proc-verify-controller-installation_{context}"]
 
 = Verifying {ControllerName} installation
@@ -23,12 +19,4 @@ The {ControllerName} server is accessible from port 80 (*https://<TOWER_SERVER_N
 If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, please contact Ansible via the Red Hat Customer portal at https://access.redhat.com/.
 ====
 
-Your {ControllerName} is now ready for initial configuration.
-
-
-[role="_additional-resources"]
-== Next steps
-
-* See link:https://docs.ansible.com/ansible-tower/latest/html/administration/index.html[Automation Controller Administration Guide] for administration through customer scripts, management jobs, and more.
-* For quick setup of {ControllerName}, see the link:https://docs.ansible.com/ansible-tower/latest/html/quickstart/index.html[Automation Controller Quick Setup Guide].
-* Review {ControllerName} functionality in the link:https://docs.ansible.com/ansible-tower/latest/html/userguide/index.html[Automation Controller User Guide].
+Upon a successful login to {ControllerName}, your installation of {PlatformName} {PlatformVers} is now complete.

--- a/downstream/modules/platform/proc-verify-hub-installation.adoc
+++ b/downstream/modules/platform/proc-verify-hub-installation.adoc
@@ -1,8 +1,4 @@
-
-
-
-
-// [id="proc-verify-hub-installation_{context}"]
+[id="proc-verify-hub-installation_{context}"]
 
 = Verifying {HubName} installation
 
@@ -19,4 +15,4 @@ Once the installation completes, you can verify your {HubName} has been installe
 If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, please contact Ansible via the Red Hat Customer portal at https://access.redhat.com/.
 ====
 
-Your {HubName} is now ready for initial configuration.
+Upon a successful login to {HubName}, your installation of {PlatformName} {PlatformVers} is now complete.

--- a/downstream/modules/platform/ref-controller-configs.adoc
+++ b/downstream/modules/platform/ref-controller-configs.adoc
@@ -1,0 +1,16 @@
+// [id="ref-controller-configs_{context}"]
+
+= Additional {ControllerName} configuration and resources
+
+See the following resources to explore additional {ControllerName} configurations.
+
+.Resources to configure {ControllerName}
+[options="header"]
+|====
+|Link|Description
+|https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Automation Controller Quick Setup Guide]|Set up {ControllerName} and run your first playbook
+|https://docs.ansible.com/automation-controller/latest/html/administration/index.html[Automation Controller Administration Guide]|Configure {ControllerName} administration through customer scripts, management jobs, etc.
+|xref:assembly-configuring-proxy-support[Configuring proxy support for {PlatformName}]|Set up {ControllerName} with a proxy server
+|xref:assembly-controlling-data-collection[Managing usability analytics and data collection from {ControllerName}]|Manage what {ControllerName} information you share with Red Hat
+|https://docs.ansible.com/automation-controller/latest/html/userguide/index.html[Automation Controller User Guide]|Review {ControllerName} functionality in more detail
+|====

--- a/downstream/modules/platform/ref-hub-configs.adoc
+++ b/downstream/modules/platform/ref-hub-configs.adoc
@@ -1,0 +1,14 @@
+[id="ref-hub-configs_{context}"]
+
+= Additional {HubName} configuration and resources
+
+See the following resources to explore additional {HubName} configurations.
+
+.Resources to configure {ControllerName}
+[options="header"]
+|====
+|Link|Description
+|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}]|Configure user access for {HubName}
+|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in {HubName}]|Add content to your {HubName}
+|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}
+|====

--- a/downstream/modules/platform/ref-setup-script-args.adoc
+++ b/downstream/modules/platform/ref-setup-script-args.adoc
@@ -37,7 +37,6 @@ $ ./setup.sh -e bundle_install=false
 [options="header"]
 |====
 |Variable|Description|Default
-|`GALAXY_ENABLE_API_ACCESS_LOG` | When set to `True`, creates a log file at `/var/log/galaxy_api_access.log` that logs all user actions made to the platform, including their username and IP address  | `False`
 |`upgrade_ansible_with_tower`|When installing {ControllerName} make sure Ansible is also up to date|`False`
 |`create_preload_data`|When installing Tower also create the Demo Org, project, credential, Job Template, etc.|`True`
 |`bundle_install_folder`|When installing from a bundle where to put the bundled repos|`var/lib/tower-bundle`

--- a/downstream/titles/aap-installation-guide/docinfo.xml
+++ b/downstream/titles/aap-installation-guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Installation Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.0</productnumber>
+<productnumber>2.1</productnumber>
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for Red Hat Ansible Automation Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>


### PR DESCRIPTION
This PR address the work as outlined in Epic [AAP-2329](https://issues.redhat.com/browse/AAP-2329), which encompasses several requests:

- Write content that guides content creators to get started with AAP after installing AAP 2.1 ([AAP-2319](https://issues.redhat.com/browse/AAP-2319))
- Write content that guides platform administrators to get started with AAP after installing AAP 2.1 ([AAP-2381](https://issues.redhat.com/browse/AAP-2381))
- Write content explaining the benefits of Mesh, linking to existing Mesh guide ([AAP-2330](https://issues.redhat.com/browse/AAP-2330))

In the preview below, I added sections after each installation scenario (sections 2.1.8, 2.2.8, etc.) so that users, after a successful install, will read a brief conceptual material about _what_ the new features are, _why_ it is relevant to them, and _how_ to get started using them. 