### PR TITLE
Replace all Gb with GB for correctness and per style guide.

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator-local-db.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator-local-db.adoc
@@ -15,7 +15,7 @@ ifdef::context[:parent-context: {context}]
 
 [NOTE]
 ====
-Default installation settings include storage of 50GB and `ReadWriteMany` access.
+Default installation settings include storage of 50 GB and `ReadWriteMany` access.
 ====
 
 

--- a/downstream/modules/platform/ref-hub-system-requirements.adoc
+++ b/downstream/modules/platform/ref-hub-system-requirements.adoc
@@ -18,11 +18,11 @@ h| OS | Red Hat Enterprise Linux 7.7 or later 64-bit (x86) or 8.2 or later 64-bi
 
 h| Ansible | version 2.9 required
 
-h| RAM | 4Gb minimum
+h| RAM | 4 GB minimum
 
 h| CPUs | 2 minimum
 
-h| Disk | 20Gb dedicated hard disk space
+h| Disk | 20 GB dedicated hard disk space
 
 Dependent on size of collections stored
 

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -42,7 +42,7 @@ h| Ansible | version 2.11 required | If Ansible is not already present on the sy
 
 | Execution nodes| Required | Notes
 
-h| RAM | 16Gb  |
+h| RAM | 16 GB  |
 
 
 h| CPUs | 4|
@@ -53,7 +53,7 @@ h| CPUs | 4|
 
 |Control nodes | Required | Notes
 
-h| RAM | 16Gb  |
+h| RAM | 16 GB  |
 
 
 h| CPUs | 4|
@@ -64,7 +64,7 @@ h| CPUs | 4|
 
 | Hybrid nodes| Required | Notes
 
-h| RAM | 16Gb  |
+h| RAM | 16 GB  |
 
 
 h| CPUs | 4|
@@ -74,20 +74,20 @@ h| CPUs | 4|
 
 |Hop nodes| Required | Notes
 
-h| RAM | 16Gb  |
+h| RAM | 16 GB  |
 
 
 h| CPUs | 4|
 
 * Serves to route traffic from one part of the Automation Mesh to another (for example, could be a bastion host into another network). RAM could affect throughput, CPU activity is low. Network bandwidth and latency generally a more important factor than either RAM/CPU.
 
-h| Disk: service node | 40Gb dedicated hard disk space |
+h| Disk: service node | 40 GB dedicated hard disk space |
 
 * *{ControllerName}*: dedicate a minimum of 20 GB to `/var/` for file and working directory storage
 * Storage volume should be rated for a minimum baseline of 1500 IOPS.
 * Projects are stored on control and hybrid, and for the duration of jobs, also on execution nodes. If the cluster has many large projects, consider having twice the GB in /var/lib/awx/projects, to avoid disk space errors.
 
-h| Disk: database node| 20Gb dedicated hard disk space |
+h| Disk: database node| 20 GB dedicated hard disk space |
 
 * 150 GB+ recommended
 * Storage volume should be rated for a high baseline IOPS (1500 or more).
@@ -106,7 +106,7 @@ h| Database | PostgreSQL version 12 |
 |===
 | | Required | Notes
 
-h| RAM | 8Gb minimum |
+h| RAM | 8 GB minimum |
 
 * 8 GB RAM (minimum and recommended for Vagrant trial installations)
 * 8 GB RAM (minimum for external standalone PostgreSQL databases)
@@ -116,11 +116,11 @@ h| CPUs | 2 minimum |
 
 * For capacity based on forks in your configuration, see additional resources
 
-h| Disk: service node | 40Gb dedicated hard disk space |
+h| Disk: service node | 40 GB dedicated hard disk space |
 
 * Storage volume should be rated for a minimum baseline of 1500 IOPS.
 
-h| Disk: database node| 20Gb dedicated hard disk space |
+h| Disk: database node| 20 GB dedicated hard disk space |
 
 * 150 GB+ recommended
 * Storage volume should be rated for a high baseline IOPS (1500 or more).
@@ -147,7 +147,7 @@ For example, a playbook run every hour (24 times a day) across 250, hosts, with 
 
 .Additional notes for {PlatformName} requirements
 
-* Actual RAM requirements vary based on how many hosts {ControllerName} will manage simultaneously (which is controlled by the `forks` parameter in the job template or the system `ansible.cfg` file). To avoid possible resource conflicts, Ansible recommends 1 GB of memory per 10 forks + 2GB reservation for {ControllerName}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/jobs.html#at-capacity-determination-and-job-impact[Automation controller Capacity Determination and Job Impact] for further details. If `forks` is set to 400, 42 GB of memory is recommended.
+* Actual RAM requirements vary based on how many hosts {ControllerName} will manage simultaneously (which is controlled by the `forks` parameter in the job template or the system `ansible.cfg` file). To avoid possible resource conflicts, Ansible recommends 1 GB of memory per 10 forks + 2 GB reservation for {ControllerName}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/jobs.html#at-capacity-determination-and-job-impact[Automation controller Capacity Determination and Job Impact] for further details. If `forks` is set to 400, 42 GB of memory is recommended.
 * A larger number of hosts can of course be addressed, though if the fork number is less than the total host count, more passes across the hosts are required. These RAM limitations are avoided when using rolling updates or when using the provisioning callback system built into {ControllerName}, where each system requesting configuration enters a queue and is processed as quickly as possible; or in cases where {ControllerName} is producing or deploying images such as AMIs. All of these are great approaches to managing larger environments. For further questions, please contact Ansible support via the Red Hat Customer portal at https://access.redhat.com/.
 * The requirements for systems managed by {PlatformNameShort} are the same as for Ansible. See link:https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html[Getting Started] in the Ansible _User Guide_.
 

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -21,11 +21,11 @@ h| OS | Red Hat Enterprise Linux 7.7 or later 64-bit (x86) or 8.2 or later 64-bi
 
 h| Ansible | version 2.9 required
 
-h| RAM | 4Gb minimum
+h| RAM | 4 GB minimum
 
 h| CPUs | 2 minimum
 
-h| Disk | 20Gb dedicated hard disk space
+h| Disk | 20 GB dedicated hard disk space
 
 Dependent on size of collections stored
 


### PR DESCRIPTION
`Gb` means gigabits and is incorrect here whereas `GB` means gigabytes.

Additionally, there should be a space between the quantity and unit (e.g. `2 GB` not `2GB`).

https://redhat-documentation.github.io/supplementary-style-guide/#gb

Closes #360 
