### PR TITLE
AAP-5052 Fix synclist repository link and UI reference

### DIFF
--- a/downstream/modules/automation-hub/proc-create-synclist.adoc
+++ b/downstream/modules/automation-hub/proc-create-synclist.adoc
@@ -4,7 +4,8 @@
 
 = Creating a synclist of Red Hat Certified collections
 
-You can create a synclist of curated Red Hat Certified collections in Automation Hub on cloud.redhat.com. Your synclist repository is located under menu[Automation Hub > Repo Management], which is updated whenever you choose to manage content within Red Hat Certified collections.
+You can create a synclist of curated Red Hat Certified collections in Automation Hub on cloud.redhat.com.
+Your synclist repository is located under menu:Automation Hub[Repo Management], which is updated whenever you choose to manage content within Red Hat Certified collections.
 
 By default, all Red Hat Certified collections are included in your initial organization synclist.
 


### PR DESCRIPTION
AAP-5052

Affects 
titles/hub/configuring-private-hub-rh-certified

[Creating a synclist of Red Hat Certified collections](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/assembly-synclists#proc-create-synclist)