### PR TITLE
2.2 Fix typo  (#403)

### DIFF
--- a/downstream/modules/platform/proc-find-delete-PVCs.adoc
+++ b/downstream/modules/platform/proc-find-delete-PVCs.adoc
@@ -2,7 +2,7 @@
 
 = Finding and deleting PVCs
 
-A persistant volume claim (PVC) is a storage volume used to store data that {HubName} and {ControllerName} applications use. These PVCs are independent from the applications and remain even when the application is deleted. If you are confident that you no longer need a PVC, or have backed it up elsewhere, you can manually delete them.
+A persistent volume claim (PVC) is a storage volume used to store data that {HubName} and {ControllerName} applications use. These PVCs are independent from the applications and remain even when the application is deleted. If you are confident that you no longer need a PVC, or have backed it up elsewhere, you can manually delete them.
 
 .Procedure
 


### PR DESCRIPTION
Backports #403 to `2.2`
Fix typo in a module