### PR TITLE
AAP-3018 Specify subdirectory in server URL for PAH (#296)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -45,7 +45,8 @@
 // Automation hub
 :HubNameStart: Automation hub
 :HubName: automation hub
-:HubNameStart: Automation hub
+:PrivateHubNameStart: Private automation hub
+:PrivateHubName: private automation hub
 :PrivateCollections: Ansible private automation hub collection management
 :EEmanagement: Ansible private automation hub EE management
 :HubDatabase: Ansible private automation hub database

--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server.adoc
@@ -1,11 +1,11 @@
 [id="proc-configure-automation-hub-server"]
-= Configuring Red Hat Automation Hub as the primary source for content
+= Configuring Red Hat {HubName} as the primary source for content
 
-You can define Red Hat Automation Hub as the default source for content in the `ansible.cfg` configuration file.
+You can define Red Hat {HubName} as the default source for content in the `ansible.cfg` configuration file.
 
 .Prerequisites
 
-* Obtain the API token for the Automation Hub server. See Creating the Automation Hub API token for more information.
+* Obtain the API token for the {HubName} server. See Creating the {HubName} API token for more information.
 
 .Procedure
 
@@ -16,11 +16,16 @@ You can define Red Hat Automation Hub as the default source for content in the `
 [galaxy_server.<server_name>]
 -----
 
-. Set the `url` option if necessary. The community Ansible Galaxy does not require an `auth_url`.
-. Set the `auth_url` option for each server name.
-. Set the API token for the Automation Hub server.
+. Set the `url` option for each server name. You must include the `api/galaxy/` subdirectory in the server URL:
++
+[subs="+quotes"]
+-----
+https://__<server_fully_qualified_domain_name>__/api/galaxy/
+-----
+. Set the `auth_url` option if necessary. The community Ansible Galaxy does not require an `auth_url`.
+. Set the API token for the {HubName} server.
 
-The following `ansible.cfg` example shows how to configure multiple servers in prioritized order, with Automation Hub configured as your primary source and an Ansible Galaxy server as a secondary source:
+The following `ansible.cfg` example shows how to configure multiple servers in prioritized order, with {HubName} configured as your primary source and an Ansible Galaxy server as a secondary source:
 
 .ansible.cfg
 -----
@@ -28,14 +33,17 @@ The following `ansible.cfg` example shows how to configure multiple servers in p
 server_list = automation_hub, my_org_hub
 
 [galaxy_server.automation_hub]
-url=https://cloud.redhat.com/api/automation-hub/ <1>
+url=https://cloud.redhat.com/api/automation-hub/api/galaxy/ <1> <2>
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 
 token=my_ah_token
 
 [galaxy_server.my_org_hub]
-url=https://automation.my_org/
+url=https://automation.my_org/api/galaxy/ <3>
 username=my_user
 password=my_pass
 -----
 <1> A trailing slash */* must follow the server URL.
+<2> Include the `/api/galaxy/` subdirectory in the Galaxy server URL.
+<3> Include the `/api/galaxy/` subdirectory in the {HubName} server URL.
+

--- a/downstream/modules/automation-hub/proc-create-api-token.adoc
+++ b/downstream/modules/automation-hub/proc-create-api-token.adoc
@@ -1,15 +1,15 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-create-api-token"]
-= Creating the Red Hat Automation Hub API token
+= Creating the Red Hat {HubName} API token
 
-Before you can interact with Automation Hub by uploading or downloading collections, you need to create an API token. The Automation Hub API token authenticates your `ansible-galaxy` client to the Red Hat Automation Hub server.
+Before you can interact with {HubName} by uploading or downloading collections, you need to create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.
 
-You can create an API token using Automation Hub *Token management*.
+You can create an API token using {HubName} *Token management*.
 
 .Prerequisites
 
-* Valid subscription credentials for Red Hat Ansible Automation Platform.
+* Valid subscription credentials for {PlatformName}.
 
 .Procedure
 

--- a/downstream/titles/hub/getting-started/docinfo.xml
+++ b/downstream/titles/hub/getting-started/docinfo.xml
@@ -1,12 +1,7 @@
 <title>Getting started with automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<<<<<<< HEAD
 <productnumber>2.1</productnumber>
 <subtitle>Configuring Red Hat Automation Hub as your default server for Ansible collections content</subtitle>
-=======
-<productnumber>2.0-ea</productnumber>
-<subtitle>Configuring Red Hat automation hub as your default server for Ansible collections content</subtitle>
->>>>>>> 115725b... AAP-3018 Specify subdirectory in server URL for PAH (#296)
 <abstract>
     <para>This guide walks you through the initial steps required to use Red Hat automation hub as the default source for certified Ansible collections content.</para>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/getting-started/docinfo.xml
+++ b/downstream/titles/hub/getting-started/docinfo.xml
@@ -1,12 +1,16 @@
 <title>Getting started with automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
+<<<<<<< HEAD
 <productnumber>2.1</productnumber>
 <subtitle>Configuring Red Hat Automation Hub as your default server for Ansible collections content</subtitle>
+=======
+<productnumber>2.0-ea</productnumber>
+<subtitle>Configuring Red Hat automation hub as your default server for Ansible collections content</subtitle>
+>>>>>>> 115725b... AAP-3018 Specify subdirectory in server URL for PAH (#296)
 <abstract>
-    <para>This guide walks you through the initial steps required to use Red Hat Automation Hub as the default source for certified Ansible collections content.</para>
+    <para>This guide walks you through the initial steps required to use Red Hat automation hub as the default source for certified Ansible collections content.</para>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
     <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>
-</abstract>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/hub/getting-started/master.adoc
+++ b/downstream/titles/hub/getting-started/master.adoc
@@ -1,19 +1,27 @@
-= Getting started with automation hub
 :imagesdir: images
+:numbered:
+:toclevels: 1
+
+:experimental:
 // :numbered:
 
-Red Hat Ansible Automation Hub provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
+include::attributes/attributes.adoc[]
 
-The Ansible Galaxy client, `ansible-galaxy`, manages roles and collections from the command line. To ensure that the `ansible-galaxy` client uses certified, supported Ansible collections whenever possible, you should update your `ansible.cfg` file to use Red Hat Automation Hub as your primary source of Ansible collections.
+// Book Title
+= Getting started with {HubName}
 
-This guide walks you through the steps required to configure your `ansible.cfg` file to use Red Hat Automation Hub as the default source for certified Ansible collections content.
+Red Hat Ansible {HubName} provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
+
+The Ansible Galaxy client, `ansible-galaxy`, manages roles and collections from the command line. To ensure that the `ansible-galaxy` client uses certified, supported Ansible collections whenever possible, you should update your `ansible.cfg` file to use Red Hat {HubName} as your primary source of Ansible collections.
+
+This guide walks you through the steps required to configure your `ansible.cfg` file to use Red Hat {HubName} as the default source for certified Ansible collections content.
 
 include::automation-hub/proc-create-api-token.adoc[leveloffset=+1]
 
-The API token is now available to use to configure Automation Hub as your default collections server or when uploading collections using the `ansible-galaxy` command line tool.
+The API token is now available to use to configure {HubName} as your default collections server or when uploading collections using the `ansible-galaxy` command line tool.
 
 include::automation-hub/proc-configure-automation-hub-server.adoc[leveloffset=+1]
 
-You have now configured Automation Hub as your default server and can proceed to download and install supported collections.
+You have now configured {HubName} as your default server and can proceed to download and install supported collections.
 
 For more information on server list configuration options and using Ansible Galaxy as an Ansible content source, see the https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[Ansible Galaxy User Guide].


### PR DESCRIPTION
Backport [PR#296](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/296)

Jira: [AAP-3018](https://issues.redhat.com/browse/AAP-3018)

Affects the following title:
/hub/getting-started/

Fix the Private Automation Hub server URL in ansible.cfg: Include the /api/galaxy/ subdirectory.
Using the URL from the current docs causes an error.