### PR TITLE
Backport 2.2-332: Ticket AAP-2007 AAP 2.1 on OCP Pre-Flight Check Documentation (PR 332)

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -26,6 +26,8 @@ You can use these instructions to install the {HubName} operator on {OCP}, speci
 . Navigate to *Operators* > *Installed Operators*.
 . Locate the *Automation hub* entry, then click *Create instance*.
 
+include::platform/con-storage-options-for-operator-installation-on-ocp.adoc[leveloffset=+2]
+include::platform/proc-provision-ocp-storage-with-readwritemany.adoc[leveloffset=+3]
 include::platform/proc-hub-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 

--- a/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
+++ b/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
@@ -1,0 +1,12 @@
+[id="proc-provision-ocp-storage-with-readwritemany_{context}"]
+
+
+= Provisioning OCP storage with `ReadWriteMany` access mode
+
+To ensure successful installation of {OperatorPlatform}, you must provision your storage type for {HubName} initially to `ReadWriteMany` access mode.
+
+.Procedure
+
+. Click link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-nfs-provisioning_persistent-storage-nfs[Provisioning] to update the access mode.
+. In the first step, update the `accessModes` from the default `ReadWriteOnce` to `ReadWriteMany`.
+. Complete the additional steps in this section to create the persistent volume claim.


### PR DESCRIPTION
Backport  PR 332 to 2.2

Backport updates from ticket [AAP-2007](https://issues.redhat.com/browse/AAP-2007) ([PR 332](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/332)