### PR TITLE
[2.2] AAP-4425 Updating version numbers in Upgrade & Migration guide

### DIFF
--- a/downstream/assemblies/platform/assembly-content-migration.adoc
+++ b/downstream/assemblies/platform/assembly-content-migration.adoc
@@ -11,7 +11,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-If you are migrating from an `ansible-core` version to `ansible-core` 2.12+, consider reviewing link:https://docs.ansible.com/ansible-core/2.12/porting_guides/core_porting_guides.html[Ansible core Porting Guides] to familiarize yourself with changes and updates between each version. When reviewing the Ansible core porting guides, ensure that you select the latest version of `ansible-core` or `devel`, which is located at the top left column of the guide.
+If you are migrating from an `ansible-core` version to `ansible-core` 2.13, consider reviewing link:https://docs.ansible.com/ansible-core/2.13/porting_guides/core_porting_guides.html[Ansible core Porting Guides] to familiarize yourself with changes and updates between each version. When reviewing the Ansible core porting guides, ensure that you select the latest version of `ansible-core` or `devel`, which is located at the top left column of the guide.
 
 For a list of fully supported and certified Ansible Content Collections, see link:https://console.redhat.com/ansible/automation-hub[Ansible Automation hub] on link:https://console.redhat.com/[console.redhat.com].
 

--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -34,7 +34,7 @@ include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 // Remove comments once 2.2 version of the docs are published.
 //== Additional resources
 
-//* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/PlatformVers/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
+//* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -31,9 +31,10 @@ The below workflow describes how to migrate from legacy venvs to {ExecEnvName} u
 include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
+// Remove comments once 2.2 version of the docs are published.
+//== Additional resources
 
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information of migrating to {ExecEnvName}.
+//* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/PlatformVers/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -33,7 +33,7 @@ include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_creator_guide/index?lb_target=production[Red Hat Ansible Automation Platform Creator Guide] for more information of migrating to {ExecEnvName}.
+* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information of migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is not a Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
+If there is not a Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -16,7 +16,7 @@ The following specifications are required for the nodes involved in the {Platfor
 * DNS records for all nodes.
 * Red Hat Enterprise Linux 8 or later 64-bit (x86) installed for all nodes.
 * Chrony configured for all nodes.
-* Python 3.8 or later for all content dependencies.
+* Python 3.9 or later for all content dependencies.
 
 == {ControllerNameStart} configuration requirements
 The following {ControllerName} configurations are required before you proceed with the {PlatformNameShort} upgrade process:
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is not a Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
+If there is not a Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is not a Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
+If there is no Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/con-why-ee.adoc
+++ b/downstream/modules/platform/con-why-ee.adoc
@@ -5,8 +5,8 @@
 {PlatformName} {PlatformVers} introduces {ExecEnvName}. {ExecEnvNameStart} are container images that allow for easier administration of Ansible by including everything needed to run Ansible automation within a single container. Automation execution environments include:
 
 * RHEL UBI 8
-* Ansible 2.9 or Ansible Core 2.11
-* Python 3.8 or later.
+* Ansible 2.9 or Ansible Core 2.13
+* Python 3.9 or later.
 * Any Ansible Content Collections
 * Collection python or binary dependencies
 

--- a/downstream/modules/platform/proc-new-aap-instance-upgrade.adoc
+++ b/downstream/modules/platform/proc-new-aap-instance-upgrade.adoc
@@ -12,7 +12,7 @@ To deploy a new Ansible Tower instance, do the following:
 . Navigate to the installer, then open the `inventory` file using a text editor to configure the `inventory` file for a Tower installation:
 .. In addition to any Tower configurations, remove any fields containing `isolated_group` or `instance_group`.
 +
-NOTE: For more information about installing Tower using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformNameShort} Installation Guide] for your specific installation scenario.
+NOTE: For more information about installing Tower using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformNameShort} Installation Guide] for your specific installation scenario.
 . Run the `setup.sh` script to begin the installation.
 
 Once the new instance is installed, configure the Tower settings to match the instance groups from your original Tower instance.

