### PR TITLE
Add an AAP version attribute

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -6,6 +6,7 @@
 :AAPCentralAuth: Ansible Automation Platform Central Authentication
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
+:PlatformVers: 2.1
 
 // AAP on Clouds
 :AAPonAzureName: Red Hat Ansible Automation Platform on Microsoft Azure


### PR DESCRIPTION
Adds an attribute called {PlatformVers} that writers can use to always link to the latest version of AAP. 