### PR TITLE
AAP2336 - Created topics for Migration & Upgrade of Operator on OCP

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -1,0 +1,26 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="aap-migration"]
+= Migrating {PlatformName} to {OperatorPlatform}
+
+:context: aap-migration
+
+[role="_abstract"]
+
+Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
+
+include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
+include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]
+include::platform/con-aap-migration-prereqs.adoc[leveloffset=+2]
+include::platform/proc-aap-migration-backup.adoc[leveloffset=+2]
+include::platform/proc-create-secret-key-secret.adoc[leveloffset=+2]
+include::platform/proc-create-postresql-secret.adoc[leveloffset=+2]
+include::platform/proc-verify-network-connectivity.adoc[leveloffset=+2]
+include::platform/proc-aap-migration.adoc[leveloffset=+1]
+include::platform/proc-post-migration-cleanup.adoc[leveloffset=+1]
+
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -10,6 +10,12 @@ ifdef::context[:parent-context: {context}]
 
 Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
 
+This guide allows you to migrate:
+
+* A VM-based installation of {ControllerName} or {HubName}, or
+* An Openshift instance of Ansible Tower 3.8.7 ({PlatformNameShort} 1.2.7)
+
+
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prereqs.adoc[leveloffset=+2]
@@ -18,6 +24,8 @@ include::platform/proc-create-secret-key-secret.adoc[leveloffset=+2]
 include::platform/proc-create-postresql-secret.adoc[leveloffset=+2]
 include::platform/proc-verify-network-connectivity.adoc[leveloffset=+2]
 include::platform/proc-aap-migration.adoc[leveloffset=+1]
+include::platform/proc-aap-create_controller.adoc[leveloffset=+2]
+include::platform/proc-aap-create_hub.adoc[leveloffset=+2]
 include::platform/proc-post-migration-cleanup.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -1,0 +1,21 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="operator-upgrade_{context}"]
+
+= Upgrading {OperatorPlatform} on {OCPShort}
+
+:context: operator-upgrade
+
+[role="_abstract"]
+
+The {OperatorPlatform} simplifies the installation, upgrade and deployment of new {PlatformName} instances in your {OCPShort} environment.
+
+include::platform/con-operator-upgrade-considerations.adoc[leveloffset=+1]
+include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]
+include::platform/proc-operator-upgrade.adoc[leveloffset=+1]
+
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-aap-migration-considerations.adoc
+++ b/downstream/modules/platform/con-aap-migration-considerations.adoc
@@ -1,0 +1,7 @@
+[id="aap-migration-considerations"]
+
+= Migration considerations
+
+
+[role="_abstract"]
+If you are upgrading from {PlatformNameShort} 1.2 on {OCPShort} 3 to {PlatformNameShort} 2.x on {OCPShort} 4, you must provision a fresh {OCPShort} version 4 cluster and then migrate the {PlatformNameShort} to the new cluster. 

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -1,0 +1,7 @@
+[id="aap-migration-prepare"]
+
+= Preparing for migration
+
+
+[role="_abstract"]
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create secret keys, and create a postresql configuration secret for migration.

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,4 +4,4 @@
 
 
 [role="_abstract"]
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create secret keys, and create a postresql configuration secret for migration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create k8s secrets for your secret key and postgresql configuration.

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -2,10 +2,11 @@
 
 = Preparing for migration
 
-
 [role="_abstract"]
+
 Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create k8s secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====
 If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_{context}[Creating a secret key secret] and xref:create-postresql-secret_{context}[Creating a postgresql configuration secret] for both and then proceed to xref:aap-migration_{context}[Migrating data to the {PlatformNameShort} Operator].
+====

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create k8s secrets for your secret key and postgresql configuration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to back up your existing data, create k8s secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -5,3 +5,7 @@
 
 [role="_abstract"]
 Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to backup your existing data, create k8s secrets for your secret key and postgresql configuration.