--- a/downstream/modules/platform/proc-new-aap-instance-upgrade.adoc
+++ b/downstream/modules/platform/proc-new-aap-instance-upgrade.adoc
@@ -12,7 +12,7 @@ To deploy a new Ansible Tower instance, do the following:
 . Navigate to the installer, then open the `inventory` file using a text editor to configure the `inventory` file for a Tower installation:
 .. In addition to any Tower configurations, remove any fields containing `isolated_group` or `instance_group`.
 +
-NOTE: For more information about installing Tower using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformNameShort} Installation Guide] for your specific installation scenario.
+NOTE: For more information about installing Tower using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformNameShort} Installation Guide] for your specific installation scenario.
 . Run the `setup.sh` script to begin the installation.
 
 Once the new instance is installed, configure the Tower settings to match the instance groups from your original Tower instance.

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -33,7 +33,7 @@ The setup script pauses and indicates that a "pre-2.x" inventory file was detect
 NOTE: By running the setup script, the Installer modified a few fields from your original inventory file, such as renaming [tower] to [automationcontroller].
 . Modify the newly generated `inventory.new.ini` file to configure your automation mesh by assigning relevant variables, nodes, and relevant node-to-node peer connections:
 +
-NOTE: The design of your automation mesh topology depends on the automation needs of your environment. The example below offers one possible scenario for automation mesh design, and the design of your automation mesh topology depends on the automation needs of your environment. Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
+NOTE: The design of your automation mesh topology depends on the automation needs of your environment. The example below offers one possible scenario for automation mesh design, and the design of your automation mesh topology depends on the automation needs of your environment. Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
 +
 .Example inventory file with a standard control plane consisting of three nodes utilizing hop nodes:
 ----
@@ -70,5 +70,5 @@ $ ./setup.sh -i inventory.new.ini -e @credentials.yml -- --ask-vault-pass
 . Once the installation completes, verify that your {PlatformNameShort} has been installed successfully by logging in to the {PlatformNameShort} dashboard UI across all automation controller nodes.
 
 .Additional resources
-* For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
-* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]
+* For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
+* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -71,4 +71,5 @@ $ ./setup.sh -i inventory.new.ini -e @credentials.yml -- --ask-vault-pass
 
 .Additional resources
 * For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
-* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]
+// Remove comments once 2.2 version of the docs are published.
+//* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -33,7 +33,9 @@ The setup script pauses and indicates that a "pre-2.x" inventory file was detect
 NOTE: By running the setup script, the Installer modified a few fields from your original inventory file, such as renaming [tower] to [automationcontroller].
 . Modify the newly generated `inventory.new.ini` file to configure your automation mesh by assigning relevant variables, nodes, and relevant node-to-node peer connections:
 +
-NOTE: The design of your automation mesh topology depends on the automation needs of your environment. The example below offers one possible scenario for automation mesh design, and the design of your automation mesh topology depends on the automation needs of your environment. Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
+NOTE: The design of your automation mesh topology depends on the automation needs of your environment. The example below offers one possible scenario for automation mesh design, and the design of your automation mesh topology depends on the automation needs of your environment.
+//Remove comment and add to the above note once 2.2 version of the docs are published.
+// Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
 +
 .Example inventory file with a standard control plane consisting of three nodes utilizing hop nodes:
 ----

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -70,5 +70,5 @@ $ ./setup.sh -i inventory.new.ini -e @credentials.yml -- --ask-vault-pass
 . Once the installation completes, verify that your {PlatformNameShort} has been installed successfully by logging in to the {PlatformNameShort} dashboard UI across all automation controller nodes.
 
 .Additional resources
-* For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
+* For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
 * For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-4425

Updating version numbers in the Upgrade & Migration guide to publish as version 2.2 docs. The changes for "AAP 2.1" > "2.2" will change when building the docs in the 2.2 branch, due to the attribute {PlatformVers}

- Change Ansible Core 2.11 to 2.13
- Change Python 3.8 to 3.9
- Change links to 2.1 (we can update the links to 2.2 once the linked docs have been updated to 2.2)