### PR TITLE
2.1 AAP-4122 Added allowlisted domains (#414)

### DIFF
--- a/downstream/modules/automation-hub/proc-create-synclist.adoc
+++ b/downstream/modules/automation-hub/proc-create-synclist.adoc
@@ -12,11 +12,22 @@ By default, all Red Hat Certified collections are included in your initial organ
 
 * You have a valid Ansible Automation Platform subscription.
 * You have Organization Administrator permissions for cloud.redhat.com.
+* Ensure that the following domain names are part of either the firewall or the proxy's allowlist for successful connection and download of collections from {HubName} or Galaxy server:
+** `galaxy.ansible.com`
+** `cloud.redhat.com`
+** `console.redhat.com`
+** `sso.redhat.com`
+* {HubNameStart} resources are stored in Amazon Simple Storage.
+Add the following domain name to the allow list:
+** `automation-hub-prd.s3.us-east-2.amazonaws.com`
+* SSL inspection must be disabled either when using self signed certificates or for the Red Hat domains.
+
 
 .Procedure
 
 . Log in to cloud.redhat.com.
 . Navigate to *Automation Hub* -> *Collections*.
 . Use the toggle switch on each collection to determine whether to exclude it from your synclist.
+
 
 When you finish managing collections for your synclist, you can navigate to menu:Automation Hub[Repo Management] to initiate the remote repository sync to your local Automation Hub. If your remote repository is already configured, you can manually sync Red Hat Certified collections to your local Automation Hub to update the collections content that you made available to local users.

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -28,7 +28,14 @@ h| Ansible | version 2.11 required | If Ansible is not already present on the sy
 h| Python | 3.8 or later |
 |===
 
+The following are necessary for you to work with project updates and collections:
 
+* Ensure that the following domain names are part of either the firewall or the proxy's allowlist for successful connection and download of collections from {HubName} or Galaxy server:
+** `galaxy.ansible.com`
+** `cloud.redhat.com`
+** `console.redhat.com`
+** `sso.redhat.com`
+* SSL inspection must be disabled either when using self signed certificates or for the Red Hat domains.
 
 == Automation controller
 

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -2,6 +2,8 @@
 :numbered:
 :experimental:
 
+include::attributes/attributes.adoc[]
+
 You can sync Automation Hub to use the Red Hat Certified Collections available through your Ansible Automation Platform subscription or community collections available through Ansible Galaxy.
 
 Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the Automation Hub service hosted on cloud.redhat.com.


### PR DESCRIPTION
* Added allowlisted domains

Added list of allowlisted domains and other requirements

Add in the doc from config AAP the domains which need to be whitelisted

https://issues.redhat.com/browse/AAP-4122

* Added allowlisted domains

Corrections and addressed comments

Add in the doc from config AAP the domains which need to be whitelisted

https://issues.redhat.com/browse/AAP-4122

Title affected:  ./hub/configuring-private-hub-rh-certified ([section 1.2](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/assembly-synclists#proc-create-synclist))