### PR TITLE
AAP-4424: AAP 2.2 Install Guide Priority Updates

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-platform.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-platform.adoc
@@ -7,4 +7,4 @@ For platform administrators looking to complete an upgrade to the {PlatformNameS
 
 include::platform/con-why-migrate-venvs-ee.adoc[leveloffset=+1]
 include::platform/con-why-migrate-ansible-29.adoc[leveloffset=+1]
-include::platform/con-why-migrate-ansible-core-212.adoc[leveloffset=+1]
+include::platform/con-why-migrate-ansible-core-213.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-cluster-platform-ext-database.adoc
+++ b/downstream/modules/platform/con-cluster-platform-ext-database.adoc
@@ -8,7 +8,7 @@ This scenario includes installation of multiple {ControllerName} nodes and an {H
 
 [NOTE]
 ====
-* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 12*.
+* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 13*.
 ** See link:https://docs.ansible.com/automation-controller/latest/html/administration/clustering.html[Clustering] for more information on configuring a clustered setup.
 * Provide a reachable IP address for the `[automationhub]` host to ensure users can sync content from Private Automation Hub from a different node.
 ====

--- a/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
@@ -1,0 +1,5 @@
+// [id="con-why-migrate-ansible-core-213_{context}"]
+
+= Migrating to Ansible Core 2.13
+
+When upgrading to Ansible Core 2.13, you will need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.13 compatible, see the https://https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.13.html[Ansible-core 2.13 Porting Guide].

--- a/downstream/modules/platform/proc-attaching-subscriptions.adoc
+++ b/downstream/modules/platform/proc-attaching-subscriptions.adoc
@@ -52,6 +52,14 @@ You have now attached your {PlatformName} subscriptions to all nodes.
 
 * If you are unable to locate certain packages that came bundled with the {PlatformNameShort} installer, or if you are seeing a `_Repositories disabled by configuration_` message, try enabling the repository using the command:
 +
+Red Hat Ansible Automation Platform 2.2 for RHEL 8
++
 ----
-subscription-manager repos --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
+subscription-manager repos --enable ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms
+----
++
+Red Hat Ansible Automation Platform 2.2 for RHEL 9
++
+----
+subscription-manager repos --enable ansible-automation-platform-2.2-for-rhel-9-x86_64-rpms
 ----

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -23,7 +23,7 @@ h| Subscription | Valid Red Hat Ansible Automation Platform |
 
 h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |
 
-h| Ansible | version 2.11 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.12.
+h| Ansible | version 2.2 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
 
 h| Python | 3.8 or later |
 |===
@@ -98,7 +98,7 @@ h| Disk: database node| 20 GB dedicated hard disk space |
 
 h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 
-h| Database | PostgreSQL version 12 |
+h| Database | PostgreSQL version 13 |
 
 |===
 
@@ -129,7 +129,7 @@ h| Disk: database node| 20 GB dedicated hard disk space |
 
 h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 
-h| Database | PostgreSQL version 12 |
+h| Database | PostgreSQL version 13 |
 
 |===
 
@@ -155,10 +155,10 @@ For example, a playbook run every hour (24 times a day) across 250, hosts, with 
 
 .Notable PostgreSQL changes
 
-{PlatformName} uses PostgreSQL 12.
+{PlatformName} uses PostgreSQL 13.
 
 * PostgreSQL user passwords will now be hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
-* You will no longer need to provide a `pg_hashed_password` in your inventory file at the time of installation because PostgreSQL 12 can now store the user's password more securely. If users supply a password in the inventory file for the installer (``pg_password``), that password will be SCRAM-SHA-256 hashed by PostgreSQL as part of the installation process. **DO NOT** use special characters in ``pg_password`` as it may cause the setup to fail.
+* You will no longer need to provide a `pg_hashed_password` in your inventory file at the time of installation because PostgreSQL 13 can now store the user's password more securely. If users supply a password in the inventory file for the installer (``pg_password``), that password will be SCRAM-SHA-256 hashed by PostgreSQL as part of the installation process. **DO NOT** use special characters in ``pg_password`` as it may cause the setup to fail.
 * Since {ControllerName} and {HubName} are using a Software Collections version of PostgreSQL in 3.8, the `rh-postgresql10` scl must be enabled in order to access the database.  Administrators can use the ``awx-manage dbshell`` command, which will automatically enable the PostgreSQL SCL.
 * If you just need to determine if your {ControllerName} instance has access to the database, you can do so with the command, ``awx-manage check_db``.
 
@@ -176,11 +176,9 @@ maintenance_work_mem == ansible_memtotal_mb*0.04
 
 Refer to the link:https://wiki.postgresql.org/wiki/Main_Page[PostgreSQL documentation] for more detail on tuning your PostgreSQL server.
 
-.Ansible software requirements
-
 While {PlatformName} depends on Ansible Playbooks and requires the installation of the latest stable version of Ansible before installing {ControllerName}, manual installations of Ansible are no longer required.
 
-Upon new installations, {ControllerName} installs the latest release package of Ansible 2.11.
+Upon new installations, {ControllerName} installs the latest release package of Ansible 2.2.
 
 If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 


### PR DESCRIPTION
Jira Issue: [AAP-4424](https://issues.redhat.com/browse/AAP-4424)
Overall:

- Changed any reference to Ansible Automation Platform 2.1 to 2.2

- Changed section with title "Migrating to Ansible Core 2.12" to "Migrating to Ansible Core 2.13"

- Changed Ansible Core 2.12 to Ansible Core 2.13

- Table 1.1 Base System: Changed PostgreSQL version 12 to PostgreSQL version 13

- Table 1.2 Automation hub: Changed PostgreSQL version 12 to PostgreSQL version 13
- Notable PostgreSQL: Changed PostgreSQL 12 to PostgreSQL 13
- Change PostgreSQL 12 to PostgreSQL 13

- 1.3 Attaching your Red Hat Ansible Automation Platform subscription: 
Troubleshooting section: Changed the command to use -> `ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms`
Added a similar command for Red Hat Enterprise Linux 9

- 1.4.7 Multi-machine cluster installation with an external managed database
Note: Changed bolded PostgreSQL 12 to PostgreSQL 13