### PR TITLE
Backport PR305 to 1.2

### DIFF
--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -8,11 +8,7 @@ By default, your local Automation Hub `community` repository directs to `https:/
 
 .Prerequisites
 
-<<<<<<< HEAD
-* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/managing-user-access/index[Managing user access in Automation Hub] for more information on permissions.
-=======
 * You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
->>>>>>> d31e9e7... update hub link for 1.2 (#234)
 * You have a `requirements.yml` file that identifies those collections to sync from Ansible Galaxy. See example below.
 
 .Requirements.yml example

--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -1,9 +1,10 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-set-community-remote"]
-= Configuring the community remote repository and syncing Ansible Galaxy collections.
+= Configuring the community remote repository and syncing Ansible Galaxy collections
 
-You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local Automation Hub. By default, your local Automation Hub `community` repository directs to `https://galaxy.ansible.com/api/v2/collections`.
+You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local Automation Hub.
+By default, your local Automation Hub `community` repository directs to `https://galaxy.ansible.com/api/`.
 
 .Prerequisites
 


### PR DESCRIPTION
Backport https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/305 to 1.2

- Jira: [AAP-2082](https://issues.redhat.com/browse/AAP-2082): Modify community remote URL
- [Link to original doc on portal](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/assembly-creating-tokens-in-automation-hub#proc-set-community-remote)

Affects `titles/hub/configuring-private-hub-rh-certified`.