### PR TITLE
Delete CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-## PRs to the AAP repo will send review requests to the following users:
-* @ariordan-redhat @dcdacosta @ianf77 @jself-sudoku @lmalivert @oraNod @rogrange @TarikFD


### PR DESCRIPTION
 PR #347 was an attempt to populate the list of PR reviewers with a default selection.

It led to confusion: there was no way to deselect members of the default list before an email requesting a review was sent out to everyone.

This PR is an attempt to reduce email noise.
By deleting the CODEOWNERS file from the repo, the **Reviewers** list will not pre-select all AAP docs writers.

We have created a PR review team called `aap-docs-pr-review-group`. So far, Don and Aine are in this team: we want to make sure it works before adding the full team. 
Link to team page: https://github.com/orgs/RedHatInsights/teams/aap-docs-pr-review-group/

If the `CODEOWNERS` file is deleted, then when you create a PR, you can select individual reviewers manually or search for the `aap-docs-pr-review-group` team to select all docs team members. You can also ping the team in a comment. 
To select the team, start typing @aap-docs in a comment or aap-docs in the reviewers list: the full team name will pop up as a suggestion.

![image](https://user-images.githubusercontent.com/44700011/175933492-975d216f-ed51-4c3e-b341-8bdbabfb0dcf.png)

![image](https://user-images.githubusercontent.com/44700011/175933575-13ebc0cf-0fbd-4492-b426-ba771b9a1878.png)

After adding the peer-review team to the **Reviewers** list:

![image](https://user-images.githubusercontent.com/44700011/176153944-ea380417-5e83-4c69-9461-f68389ed4d8e.png)
