### PR TITLE
Updated navigator installation method

### DIFF
--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -17,26 +17,12 @@ You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from an RPM.
 
 .Procedure
 
-. Attach the {PlatformName} SKU.
-+
-----
-$ subscription-manager attach --pool=<sku-pool-id>
-----
+. Install {Navigator} using the following:
 
-. Enable the repository for RHEL 8.
-+
+[options="nowrap" subs="+quotes"]
 ----
-$ sudo subscription-manager repos --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
+sudo dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
 ----
-
-
-. Install {Navigator}.
-+
-----
-$ dnf install ansible-navigator
-----
-+
-
 
 .Verification
 

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -14,11 +14,22 @@ You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from an RPM.
 * You have installed RHEL 8 or later.
 * You registered your system with Red Hat Subscription Manager.
 
+[NOTE]
+====
+Ensure that you only install the navigator matching your current {PlatformName} environment.
+====
 
 .Procedure
 
-. Install {Navigator} with the following command:
+. Attach the {PlatformName} SKU:
+[options="nowrap" subs="+quotes"]
++
+----
+$ subscription-manager attach --pool=<sku-pool-id>
+----
 
+. Install {Navigator} with the following command:
++
 [options="nowrap" subs="+quotes"]
 ----
 $ sudo dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -32,7 +32,7 @@ $ subscription-manager attach --pool=<sku-pool-id>
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ sudo dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
+# dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
 ----
 
 .Verification

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -17,11 +17,11 @@ You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from an RPM.
 
 .Procedure
 
-. Install {Navigator} using the following:
+. Install {Navigator} with the following command:
 
 [options="nowrap" subs="+quotes"]
 ----
-sudo dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
 ----
 
 .Verification


### PR DESCRIPTION
Leaving ansible-autmoation-platform-2.1-for-rhel-8-x86_64-rpms enabled
causes installation to fail. A new installayion method was suggested.

Install Automation content navigator on RHEL Document update

https://issues.redhat.com/browse/AAP-4972