### PR TITLE
2.1 AAP-4775 Add user-replaced value for SSH tunnelling IP address (#431)

### DIFF
--- a/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-ssh-tunnel.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-ssh-tunnel.adoc
@@ -39,14 +39,14 @@ The following example shows the line in a hosts file:
 ----
 . As a user with root privileges, run the `ssh` command to establish an SSH tunnel.
 +
-In the example below, the IP address is the address of the SSH server in your DMZ.
-Change this IP address for your SSH tunnel.
-The `-L` flag makes your local system route traffic for the {ControllerName} URL over port 443 (HTTPs).
+In the example below, `_SSH_server_IP_` represents the IP address of the SSH server in your DMZ.
 +
 [subs="+quotes"]
 ----
-sudo ssh azureuser@20.231.60.123 -i ~/.ssh/id_ssh_key -N -f -L 443:controller.<__your_AAPonAzure_instance__>.az.ansiblecloud.com:443
+sudo ssh azureuser@<__SSH_server_IP__> -i ~/.ssh/id_ssh_key -N -f -L 443:controller.<__your_AAPonAzure_instance__>.az.ansiblecloud.com:443
 ----
++
+The `-L` flag makes your local system route traffic for the {ControllerName} URL over port 443 (HTTPs).
 +
 [NOTE]
 ====


### PR DESCRIPTION
Backports https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/431 Add user-replaced value for SSH tunnelling IP address to 2.1

[AAP-4775](https://issues.redhat.com/browse/AAP-4775)
The `ssh` command to establish an SSH tunnel contains an IP address. Replace this with a user-replaced value.
Affects the AAP on Azure guide.