### PR TITLE
AAP-4426 Updated version #s from 2.1 to 2.2

### DIFF
--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -39,7 +39,7 @@ metadata:
   name: ansible-automation-platform
   namespace: ansible-automation-platform
 spec:
-  channel: 'stable-2.1'
+  channel: 'stable-2.2'
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators
@@ -72,7 +72,7 @@ This file creates a `Subscription` object called `_ansible-automation-platform
 It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace.
 +
 To change the Automation controller name from `_example_`, edit the _name_ field in the `kind: AutomationController` section of [filename]`sub.yaml` and replace `_<automation_controller_name>_` with the name you want to use:
-+   
++
 [subs="+quotes"]
 -----
 apiVersion: automationcontroller.ansible.com/v1beta1

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -11,7 +11,10 @@ By default, the {PlatformName} operator automatically creates and configures a m
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
 
-NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12.
+[NOTE]
+====
+{PlatformNameShort} 2.2 supports PostgreSQL 12.
+====
 
 .Procedure
 

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -13,7 +13,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} 2.2 supports PostgreSQL 12.
+{PlatformNameShort} 2.2 supports PostgreSQL 13.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -11,7 +11,10 @@ By default, the {PlatformName} operator automatically creates and configures a m
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.
 
-NOTE: {PlatformNameShort} 2.0 and 2.1 supports PostgreSQL 12.
+[NOTE]
+====
+{PlatformNameShort} 2.0 or later supports PostgreSQL 12.
+====
 
 .Procedure
 

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -13,7 +13,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} 2.0 or later supports PostgreSQL 12.
+{PlatformNameShort} 2.2 supports PostgreSQL 12.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -13,7 +13,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} 2.2 supports PostgreSQL 12.
+{PlatformNameShort} 2.2 supports PostgreSQL 13.
 ====
 
 .Procedure


### PR DESCRIPTION
Includes the following specified changes from ticket AAP-4426:

- Overall - Change any reference to Ansible Automation Platform 2.1 to 2.2

- 3.3. Configuring an external database for automation controller on Red Hat Ansible Automation Platform operator

- Note: Change the note to say Ansible Automation Platform 2.2 supports PostgreSQL 13
4.4. Configuring an external database for automation hub on Red Hat Ansible Automation Platform operator

- Note: Change the note to say Ansible Automation Platform 2.2 supports PostgreSQL 13
5.2. Subscribing a namespace to an operator using the OpenShift Container Platform CLI

- In the yaml code, change "stable-2.1" to "stable-2.2"