+
+[NOTE]
+====
+If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_{context}[Creating a secret key secret] and xref:create-postresql-secret_{context}[Creating a postgresql configuration secret] for both and then proceed to xref:aap-migration_{context}[Migrating data to the {PlatformNameShort} Operator].

--- a/downstream/modules/platform/con-aap-migration-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-migration-prereqs.adoc
@@ -1,0 +1,16 @@
+[id="aap-migration-prereqs"]
+
+= Prerequisites
+To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have the following:
+
+[role="_abstract"]
+
+* Secret key secret
+* Postgresql configuration
+* Role-Based Access Controls
+* Network connectivity
+
+[NOTE]
+====
+Secret key information can be located in the inventory file created during the initial {PlatformName} installation. If you are unable to remember your secret key or have trouble locating your inventory file, contact link::https://access.redhat.com/[Ansible support] via the Red Hat Customer portal. 
+====

--- a/downstream/modules/platform/con-aap-migration-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-migration-prereqs.adoc
@@ -7,10 +7,10 @@ To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have t
 
 * Secret key secret
 * Postgresql configuration
-* Role-Based Access Controls
-* Network connectivity
+* Role-based Access Control for the namespaces on the new OpenShift cluster
+* Previous PostgreSQL database host must be resolvable from the new OpenShift cluster
 
 [NOTE]
 ====
-Secret key information can be located in the inventory file created during the initial {PlatformName} installation. If you are unable to remember your secret key or have trouble locating your inventory file, contact link::https://access.redhat.com/[Ansible support] via the Red Hat Customer portal. 
+Secret key information can be located in the inventory file created during the initial {PlatformName} installation. If you are unable to remember your secret key or have trouble locating your inventory file, contact link:https://access.redhat.com/[Ansible support] via the Red Hat Customer portal.
 ====

--- a/downstream/modules/platform/con-aap-migration-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-migration-prereqs.adoc
@@ -1,9 +1,10 @@
 [id="aap-migration-prereqs"]
 
 = Prerequisites
-To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have the following:
 
 [role="_abstract"]
+
+To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have the following:
 
 * Secret key secret
 * Postgresql configuration

--- a/downstream/modules/platform/con-aap-migration-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-migration-prereqs.adoc
@@ -8,7 +8,7 @@ To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have t
 * Secret key secret
 * Postgresql configuration
 * Role-based Access Control for the namespaces on the new OpenShift cluster
-* Previous PostgreSQL database host must be resolvable from the new OpenShift cluster
+* The new OpenShift cluster must be able to connect to the previous PostgreSQL database
 
 [NOTE]
 ====

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -9,7 +9,7 @@ Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-li
 
 Follow one of the workflows below to install the {OperatorPlatform} and use it to install the components of {PlatformNameShort} that you require.
 
-* {ControllerNameStart} and customer resources first, then {HubName} and customer resources;
-* {HubNameStart} and customer resources first, then {ControllerName} and customer resources;
-* {ControllerNameStart} and customer resources;
-* {HubNameStart} and custom resources.
+* {ControllerNameStart} custom resources first, then {HubName} custom resources;
+* {HubNameStart} custom resources first, then {ControllerName} custom resources;
+* {ControllerNameStart} custom resources;
+* {HubNameStart} custom resources.

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -10,10 +10,10 @@ If you are using a version of {OCPShort} that is not supported by the version of
 
 Use this support matrix to determine the {OCPShort} version needed:
 
-.{PlatormNameShort}/{OCPShort} support matrix
+.{PlatformNameShort}/{OCPShort} support matrix
 [options="header"]
 |====
