### PR TITLE
AAP-3112 Incorrect variable name for view-only Hub (#301)

### DIFF
--- a/downstream/assemblies/hub/assembly-view-only-access.adoc
+++ b/downstream/assemblies/hub/assembly-view-only-access.adoc
@@ -1,6 +1,6 @@
 [id="assembly-view-only-access"]
 = Enabling view-only access for your private automation hub
 
-By enabling view-only access, you can grant access for users to view collections or namespaces on your private automation hub without the need for them to log in. View-only access allows you to share content with unauthorized users while restricting their ability to download and view source code or otherwise change anything on your private automation hub.
+By enabling view-only access, you can grant access for users to view collections or namespaces on your private automation hub without the need for them to log in. View-only access allows you to share content with unauthorized users while restricting their ability to only view or download source code, without permissions to edit anything on your private automation hub.
 
 include::automation-hub/con-enable-view-only.adoc[leveloffset=+1]

--- a/downstream/modules/automation-hub/con-enable-view-only.adoc
+++ b/downstream/modules/automation-hub/con-enable-view-only.adoc
@@ -6,8 +6,8 @@
 
 Enable view-only access for your private {HubName} by editing the inventory file found on your {PlatformName} installer.
 
-* If you are installing a new instance of {PlatformNameShort}, follow these steps to add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to your `inventory` file along with your other installation configurations:
-* If you are updating an existing {PlatformNameShort} installation to include view-only access, add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to your `inventory` file then run the `setup.sh` script to apply the updates:
+* If you are installing a new instance of {PlatformNameShort}, follow these steps to add the `automationhub_enable_unauthenticated_collection_access` and `automationhub_enable_unauthenticated_collection_download` parameters to your `inventory` file along with your other installation configurations:
+* If you are updating an existing {PlatformNameShort} installation to include view-only access, add the `automationhub_enable_unauthenticated_collection_access` and `automationhub_enable_unauthenticated_collection_download` parameters to your `inventory` file then run the `setup.sh` script to apply the updates:
 
 .Procedure
 . Navigate to the installer.
@@ -24,13 +24,16 @@ $ cd ansible-automation-platform-setup-<latest-version>
 -----
 +
 . Open the `inventory` file with a text editor.
-. Add the `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` parameter to the inventory file and set to `TRUE`, following the example below:
+. Add the `automationhub_enable_unauthenticated_collection_access` and `automationhub_enable_unauthenticated_collection_download` parameters to the inventory file and set both to `True`, following the example below:
 +
 ----
 [all:vars]
 
-GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True
+automationhub_enable_unauthenticated_collection_access = True <1>
+automationhub_enable_unauthenticated_collection_download = True <2>
 ----
+<1> Allows unauthorized users to view collections
+<2> Allows unathorized users to download collections
 . Run the `setup.sh` script. The installer will now enable view-only access to your {HubName}.
 
 .Verification


### PR DESCRIPTION
Backport #301 

Jira: https://issues.redhat.com/browse/AAP-3112

Updated the variable for enabling view-only access in automation hub during AAP install.
Changed GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS to automationhub_enable_unauthenticated_collection_access

Preview (VPN required): http://file.rdu.redhat.com/kevchin/view-only-update/build/tmp/en-US/html-single/#assembly-view-only-access