### PR TITLE
AAP-2344 New assembly for on-prem to OCP upgrade

### DIFF
--- a/downstream/assemblies/platform/assembly-upgrading-from-aap-on-prem-to-ocp.adoc
+++ b/downstream/assemblies/platform/assembly-upgrading-from-aap-on-prem-to-ocp.adoc
@@ -1,0 +1,41 @@
+
+ifdef::context[:parent-context: {context}]
+
+
+[id="assembly_upgrading-from-aap-on-prem-to-aap-operator-on-ocp_{context}"]
+= Upgrading from {PlatformName} 1.2 on-prem to {PlatformName} operator on {OCP}
+
+
+:context: assembly-upgrading-from-aap-on-prem-to-ocp
+
+[role="_abstract"]
+
+As a platform administrator who wants to upgrade from {PlatformName} 1.2 on prem or on virtual machines, you must upgrade to the {PlatformName} 2.x operator on {OCP} {OCPLatest} in order to easily deploy and manage {PlatformNameShort} components on {OCPShort} for efficient automation of application development and IT management for your organization.
+
+To perform this task successfully, you must:
+
+* Set up secret key files.
+* Create a database secret key.
+* Expose the host as an external IP.
+* Install {PlatformName} operator from {OperatorHub} and use the your previous database key when deploying a new {ControllerName}.
+
+
+include::modules/.adoc[leveloffset=+2]
+
+include::modules/TEMPLATE_PROCEDURE_reference-material.adoc[leveloffset=2]
+////
+
+[role="_additional-resources"]
+== Additional resources (or Next steps)
+////
+Optional. Delete if not used.
+////
+* A bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+////
+Restore the context to what it was before this assembly.
+////
+ifdef::parent-context-of-assembly_upgrading-from-aap-on-prem-to-aap-operator-on-ocp[:context: {parent-context-of-assembly_upgrading-from-aap-on-prem-to-aap-operator-on-ocp}]
+ifndef::parent-context-of-assembly_upgrading-from-aap-on-prem-to-aap-operator-on-ocp[:!context:]


### PR DESCRIPTION
Jira ticket AAP-2344 - upgrading from an existing on-premise installation of AAP to using the AAP Operator on OpenShift Container Platform 4.