-|{PlatformNameShort}|Supported {OCPShort} versions
+|{PlatformNameShort} version| Supported {OCPShort} versions
 //|2.3 | 4.9 - 4.12 [Include row for the 2.3 release of doc]
 |2.2 | 4.8 - 4.11
 |2.1 | 4.7 - 4.10

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -6,4 +6,4 @@
 [role="_abstract"]
 {PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref::operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
 
-If you are running {OCPShort} 4.6 with {PlatformName} 2.0, you must upgrade your cluster before upgrading to {PlatformName} 2.1 and above. For information about upgrading your cluster, refer to link::https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].
+If you are running {OCPShort} 4.6 with {PlatformName} 2.0, you must upgrade your cluster before upgrading to {PlatformName} 2.1 and above. For information about upgrading your cluster, refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -1,0 +1,9 @@
+[id="operator-upgrade-considerations"]
+
+= Upgrade considerations
+
+
+[role="_abstract"]
+{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref::operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
+
+If you are running {OCPShort} 4.6 with {PlatformName} 2.0, you must upgrade your cluster before upgrading to {PlatformName} 2.1 and above. For information about upgrading your cluster, refer to link::https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -6,4 +6,17 @@
 [role="_abstract"]
 {PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref::operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
 
-If you are running {OCPShort} 4.6 with {PlatformName} 2.0, you must upgrade your cluster before upgrading to {PlatformName} 2.1 and above. For information about upgrading your cluster, refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].
+If you are using a version of {OCPShort} that is not supported by the version of {PlatformName} to which you are upgrading, you must upgrade your {OCPShort} cluster to a supported version prior to upgrading.
+
+Use this support matrix to determine the {OCPShort} version needed:
+
+.{PlatormNameShort}/{OCPShort} support matrix
+[options="header"]
+|====
+|{PlatformNameShort}|Supported {OCPShort} versions
+//|2.3 | 4.9 - 4.12 [Include row for the 2.3 release of doc]
+|2.2 | 4.8 - 4.11
+|2.1 | 4.7 - 4.10
+|====
+
+For information about upgrading your cluster, refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -8,15 +8,6 @@
 
 If you are using a version of {OCPShort} that is not supported by the version of {PlatformName} to which you are upgrading, you must upgrade your {OCPShort} cluster to a supported version prior to upgrading.
 
-Use this support matrix to determine the {OCPShort} version needed:
-
-.{PlatformNameShort}/{OCPShort} support matrix
-[options="header"]
-|====
-|{PlatformNameShort} version| Supported {OCPShort} versions
-//|2.3 | 4.9 - 4.12 [Include row for the 2.3 release of doc]
-|2.2 | 4.8 - 4.11
-|2.1 | 4.7 - 4.10
-|====
+Refer to the link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle] to determine the {OCPShort} version needed.
 
 For information about upgrading your cluster, refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/updating_clusters/index[Updating clusters].

--- a/downstream/modules/platform/con-operator-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-prereq.adoc
@@ -1,0 +1,9 @@
+[id="operator-upgrade-prereq_{context}"]
+
+= Prerequisites
+
+
+[role="_abstract"]
+To upgrade to a newer version of {OperatorPlatform}, you must have the following:
+
+* TBD

--- a/downstream/modules/platform/con-operator-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-prereq.adoc
@@ -8,4 +8,4 @@ To upgrade to a newer version of {OperatorPlatform}, it is recommended that you 
 
 * Create AutomationControllerBackup and AutomationHubBackup objects.
 //See (Backup and Restore) for information on creating backup objects. [add link to new backup and restore doc when complete]
-* Review the release notes for new {PlatformNameShort} version to which you are upgrading, and any intermediate versions.
+* Review the release notes for the new {PlatformNameShort} version to which you are upgrading and any intermediate versions.

--- a/downstream/modules/platform/con-operator-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-prereq.adoc
@@ -6,5 +6,6 @@
 [role="_abstract"]
 To upgrade to a newer version of {OperatorPlatform}, it is recommended that you do the following:
 
-* Create AutomationControllerBackup and AutomationHubBackup objects. See (Backup and Restore) for information on creating backup objects.
+* Create AutomationControllerBackup and AutomationHubBackup objects.
+//See (Backup and Restore) for information on creating backup objects. [add link to new backup and restore doc when complete]
 * Review the release notes for new {PlatformNameShort} version to which you are upgrading, and any intermediate versions.

