### PR TITLE
Update broken hub link

### DIFF
--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -3,13 +3,15 @@
 [id="proc-set-community-remote"]
 = Configuring the community remote repository and syncing Ansible Galaxy collections
 
-You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local Automation Hub.
-By default, your local Automation Hub `community` repository directs to `https://galaxy.ansible.com/api/`.
+You can edit the *community* remote repository to sync chosen collections from Ansible Galaxy to your local {HubName}.
+By default, your local {HubName} `community` repository directs to `https://galaxy.ansible.com/api/`.
 
 .Prerequisites
 
-* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
-* You have a `requirements.yml` file that identifies those collections to sync from Ansible Galaxy. See example below.
+* You have *Modify Ansible repo content* permissions.
+See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
+* You have a `requirements.yml` file that identifies those collections to sync from Ansible Galaxy.
+See example below.
 
 .Requirements.yml example
 -----
@@ -21,19 +23,19 @@ collections:
 -----
 
 .Procedure
-. Log in to your local Automation Hub.
-. Navigate to menu:Repo Management[]].
+. Log in to your local {HubName}.
+. Navigate to menu:Repo Management[].
 . Click the *Remotes* tab.
 . In the *community* remote, click image:more_actions.png[More actions] and click btn:[Edit].
 . In the modal, click btn:[Browse] and locate the `requirements.yml` file on your local machine.
 . Click btn:[Save].
 
-The modal closes and returns you to the *Repo Management* page. 
-You can now sync collections identified in your `requirements.yml` file from Ansible Galaxy to your local Automation Hub.
+The modal closes and returns you to the *Repo Management* page.
+You can now sync collections identified in your `requirements.yml` file from Ansible Galaxy to your local {HubName}.
 
-. Click btn:[Sync] to sync collections from Ansible Galaxy and Automation Hub.
+. Click btn:[Sync] to sync collections from Ansible Galaxy and {HubName}.
 
-The *Sync status* notification updates to notify you of completion or failure of Ansible Galaxy collections sync to your Automation Hub.
+The *Sync status* notification updates to notify you of completion or failure of Ansible Galaxy collections sync to your {HubName}.
 
 .Verification
 

--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -8,7 +8,7 @@ By default, your local Automation Hub `community` repository directs to `https:/
 
 .Prerequisites
 
-* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
+* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
 * You have a `requirements.yml` file that identifies those collections to sync from Ansible Galaxy. See example below.
 
 .Requirements.yml example
@@ -22,17 +22,18 @@ collections:
 
 .Procedure
 . Log in to your local Automation Hub.
-. Navigate to *Repo Management*.
+. Navigate to menu:Repo Management[]].
 . Click the *Remotes* tab.
-. In the *community* remote, click image:more_actions.png[More actions] and click *Edit*.
-. In the modal, click *Browse* and locate the `requirements.yml` file on your local machine.
-. Click *Save*.
+. In the *community* remote, click image:more_actions.png[More actions] and click btn:[Edit].
+. In the modal, click btn:[Browse] and locate the `requirements.yml` file on your local machine.
+. Click btn:[Save].
 
-The modal will close and return you to the *Repo Management* page. You can now sync collections identified in your `requirements.yml` file from Ansible Galaxy to your local Automation Hub.
+The modal closes and returns you to the *Repo Management* page. 
+You can now sync collections identified in your `requirements.yml` file from Ansible Galaxy to your local Automation Hub.
 
-. Click *Sync* to sync collections from Ansible Galaxy and Automation Hub.
+. Click btn:[Sync] to sync collections from Ansible Galaxy and Automation Hub.
 
-The *Sync status* notification will update to notify you of completion or failure of Ansible Galaxy collections sync to your Automation Hub.
+The *Sync status* notification updates to notify you of completion or failure of Ansible Galaxy collections sync to your Automation Hub.
 
 .Verification
 

--- a/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
@@ -1,28 +1,32 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-set-rhcertified-remote"]
-= Configuring the rh-cerftified remote repository and syncing Red Hat Certified collections.
+= Configuring the rh-certified remote repository and syncing Red Hat Certified collections.
 
-You can edit the *rh-certified* remote repository to sync collections from Automation Hub hosted on cloud.redhat.com to your local Automation Hub. By default, your local Automation Hub `rh-certified` repository includes the URL for the entire group of Red Hat Certified Collections available on cloud.redhat.com. To only use those collections specified by your organization, you need to include a unique URL.
+You can edit the *rh-certified* remote repository to sync collections from {HubName} hosted on cloud.redhat.com to your local {HubName}.
+By default, your local {HubName} `rh-certified` repository includes the URL for the entire group of Red Hat Certified Collections available on cloud.redhat.com.
+To use only those collections specified by your organization, you must include a unique URL.
 
 .Prerequisites
 
-* You have *Modify Ansible repo content* permissions. See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/managing-user-access/index[Managing user access in Automation Hub] for more information on permissions.
-* You have retrieved the Sync URL and API Token from the Automation Hub hosted service on cloud.redhat.com.
+* You have *Modify Ansible repo content* permissions.
+See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
+* You have retrieved the Sync URL and API Token from the {HubName} hosted service on cloud.redhat.com.
 
 .Procedure
-. Log in to your local Automation Hub.
-. Navigate to *Repo Management*.
+. Log in to your local {HubName}.
+. Navigate to menu:Repo Management[].
 . Click the *Remotes* tab.
-. In the *rh-certified* remote, click image:more_actions.png[More actions] and click *Edit*.
+. In the *rh-certified* remote, click image:more_actions.png[More actions] and click btn:[Edit].
 . In the modal, paste the Sync URL and Token you acquired from cloud.redhat.com.
-. Click *Save*.
+. Click btn:[Save].
 
-The modal will close and return you to the *Repo Management* page. You can now sync collections between your organization synclist on cloud.redhat.com and your local Automation Hub.
+The modal closes and returns you to the *Repo Management* page.
+You can now sync collections between your organization synclist on cloud.redhat.com and your local {HubName}.
 
-. Click *Sync* to sync collections.
+. Click btn:[Sync] to sync collections.
 
-The *Sync status* notification will update to notify you of completion of Red Hat Certified collections sync.
+The *Sync status* notification updates to notify you of completion of Red Hat Certified collections sync.
 
 .Verification
 


### PR DESCRIPTION
Updating this again to replace version with attribute as the stated version
is rather old. This will be backported to 2.1 and 2.2.

Broken Links found for version 1.0 and 1.2 for ANSIBLE GALAXY COLLECTIONS IN AUTOMATION HUB

https://issues.redhat.com/browse/AAP-1625