### PR TITLE
AAP-2423: Add repo info for installing ansible-builder (#299)

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -2,12 +2,22 @@
 
 = Installing {Builder}
 
-You can install {Builder} using Red Hat Subscription Management to register and attach to your {PlatformName} subscription. In your terminal, run the following command:
+You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-attaching-subscriptions_planning/[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
+
+NOTE: You must have valid subscriptions attached on the host before installing `ansible-builder`.
+
+.Procedure
+
+. In your terminal, run the following command:
++
 ----
 $ dnf install ansible-builder
 ----
-
++
 You can also install {Builder} from the https://pypi.org/project/ansible-builder/[Python Package Index (PyPI)]. To install with this setup, run:
++
 ----
 $ pip install ansible-builder
 ----
++
+NOTE: If you encounter issues while installing from PyPI, please install and reproduce on a supported installation.


### PR DESCRIPTION
[AAP-2423](https://issues.redhat.com/browse/AAP-2423): Revised instructions to be more accurate.

Local build on backport branch reflected changes in [PR#99](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/299)