--- a/downstream/modules/platform/con-operator-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-prereq.adoc
@@ -4,6 +4,7 @@
 
 
 [role="_abstract"]
-To upgrade to a newer version of {OperatorPlatform}, you must have the following:
+To upgrade to a newer version of {OperatorPlatform}, it is recommended that you do the following:
 
-* TBD
+* Create AutomationControllerBackup and AutomationHubBackup objects. See (Backup and Restore) for information on creating backup objects.
+* Review the release notes for new {PlatformNameShort} version to which you are upgrading, and any intermediate versions.

--- a/downstream/modules/platform/proc-aap-create_controller.adoc
+++ b/downstream/modules/platform/proc-aap-create_controller.adoc
@@ -1,0 +1,17 @@
+[id="aap-create_controller"]
+
+= Creating an AutomationController object
+
+[role=_abstract]
+
+Use the following steps to create an AutomationController custom resource object.
+
+.Procedure
+. Log in to *{OCP}*.
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Select the *Automation Controller* tab.
+. Click btn:[Create AutomationController].
+. Enter a name for the new deployment.
+. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
+. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -1,0 +1,17 @@
+[id="aap-create_hub"]
+
+= Creating an AutomationHub object
+
+[role=_abstract]
+
+Use the following steps to create an AutomationHub custom resource object.
+
+.Procedure
+. Log in to *{OCP}*.
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Select the *Automation Hub* tab.
+. Click btn:[Create AutomationHub].
+. Enter a name for the new deployment.
+. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
+. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-migration-backup.adoc
+++ b/downstream/modules/platform/proc-aap-migration-backup.adoc
@@ -7,14 +7,15 @@ Before migrating your data from {PlatformNameShort} 2.x or earlier, you must bac
 . Log in to your current deployment project.
 . Run setup.sh to create a backup of your current data/deployment:
 +
-For on prem deployments:
+For on-prem deployments of version 2.x or earlier:
 +
 -----
 $ ./setup.sh -b
 -----
 +
-For OpenShift deployments:
+For OpenShift deployments prior to version 2.0 (non-operator deployments):
 +
 -----
 ./setup_openshift.sh -b
 -----
+//reminder - add a cross reference statement to new Backup and Restore doc once published. "For Openshift Operator installations for version 2.0 and later, refer to"

--- a/downstream/modules/platform/proc-aap-migration-backup.adoc
+++ b/downstream/modules/platform/proc-aap-migration-backup.adoc
@@ -1,0 +1,20 @@
+[id="aap-migration-backup"]
+
+[role="_abstract"]
+Before migrating your data from {PlatformNameShort} 2.x or earlier, you must back up your data for loss prevention. To backup your data, do the following:
+
+.Procedure
+. Log in to your current deployment project.
+. Run setup.sh to create a backup of your current data/deployment:
++
+For on prem deployments:
++
+-----
+$ ./setup.sh -b
+-----
++
+For OpenShift deployments:
++
+-----
+./setup_openshift.sh -b
+-----

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -4,4 +4,4 @@
 
 [role=_abstract]
 
-Once you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatform}, you can migrate your data by creating a custom resource controller object.
+After you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatform}, you must create a custom resource controller object before you can migrate your data.

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -5,13 +5,3 @@
 [role=_abstract]
 
 Once you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatform}, you can migrate your data by creating a custom resource controller object.
