### PR TITLE
[WIP] AAP-585 Importing CA certificates for automation mesh

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
@@ -3,20 +3,24 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-automation-mesh"]
-= Installing {AutomationMesh}
+= Installing and configuring {AutomationMesh}
 
 
 :context: installing-automation-mesh
 
 
 [role="_abstract"]
-You can install an {AutomationMesh} using the instructions found in the {PlatformName} Installation Guide. {PlatformNameShort} installations are separated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment. Review the systems requirements for each component and {AutomationMesh} node type before proceeding with your installation.
+You can install {AutomationMesh} using the instructions found in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]. {PlatformNameShort} installations are separated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment. Review the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements] for each component and {AutomationMesh} node type before proceeding with your installation.
+
+The following sections provide options for you to configure your {AutomationMesh}, including an option to import your own CA certificate.
+
+include::platform/proc-import-mesh-ca.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
-* See the {PlatformName} Reference Architecture for additional information before installing.
+* Review the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements] for additional information before installing.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-installing-automation-mesh.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-You can install {AutomationMesh} using the instructions found in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]. {PlatformNameShort} installations are separated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment. Review the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements] for each component and {AutomationMesh} node type before proceeding with your installation.
+You can install {AutomationMesh} using the instructions found in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]. {PlatformNameShort} installations are separated into unique scenarios based on the components deployed. You can incorporate {AutomationMesh} designs based on which platform components you intend to deploy in your environment.
 
 The following sections provide options for you to configure your {AutomationMesh}, including an option to import your own CA certificate.
 

--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -12,9 +12,14 @@ To import your own CA certificate, it must meet the following requirements:
 * asdasd
 
 .Procedure
-* In the `inventory` file, add the following variables and specify a path to both the certificate file (`.crt`) and the private RSA key (`.key`), following the example below:
+
+. Open the `inventory` file for editing.
+. Add the `mesh_ca_keyfile` variable and specify the full path to the CA certificate file (.crt).
+. Add the `mesh_ca_certfile` variable and specify the full path to the private RSA key (.key).
+. Save the changes to the inventory file.
+
+.Example
 [subs="+quotes"]
-+
 ----
 [all:vars]
 mesh_ca_keyfile=/tmp/__<mesh_CA>__.key

--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -1,15 +1,10 @@
 [id="proc-import-mesh-ca_{context}"]
 
 = Importing a Certificate Authority (CA) certificate
+
 A Certificate Authority (CA) is used to certify and sign execution nodes in an {AutomationMesh} environment. Users who wish to provide their own CA can do so by specifying the path to the certificate and the private RSA key file in the `inventory` file of their {PlatformName} installer.
 
 NOTE: Users are not required to have a CA prior to their {AutomationMesh} installation. Users without a CA can proceed with their {PlatformNameShort} installation where the installer will generate a CA for the user using OpenSSL.
-
-.Prerequisites
-To import your own CA certificate, it must meet the following requirements:
-
-* asdasd
-* asdasd
 
 .Procedure
 
@@ -25,6 +20,8 @@ To import your own CA certificate, it must meet the following requirements:
 mesh_ca_keyfile=/tmp/__<mesh_CA>__.key
 mesh_ca_certfile=/tmp/__<mesh_CA>__.crt
 ----
+
+With the CA files added to the inventory file, run the installer to apply the CA. This process copies and stores the CA on each control node on your network. By default, the certfile and keyfile will be added to `/etc/receptor/tls/ca/`.
 
 .Optional: Assigning CA certificates to individual nodes
 Users can also assign CA certificates to individual nodes by adding the `mesh_node_certfile=` and `mesh_node_keyfile=` fields to each node, following the example below:

