### PR TITLE
2.2 AAP-5335 Fix ID for tools assembly (#488)

### DIFF
--- a/downstream/assemblies/dev-guide/assembly-tools-components.adoc
+++ b/downstream/assemblies/dev-guide/assembly-tools-components.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 
 
-[id=" stools"]
+[id="tools"]
 =  Tools and components
 
 


### PR DESCRIPTION
Backports https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/488 to 2.2

AAP-5335

Affects Platform Creator Guide (`/titles/dev-guide/`)