### PR TITLE
Added Python requirement to AAP docs

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -23,6 +23,8 @@ h| Ansible | version 2.9 required |
 
 h| RAM | 4Gb minimum |
 
+h| Python | 3.8 or later |
+
 * 4 GB RAM (minimum and recommended for Vagrant trial installations)
 * 4 GB RAM (minimum for external standalone PostgreSQL databases)
 * For capacity based on forks in your configuration, see additional resources

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -21,9 +21,9 @@ h| OS | Red Hat Enterprise Linux 8.3 or later 64-bit (x86) |
 
 h| Ansible | version 2.9 required |
 
-h| RAM | 4Gb minimum |
-
 h| Python | 3.8 or later |
+
+h| RAM | 4Gb minimum |
 
 * 4 GB RAM (minimum and recommended for Vagrant trial installations)
 * 4 GB RAM (minimum for external standalone PostgreSQL databases)


### PR DESCRIPTION
Added requirement for Python 3.8 or later to Installation guide.
The Upgrade/Miration Guide has no correspponding requirements section so
that document has been missed out.

Add python requirements for AAP into docs

https://issues.redhat.com/browse/AAP-3385