--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -1,0 +1,29 @@
+[id="proc-import-mesh-ca_{context}"]
+
+= Importing a Certificate Authority (CA) certificate
+A Certificate Authority (CA) is used to certify and sign execution nodes in an {AutomationMesh} environment. Users who wish to provide their own CA can do so by specifying the path to the certificate and the private RSA key file in the `inventory` file of their {PlatformName} installer.
+
+NOTE: Users are not required to have a CA prior to their {AutomationMesh} installation. Users without a CA can proceed with their {PlatformNameShort} installation where the installer will generate a CA for the user using OpenSSL.
+
+.Prerequisites
+To import your own CA certificate, it must meet the following requirements:
+
+* asdasd
+* asdasd
+
+.Procedure
+* In the `inventory` file, add the following variables and specify a path to both the certificate file (`.crt`) and the private RSA key (`.key`), following the example below:
+[subs="+quotes"]
++
+----
+[all:vars]
+mesh_ca_keyfile=/tmp/__<mesh_CA>__.key
+mesh_ca_certfile=/tmp/__<mesh_CA>__.crt
+----
+
+.Optional: Assigning CA certificates to individual nodes
+Users can also assign CA certificates to individual nodes by adding the `mesh_node_certfile=` and `mesh_node_keyfile=` fields to each node, following the example below:
+----
+[automationcontroller]
+121-addr.tatu.home ansible_host=192.168.111.121  node_type=hybrid mesh_node_certfile=/tmp/192.168.111.121.crt mesh_node_keyfile=/tmp/192.168.111.121.key
+----

--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -2,7 +2,7 @@
 
 = Importing a Certificate Authority (CA) certificate
 
-A Certificate Authority (CA) is used to certify and sign execution nodes in an {AutomationMesh} environment. Users who wish to provide their own CA can do so by specifying the path to the certificate and the private RSA key file in the `inventory` file of their {PlatformName} installer.
+A Certificate Authority (CA) is used to verify and sign individual node certificates in an {AutomationMesh} environment. Users who wish to provide their own CA can do so by specifying the path to the certificate and the private RSA key file in the `inventory` file of their {PlatformName} installer.
 
 NOTE: Users are not required to have a CA prior to their {AutomationMesh} installation. Users without a CA can proceed with their {PlatformNameShort} installation where the installer will generate a CA for the user using OpenSSL.
 
@@ -21,11 +21,4 @@ mesh_ca_keyfile=/tmp/__<mesh_CA>__.key
 mesh_ca_certfile=/tmp/__<mesh_CA>__.crt
 ----
 
-With the CA files added to the inventory file, run the installer to apply the CA. This process copies and stores the CA on each control node on your network. By default, the certfile and keyfile will be added to `/etc/receptor/tls/ca/`.
-
-.Optional: Assigning CA certificates to individual nodes
-Users can also assign CA certificates to individual nodes by adding the `mesh_node_certfile=` and `mesh_node_keyfile=` fields to each node, following the example below:
-----
-[automationcontroller]
-121-addr.tatu.home ansible_host=192.168.111.121  node_type=hybrid mesh_node_certfile=/tmp/192.168.111.121.crt mesh_node_keyfile=/tmp/192.168.111.121.key
-----
+With the CA files added to the inventory file, run the installer to apply the CA. This process copies the CA on each control and execution node on your mesh network. By default, the certfile and keyfile will be added to `/etc/receptor/tls/ca/`.

--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -4,7 +4,7 @@
 
 A Certificate Authority (CA) is used to verify and sign individual node certificates in an {AutomationMesh} environment. Users who wish to provide their own CA can do so by specifying the path to the certificate and the private RSA key file in the `inventory` file of their {PlatformName} installer.
 
-NOTE: Users are not required to have a CA prior to their {AutomationMesh} installation. Users without a CA can proceed with their {PlatformNameShort} installation where the installer will generate a CA for the user using OpenSSL.
+NOTE: Users are not required to have a CA prior to their {AutomationMesh} installation. Users without a CA can proceed with their {PlatformNameShort} installation where the installer will generate a CA for the user.
 
 .Procedure
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-585

Documenting the procedure to import CA files to the inventory file during an installation to support a user's automation mesh certification. Adding a mention to these inventory file fields to the installation guide, but also adding more information on the automation mesh guide for the requirements and full instructions.

Preview (VPN required): http://file.rdu.redhat.com/kevchin/import-mesh-ca4/tmp/en-US/html-single/#proc-import-mesh-ca_installing-automation-mesh