-
-.Procedure
-. Log in to *{OCP}*.
-. Navigate to menu:Operators[Installed Operators].
-. Select the {OperatorPlatform} installed on your project namespace.
-. Select the *Automation Controller* tab.
-. Click btn:[Create AutomationController].
-. Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
-. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -1,0 +1,17 @@
+[id="aap-migration_{context}"]
+
+= Migrating data to the {PlatformNameShort} Operator
+
+[role=_abstract]
+
+Once you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatform}, you can migrate your data by creating a custom resource controller object.
+
+.Procedure
+. Log in to *{OCP}*.
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Select the *Automation Controller* tab.
+. Click btn:[Create AutomationController].
+. Enter a name for the new deployment.
+. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
+. Click btn:[Create].

--- a/downstream/modules/platform/proc-create-postresql-secret.adoc
+++ b/downstream/modules/platform/proc-create-postresql-secret.adoc
@@ -1,0 +1,30 @@
+[id="create-postresql-secret_{context}"]
+
+= Creating a postgresql configuration secret
+
+[role=_abstract]
+
+For migration to be successful, you must provide access to the database for your existing deployment.
+
+.Procedure
+
+. Create a yaml file for your postgresql configuration secret:
++
+-----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-old-postgres-configuration
+  namespace: <target namespace>
+stringData:
+  host: <external ip or url resolvable by the cluster>
+  port: <external port, this usually defaults to 5432>
+  database: <desired database name>
+  username: <username to connect as>
+  password: <password to connect with>
+type: Opaque
+-----
+. Apply the postgresql configuration yaml to the cluster:
+-----
+oc apply -f <old-postgres-configuration.yml>
+-----

--- a/downstream/modules/platform/proc-create-postresql-secret.adoc
+++ b/downstream/modules/platform/proc-create-postresql-secret.adoc
@@ -17,11 +17,11 @@ metadata:
   name: <resourcename>-old-postgres-configuration
   namespace: <target namespace>
 stringData:
-  host: <external ip or url resolvable by the cluster>
-  port: <external port, this usually defaults to 5432>
-  database: <desired database name>
-  username: <username to connect as>
-  password: <password to connect with>
+  host: "<external ip or url resolvable by the cluster>"
+  port: "<external port, this usually defaults to 5432>"
+  database: "<desired database name>"
+  username: "<username to connect as>"
+  password: "<password to connect with>"
 type: Opaque
 -----
 . Apply the postgresql configuration yaml to the cluster:

--- a/downstream/modules/platform/proc-create-secret-key-secret.adoc
+++ b/downstream/modules/platform/proc-create-secret-key-secret.adoc
@@ -1,0 +1,28 @@
+[id="create-secret-key-secret_{context}"]
+
+= Creating a secret key secret
+
+[role=_abstract]
+
+To migrate your data to {OperatorPlatform} on {OCPShort}, you must create a secret key that matches the secret key defined in the inventory file during your initial installation. Otherwise, the migrated data will remain encrypted and unusable after migration.
+
+.Procedure
+
+. Locate the old secret key in the inventory file you used to deploy AAP in your previous installation.
+. Create a yaml file for your secret key:
++
+-----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <resourcename>-secret-key
+  namespace: <target-namespace>
+stringData:
+  secret_key: <old-secret-key>
+type: Opaque
+-----
+. Apply the secret key yaml to the cluster:
++
+-----
+oc apply -f <secret-key.yml>
+-----

--- a/downstream/modules/platform/proc-find-delete-PVCs.adoc
+++ b/downstream/modules/platform/proc-find-delete-PVCs.adoc
@@ -18,4 +18,3 @@ oc get pvc -n <namespace>
 -----
 oc delete pvc -n <namespace> <pvc-name>
 -----
-+

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -13,4 +13,4 @@
 
 The installation process will begin. When installation is complete, a modal will appear notifying you that the {PlatformName} operator is installed in the specified namespace.
 
-* Click *View Operator* to view your newly installed {PlatformName} operator.
+* Click btn:[View Operator] to view your newly installed {PlatformName} operator.

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -2,14 +2,14 @@
 
 .Procedure
 . Log in to {OCP}.
