### PR TITLE
2.1 AAP-4844 Swapped file labels (#487)

### DIFF
--- a/downstream/modules/platform/proc-import-mesh-ca.adoc
+++ b/downstream/modules/platform/proc-import-mesh-ca.adoc
@@ -9,8 +9,8 @@ NOTE: The {PlatformNameShort} installation program generates a CA if you do not 
 .Procedure
 
 . Open the `inventory` file for editing.
-. Add the `mesh_ca_keyfile` variable and specify the full path to the CA certificate file (`.crt`).
-. Add the `mesh_ca_certfile` variable and specify the full path to the private RSA key (`.key`).
+. Add the `mesh_ca_keyfile` variable and specify the full path to the private RSA key (`.key`).
+. Add the `mesh_ca_certfile` variable and specify the full path to the CA certificate file (`.crt`).
 . Save the changes to the inventory file.
 
 .Example


### PR DESCRIPTION
Swapped file labels.

Reversed the file labels for keyfile and certificate variables

Documentation bug on 2.2. Importing a Certificate Authority (CA) certificate

https://issues.redhat.com/browse/AAP-4844