### PR TITLE
AAP-5335 Fix ID for tools assembly

### DIFF
--- a/downstream/assemblies/dev-guide/assembly-tools-components.adoc
+++ b/downstream/assemblies/dev-guide/assembly-tools-components.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 
 
-[id=" stools"]
+[id="tools"]
 =  Tools and components
 
 


### PR DESCRIPTION
AAP-5335

Affects Platform Creator Guide (`/titles/dev-guide/`)

Chapter 4 isn't rendering on the customer portal: clicking on the chapter name in the left nav causes a 404-not-found error.
You can navigate to all other chapters from the left nav.

The local build is OK.

in the Pantheon prod build, you can scroll to the chapter, but clicking the chapter name in the left nav doesn't navigate to the chapter title.
Clicking all other chapters in the left nav brings you to the chapter.