-. Navigate to *Operators* -> *OperatorHub*.
-. Search for the {PlatformName} operator and click *Install*.
+. Navigate to menu:Operators[OperatorHub].
+. Search for the {PlatformName} operator and click btn:[Install].
 . Select an *Update Channel*:
 +
 * *stable-2.x*: deploys only one {HubName} or {ControllerName} instance and is suitable for most cases. The stable-2.x channel does not require administrator privileges and utilizes fewer resources because it only monitors a single namespace.
 * *stable-2.x-cluster-scoped*: deploys {HubName} and {ControllerName} across multiple namespaces in the cluster and requires administrator privileges for all namespaces in the cluster.
 . Select *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
-. Click *Install*.
+. Click btn:[Install].
 
 The installation process will begin. When installation is complete, a modal will appear notifying you that the {PlatformName} operator is installed in the specified namespace.
 

--- a/downstream/modules/platform/proc-operator-upgrade.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade.adoc
@@ -1,0 +1,16 @@
+[id="operator-upgrade{context}"]
+
+= Upgrading the {OperatorPlatform}
+
+
+[role=_abstract]
+
+To upgrade to the latest version of {OperatorPlatform} on {OCPShort}, do the following:
+
+.Prodedure
+. Log in to {OCPShort}.
+. Navigate to menu:Operators[Installed Operators].
+. Select the *Subscriptions* tab.
+. Under *Upgrade status*, click btn:[Upgrade Available].
+. Click btn:[Preview InstallPlan].
+. Click btn:[Approve].

--- a/downstream/modules/platform/proc-post-migration-cleanup.adoc
+++ b/downstream/modules/platform/proc-post-migration-cleanup.adoc
@@ -4,13 +4,13 @@
 
 [role=_abstract]
 
-Once your data migration is complete, you need to delete any InstanceGroups that are no longer required.
+After your data migration is complete, you must delete any InstanceGroups that are no longer required.
 
 .Procedure
 . Log in to {PlatformName} as the administrator with the password you created during migration.
 [NOTE]
 ====
-Note: If you did not create an administrator password during migration, one was automatically created for you. To locate this password, go to your project, select menu:Workloads[Secrets] and open controller-admin-password. From there you can copy the password and paste it into the {PlatformName} password field. 
+Note: If you did not create an administrator password during migration, one was automatically created for you. To locate this password, go to your project, select menu:Workloads[Secrets] and open controller-admin-password. From there you can copy the password and paste it into the {PlatformName} password field.
 ====
 . Select menu:Administration[InstanceGroups].
 . Select all InstanceGroups except controlplane and default.

--- a/downstream/modules/platform/proc-post-migration-cleanup.adoc
+++ b/downstream/modules/platform/proc-post-migration-cleanup.adoc
@@ -1,0 +1,17 @@
+[id="post-migration-cleanup_{context}"]
+
+= Post migration cleanup
+
+[role=_abstract]
+
+Once your data migration is complete, you need to delete any InstanceGroups that are no longer required.
+
+.Procedure
+. Log in to {PlatformName} as the administrator with the password you created during migration.
+[NOTE]
+====
+Note: If you did not create an administrator password during migration, one was automatically created for you. To locate this password, go to your project, select menu:Workloads[Secrets] and open controller-admin-password. From there you can copy the password and paste it into the {PlatformName} password field. 
+====
+. Select menu:Administration[InstanceGroups].
+. Select all InstanceGroups except controlplane and default.
+. Click btn:[Delete].

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -1,0 +1,51 @@
+[id="verify-network-connectivity_{context}"]
+
+= Verifying network connectivity
+
+[role=_abstract]
+
+To ensure successful migration of your data, verify that you have network connectivity from your new operator deployment to your old deployment database.
+
+.Prerequisites
+Take note of the host and port information from your existing deployment. This information is located in the postgres.py file located in the conf.d directory.
+
+.Procedure
+
+. Create a yaml file to verify the connection between your new deployment and your old deployment database:
++
+-----
+api.Version: v1
+kind: Pod
+metadata:
+    name: dbchecker
+    namespace: <namespace>
+spec:
+    -name: postgres
+    image: registry.redhat.io/rhel8/postgresql-12:latest
+-----
+. Apply the connection checker yaml file to your new project deployment:
++
+-----
+oc project ansible-automation-platform
+oc apply -f connetion_checker.yaml
+-----
+. Verify that the connection checker pod is running:
++
+-----
+oc get pods
+-----
+. Connect to a pod shell:
++
+-----
+oc rsh dbchecker
+-----
+. Once the shell session opens in the pod, verify that the new project can connect to your old project cluster:
++
+-----
+pg_isready -h <old-host-address> -p <old-port-number> -U awx
+-----
++
+.Example
+-----
+<old-host-address>:<old-port-number> - accepting connections
+-----

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -21,7 +21,7 @@ metadata:
     namespace: <namespace>
 spec:
     -name: postgres
