### PR TITLE
2.2 AAP-5260 Add virtual appliance routing info

### DIFF
--- a/downstream/modules/aap-on-azure/proc-azure-update-route-tables.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-update-route-tables.adoc
@@ -47,10 +47,14 @@ After you have configured the routing rules, traffic is routed to and from {Plat
 
 .Outbound routing through virtual appliances
 
-If your organization uses Azure firewall services or third-party firewall appliances through a Virtual Appliance connection, you must configure routes to enable application management and automation against external resources.
+If your organization uses Azure firewall services or third-party firewall appliances through a Virtual Appliance connection, you must configure outbound connectivity from the managed application, to enable Red Hat to maintain your application and to enable automation against external resources.
+
+The easiest way to implement this is to create a firewall rule that allows all outbound traffic from port 443.
+
+If you choose not to allow all outbound traffic from  port 443, you must configure routes.
 
 * For Red Hat to manage and upgrade {AAPonAzureNameShort} and execute security patching, any machine in the Azure Kubernetes service (AKS) cluster must be allowed to submit a request to pull updates for containers used by {PlatformNameShort}.
-Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR block (`192.168.0.0/24`) of the {AAPonAzureNameShort} managed application to the following domains:
+Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR range of the {AAPonAzureNameShort} managed application to the following domains:
 
 ** `registry.redhat.io`
 ** `quay.io`

--- a/downstream/modules/aap-on-azure/proc-azure-update-route-tables.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-update-route-tables.adoc
@@ -43,5 +43,22 @@ aks-agentpool-<numbers>-routetable
 
 After you have configured the routing rules, traffic is routed to and from {PlatformNameShort} on Azure through your hub network.
 
+[#outbound-routing-virtual-appliances]
+
+.Outbound routing through virtual appliances
+
+If your organization uses Azure firewall services or third-party firewall appliances through a Virtual Appliance connection, you must configure routes to enable application management and automation against external resources.
+
+* For Red Hat to manage and upgrade {AAPonAzureNameShort} and execute security patching, any machine in the Azure Kubernetes service (AKS) cluster must be allowed to submit a request to pull updates for containers used by {PlatformNameShort}.
+Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR block (`192.168.0.0/24`) of the {AAPonAzureNameShort} managed application to the following domains:
+
+** `registry.redhat.io`
+** `quay.io`
+
+* You must also allow traffic from your firewall to any other external domain or IP address that you want {PlatformNameShort} to run automation jobs against.
+Otherwise, your firewall will block connectivity between {PlatformNameShort} and destinations for automation.
+
+== Additional resources
+
 For further information about adding routes to a route table in Azure, refer to link:https://docs.microsoft.com/en-us/azure/virtual-network/manage-route-table#create-a-route[Create a route] in the Microsoft Azure _Virtual network_ guide.
 


### PR DESCRIPTION
Backports https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/471 and https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/475 to 2.2
Affects Ansible on Azure guide
AAP-5260