### PR TITLE
Add AAP docs team members as default reviewers for PRs to main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+## PRs to the AAP repo will send review requests to the following users:
+* @ariordan-redhat @dcdacosta @ianf77 @jself-sudoku @lmalivert @oraNod @rogrange @TarikFD


### PR DESCRIPTION
**Problem:**
When you create a PR to the AAP repo, you have to select reviewers manually. There isn't a way to have the AAP docs team members at the top of the list.

**Solution:**
This PR creates a file called CODEOWNERS in the root directory of the repo.
The file contains a list of GitHub IDs for the writers on the team.
Once merged to `main`, these people will be selected by default in the **Reviewers** list for subsequent PRs to  the `main` branch.

You can add more people as reviewers in your PR.
You can remove people from your PR review list by clicking **Reviewers** and de-selecting them:

![image](https://user-images.githubusercontent.com/44700011/171876700-be6eb28b-538c-4200-89e0-0aeeedeaf9df.png)

I have added the following team members in this PR.

- @ariordan-redhat
- @dcdacosta 
- @ianf77 
- @jself-sudoku
- @lmalivert 
- @oraNod 
- @rogrange 
- @TarikFD

Please approve this PR if you're happy to be added to the list of default reviewers.

GitHub documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners