### PR TITLE
2.2 AAP-5311 Update latest OCP version to 4.11 (#479)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -99,7 +99,7 @@
 // OpenShift attributes
 :OCP: Red Hat OpenShift Container Platform
 :OCPShort: OpenShift Container Platform
-:OCPLatest: 4.10
+:OCPLatest: 4.11
 :ODF: Red Hat OpenShift Data Foundation
 :ODFShort: OpenShift Data Foundation
 


### PR DESCRIPTION
Backports #479 AAP-5311 to `2.2`
Update the attribute representing the latest OpenShift release to 4.11

