### PR TITLE
2.2 AAP-4086 Removed instructions for installing builder with pip (#427)

### DIFF
--- a/downstream/assemblies/builder/assembly-building-off-existing-ee.adoc
+++ b/downstream/assemblies/builder/assembly-building-off-existing-ee.adoc
@@ -3,5 +3,4 @@
 = Building off of existing base EEs provided by {PlatformName}
 
 include::builder/con-gathering-system-dependencies.adoc[leveloffset=+1]
-include::builder/con-pip-based-req.adoc[leveloffset=+1]
 include::builder/proc-customize-ee-image.adoc[leveloffset=+1]

--- a/downstream/modules/builder/con-pip-based-req.adoc
+++ b/downstream/modules/builder/con-pip-based-req.adoc
@@ -1,9 +1,0 @@
-[id="con-pip-based-req"]
-
-= Note for `pip`-based requirements
-
-Python requirements files are combined into a single file using the `requirements-parser` library in order to support complex syntax. Entries from separate collections that give the same package name will be combined into the same entry, with the constraints combined.
-
-There are several package names which are specifically ignored by `ansible-builder`; if a collection lists these, they will not be included in the combined file. These include test packages and packages that provide Ansible itself.
-
-The full list can be found in `EXCLUDE_REQUIREMENTS` in the https://github.com/ansible/ansible-builder/blob/devel/ansible_builder/requirements.py[ansible_builder.requirements.py] module.

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -13,11 +13,3 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 ----
 $ dnf install ansible-builder
 ----
-+
-You can also install {Builder} from the https://pypi.org/project/ansible-builder/[Python Package Index (PyPI)]. To install with this setup, run:
-+
-----
-$ pip install ansible-builder
-----
-+
-NOTE: If you encounter issues while installing from PyPI, please install and reproduce on a supported installation.


### PR DESCRIPTION
Removed instructions from the builder guide about installing using pip

Remove Instructions on Installing ansible-builder via pip

https://issues.redhat.com/browse/AAP-4086