### PR TITLE
2.2 AAP-5095 Fix YAML field formatting in table (#462)

### DIFF
--- a/downstream/modules/platform/proc-create-keycloak-realm.adoc
+++ b/downstream/modules/platform/proc-create-keycloak-realm.adoc
@@ -39,13 +39,13 @@ spec:
 [cols="30% 60%",options="header]
 |====
 | *Field* | *Description*
-| metadata.name: | Set a unique value in metadata for the name of the configuration resource (CR).
-| metadata.namespace: | Set a unique value in metadata for the name of the configuration resource (CR).
-| metadata.labels.app: |Set labels to a unique value. This is used when creating the client CR.
-| metadata.labels.realm: | Set labels to a unique value. This is used when creating the client CR.
-| spec.realm.id: | Set the realm name and id. These must be the same.
-| spec.realm.realm: | Set the realm name and id. These must be the same.
-| spec.realm.displayname: | Set the name to display.
+| `metadata.name` | Set a unique value in metadata for the name of the configuration resource (CR).
+| `metadata.namespace` | Set a unique value in metadata for the name of the configuration resource (CR).
+| `metadata.labels.app` |Set labels to a unique value. This is used when creating the client CR.
+| `metadata.labels.realm` | Set labels to a unique value. This is used when creating the client CR.
+| `spec.realm.id` | Set the realm name and id. These must be the same.
+| `spec.realm.realm` | Set the realm name and id. These must be the same.
+| `spec.realm.displayname` | Set the name to display.
 |====
 
 . Click btn:[Create] and wait for the process to complete.


### PR DESCRIPTION
Backports #462 to 2.2
AAP-5095

There is a formatting error in the table describing YAML fields in the [Creating a Keycloak realm for AAP](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/red_hat_ansible_automation_platform_operator_installation_guide/index#proc-create-keycloak-realm_using-a-rhsso-operator) section of the Operator Installation guide.

The field names should be enclosed in single backticks.


