### PR TITLE
Add writers who are members of the org to CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 ## PRs to the AAP repo will send review requests to the following users:
-* @ariordan-redhat @dcdacosta @ianf77 @jself-sudoku @lmalivert @oraNod @rogrange @TarikFD
+* @ariordan-redhat @lmalivert @rogrange @TarikFD

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+## PRs to the AAP repo will send review requests to the following users:
+* @ariordan-redhat @dcdacosta @ianf77 @jself-sudoku @lmalivert @oraNod @rogrange @TarikFD


### PR DESCRIPTION
When you create a PR, you must manually add reviewers.

This PR creates a CODEOWNERS file in the base directory of this repo.
The PR target branch is `temp-codeowners`.
If merged, then new PRs to this branch should add the team to the default list of reviewers.
