### PR TITLE
Ignore built master.html files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ html/
 */.DS_Store
 *.zip
 emender/results/*
+downstream/titles/*/master.html
+downstream/titles/*/*/master.html


### PR DESCRIPTION
When you build a book using `asciidoctor`, a `master.html` file is created in the title directory for the book.

Add `master.html` to the `.gitignore` file for the repo so that `master.html` is not included in PRs.