### PR TITLE
[Backport 2.1] AAP-1621 Fixes to HA Hub (#330)

### DIFF
--- a/downstream/modules/automation-hub/con-required-shared-filesystem.adoc
+++ b/downstream/modules/automation-hub/con-required-shared-filesystem.adoc
@@ -5,4 +5,4 @@
 
 = Required shared filesystem
 
-A high availability {HubName} requires you to have a shared file system already set up in your environment. Before you run the {PlatformName} installer, verify that the `/var/lib/pulp` directory exists across your cluster as a result of your shared file system installation. The {PlatformName} installer will return an error if `/var/lib/pulp` is not detected in one of your nodes, causing your HA {HubName} setup to fail.
+A high availability {HubName} requires you to have a shared file system, such as NFS, already installed in your environment. Before you run the {PlatformName} installer, verify that the `/var/lib/pulp` directory exists across your cluster as a result of your shared file system installation. The {PlatformName} installer will return an error if `/var/lib/pulp` is not detected in one of your nodes, causing your HA {HubName} setup to fail.

--- a/downstream/titles/hub/high-availability/master.adoc
+++ b/downstream/titles/hub/high-availability/master.adoc
@@ -6,8 +6,12 @@ include::attributes/attributes.adoc[]
 
 This guide provides an overview of the requirements and procedures for a high availability deployment of your {HubName}.
 
-A high availability (HA) configuration provides a reliable and scalable solution that minimizes downtime for your Ansible automation environment. HA prepares your system for damage mitigation, where a failure in a primary cluster prompts a standby cluster to take over, resulting in no downtime for the customer. To set up a HA deployment of {HubName}, configure the {PlatformName}(AAP) installer based on the requirements detailed in this guide.
+A high availability (HA) configuration increases reliability and scalablility for {HubName} deployments.
 
-Please note that this guide covers deployment of a HA {HubName} application stack only. Other HA components, such as database and file system HA, or setting up DNS load balancing, are out of scope for this guide.
+HA deployments of {HubName} have multiple nodes that concurrently run the same service with a load balancer distributing workload (an "active-active" configuration).
+This configuration eliminates single points of failure to minimize service downtime and allows you to easily add or remove nodes to meet workload demands.
+
+This guide covers deployment of a HA {HubName} application stack only.
+Other HA components, such as database and file system HA, or setting up DNS load balancing, are out of scope for this guide.
 
 include::hub/assembly-deploying-high-availability-hub.adoc[leveloffset=+1]]


### PR DESCRIPTION
Backporting #330 

Conceptual fixes to the high availability docs to :
- Clarify if HA for private automation hub is an active-active or an active-passive setup.
- Clarify if DNS load balancing is implied
- Specify the requirements for a shared filesystem (NFS or otherwise?)

Preview link (VPN required): http://file.rdu.redhat.com/kevchin/ha_hub3/tmp/en-US/html-single/