### PR TITLE
Migrating playbooks and roles to Core 2.12

### DIFF
--- a/downstream/assemblies/platform/assembly-content-migration.adoc
+++ b/downstream/assemblies/platform/assembly-content-migration.adoc
@@ -1,0 +1,27 @@
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="content-migration"]
+= Ansible content migration
+
+
+:context: content-migration
+
+
+[role="_abstract"]
+
+If you are migrating from an `ansible-core` version to `ansible-core` 2.12+, consider reviewing link:https://docs.ansible.com/ansible-core/2.12/porting_guides/core_porting_guides.html[Ansible core Porting Guides] to familiarize yourself with changes and updates between each version. When reviewing the Ansible core porting guides, ensure that you select the latest version of `ansible-core` or `devel`, which is located at the top left column of the guide.
+
+For a list of fully supported and certified Ansible Content Collections, see link:https://console.redhat.com/ansible/automation-hub[Ansible Automation hub] on link:https://console.redhat.com/[console.redhat.com].
+
+
+include::platform/proc-migrate-playbooks-roles.adoc[leveloffset=+1]
+
+
+
+
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
+++ b/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
@@ -1,0 +1,34 @@
+
+[id="proc-migrate-playbooks-roles_{context}"]
+
+
+= Migrating your Ansible playbooks and roles to Core 2.12
+
+[role="_abstract"]
+
+When you are migrating from non collection-based content to collection-based content, you should use Fully Qualified Collection Names (FQCN) when using Ansible conentt collections in playbooks and roles. If the collection name is not defined, you may encounter behavioral changes within your environment.
+
+Example playbook with FQCN:
+
+----
+- name: get some info
+  amazon.aws.ec2_vpc_net_info:
+    region: "{{ec2_region}}"
+  register: all_the_info
+  delegate_to: localhost
+  run_once: true
+----
+
+If you are using ansible-core modules and are not calling a module from a different Collection, you should use the FQCN. In this case, you will use `ansible.builtin.copy` instead of `copy`.
+
+Example module with FQCN:
+
+----
+- name: copy file with owner and permissions
+  ansible.builtin.copy:
+  src: /srv/myfiles/foo.conf
+  dest: /etc/foo.conf
+  owner: foo
+  group: foo
+  mode: '0644'
+----

--- a/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
+++ b/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
@@ -6,7 +6,7 @@
 
 [role="_abstract"]
 
-When you are migrating from non collection-based content to collection-based content, you should use Fully Qualified Collection Names (FQCN) when using Ansible content collections in playbooks and roles. If the collection name is not defined, you may encounter behavioral changes within your environment.
+When you are migrating from non collection-based content to collection-based content, you should use the Fully Qualified Collection Names (FQCN) in playbooks and roles to avoid unexpected behavior.
 
 Example playbook with FQCN:
 

--- a/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
+++ b/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
@@ -19,7 +19,7 @@ Example playbook with FQCN:
   run_once: true
 ----
 
-If you are using ansible-core modules and are not calling a module from a different Collection, you should use the FQCN. In this case, you will use `ansible.builtin.copy` instead of `copy`.
+If you are using ansible-core modules and are not calling a module from a different Collection, you should use the FQCN `ansible.builtin.copy`.
 
 Example module with FQCN:
 

--- a/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
+++ b/downstream/modules/platform/proc-migrate-playbooks-roles.adoc
@@ -6,7 +6,7 @@
 
 [role="_abstract"]
 
-When you are migrating from non collection-based content to collection-based content, you should use Fully Qualified Collection Names (FQCN) when using Ansible conentt collections in playbooks and roles. If the collection name is not defined, you may encounter behavioral changes within your environment.
+When you are migrating from non collection-based content to collection-based content, you should use Fully Qualified Collection Names (FQCN) when using Ansible content collections in playbooks and roles. If the collection name is not defined, you may encounter behavioral changes within your environment.
 
 Example playbook with FQCN:
 

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -11,3 +11,4 @@ include::attributes/attributes.adoc[]
 
 include::platform/assembly-upgrading-to-aap.adoc[leveloffset=+1]
 include::platform/assembly-migrate-legacy-venv-to-ee.adoc[leveloffset=+1]
+include::platform/assembly-content-migration.adoc[leveloffset=+1]


### PR DESCRIPTION
**Jira**: Epic [AAP-2346](https://issues.redhat.com/browse/AAP-2346)
This epic has 2 child issues [AAP-2347](https://issues.redhat.com/browse/AAP-2347) and [AAP-2348](https://issues.redhat.com/browse/AAP-2348), which is addressed in this PR - how to migrate playbooks and roles to core 2.12. 

Draft of content, along with comments and revisions from SMEs included in [google doc](https://docs.google.com/document/d/1s4YZh0L6F7lMCIxCD6sWfuCIgPOFEVadFmsx4ahKseA/edit?userstoinvite=gnalawad%40redhat.com&actionButton=1#heading=h.2ntpwbtc7i5p). 

**Preview link**: [Ansible content migration](http://file.rdu.redhat.com/~lmodemal/aap-upgrade-220905/master.html)