### PR TITLE
2.1 AAP-5335 Fix ID for tools assembly (#488)

### DIFF
--- a/downstream/assemblies/dev-guide/assembly-tools-components.adoc
+++ b/downstream/assemblies/dev-guide/assembly-tools-components.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 
 
-[id=" stools"]
+[id="tools"]
 =  Tools and components
 
 


### PR DESCRIPTION
Backports #488 to 2.1

AAP-5335

Affects Platform Creator Guide (`/titles/dev-guide/`)