### PR TITLE
AAP-2082 Modify community remote URL (#305)

### DIFF
--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -1,9 +1,10 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-set-community-remote"]
-= Configuring the community remote repository and syncing Ansible Galaxy collections.
+= Configuring the community remote repository and syncing Ansible Galaxy collections
 
-You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local Automation Hub. By default, your local Automation Hub `community` repository directs to `https://galaxy.ansible.com/api/v2/collections`.
+You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local Automation Hub.
+By default, your local Automation Hub `community` repository directs to `https://galaxy.ansible.com/api/`.
 
 .Prerequisites
 


### PR DESCRIPTION
Backport https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/305 to 2.0-ea

Jira: [AAP-2082](https://issues.redhat.com/browse/AAP-2082)
Modify community remote URL

Affects `titles/hub/configuring-private-hub-rh-certified`:
[_Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub_](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.0-ea/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index)