-    image: registry.redhat.io/rhel8/postgresql-12:latest
+    image: registry.redhat.io/rhel8/postgresql-13:latest
 -----
 . Apply the connection checker yaml file to your new project deployment:
 +

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -18,11 +18,12 @@ apiVersion: v1
 kind: Pod
 metadata:
     name: dbchecker
-    namespace: <namespace>
 spec:
-containers:
-    -name: postgres
-    image: registry.redhat.io/rhel8/postgresql-13:latest
+  containers:
+    - name: dbchecker
+      image: registry.redhat.io/rhel8/postgresql-12:latest
+      command: ["sleep"]
+      args: ["600"]
 -----
 . Apply the connection checker yaml file to your new project deployment:
 +

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -14,12 +14,13 @@ Take note of the host and port information from your existing deployment. This i
 . Create a yaml file to verify the connection between your new deployment and your old deployment database:
 +
 -----
-api.Version: v1
+apiVersion: v1
 kind: Pod
 metadata:
     name: dbchecker
     namespace: <namespace>
 spec:
+containers:
     -name: postgres
     image: registry.redhat.io/rhel8/postgresql-13:latest
 -----

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -27,7 +27,7 @@ spec:
 +
 -----
 oc project ansible-automation-platform
-oc apply -f connetion_checker.yaml
+oc apply -f connection_checker.yaml
 -----
 . Verify that the connection checker pod is running:
 +

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -41,7 +41,7 @@ oc get pods
 -----
 oc rsh dbchecker
 -----
-. Once the shell session opens in the pod, verify that the new project can connect to your old project cluster:
+. After the shell session opens in the pod, verify that the new project can connect to your old project cluster:
 +
 -----
 pg_isready -h <old-host-address> -p <old-port-number> -U awx

--- a/downstream/titles/aap-operator-installation/docinfo.xml
+++ b/downstream/titles/aap-operator-installation/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Red Hat Ansible Automation Platform Operator Installation Guide</title>
+<title>Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.2</productnumber>
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -8,11 +8,11 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Red Hat Ansible Automation Platform Operator Installation Guide
+= Deploying the {OperatorPlatform} on {OCPShort}
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
-This guide helps you to understand the installation requirements and processes behind installing the {PlatformNameShort} operator on OpenShift Container Platform.
+This guide helps you to understand the installation, migration and upgrade requirements for deploying the {OperatorPlatform} on {OCPShort}.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
@@ -30,4 +30,6 @@ include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
 
-include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[leveloffset=+1]
+include::platform/assembly-aap-migration.adoc[leveloffset=+1]
+
+include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]


### PR DESCRIPTION
This bug addresses the work for https://issues.redhat.com/browse/AAP-2336 and the child tasks associated with it:

Changes in this pull request include:

Title change to "Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform"
Chapter 6: Migrating to the Ansible Automation Platform operator on OpenShift Container Platform 
Chapter 7: Upgrading the Ansible Automation Platform operator on OpenShift Container Platform

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP-2336/master.html