### PR TITLE
AAP-5465 User-configurable CIDR blocks in AAP on Azure (#505)

### DIFF
--- a/downstream/modules/aap-on-azure/con-aap-azure-network.adoc
+++ b/downstream/modules/aap-on-azure/con-aap-azure-network.adoc
@@ -2,7 +2,35 @@
 
 = Network
 
-{AAPonAzureNameShort} deploys its infrastructure into a Class C network range 192.168.0.0/24.
-You cannot change this range.
-To ensure successful network peering and communication between {AAPonAzureNameShort} and your existing networks, your enterprise network ranges must not overlap with this network range.
+You can configure the networking address range (CIDR block) for the VNet that your {AAPonAzureNameShort} application uses.
+You set the CIDR block for the application in a network configuration form when you deploy {AAPonAzureNameShort}.
+Plan your networking configuration before you deploy the {AAPonAzureNameShort} application, because you cannot change it after deployment.
+
+When you are planning your network configuration, bear the following in mind:
+
+* The managed application requires at least a /24 Vnet that is divided into four subnets. The subnets have minimum address spacing.
++
+[cols="a,a"]
+|===
+|Networking entity |Minimum CIDR Block
+
+|VNet |/24
+
+|Cluster subnet |/26
+
+|Gateway subnet |/28
+
+|Database subnet |/28
+
+|Private link subnet |/28
+|===
+
+* Ensure that the VNet range you configure does not intersect with the default CIDR block for AKS clusters (10.0.0.0/16).
+The Azure user interface does not prevent you entering this range, but using the default AKS CIDR block for your VNet causes networking issues.
+* To ensure successful network peering and communication between {AAPonAzureNameShort} and your existing networks, your enterprise network ranges must not overlap with the VNet network range.
+* If you do not have any existing Azure VNets, the Azure user interface suggests a default CIDR block and range for the VNet.
+Do not accept these defaults. Instead, use the network configuration that you have planned.
+
+For information about planning the network address range and completing the networking configuration form on deployment, refer to
+link:https://access.redhat.com/articles/6973251[Red Hat Ansible Automation Platform on Microsoft Azure VNet Preparation].
 

--- a/downstream/modules/aap-on-azure/con-aap-private-access.adoc
+++ b/downstream/modules/aap-on-azure/con-aap-private-access.adoc
@@ -15,5 +15,8 @@ No two Azure networking configurations are the same.
 To allow user access to your {PlatformNameShort} URLs, your organization will need to work with your Azure administrators to connect the private access deployment.
 ====
 
+The following diagram outlines the application resources and architecture that are deployed into the managed application resource group on a private deployment of {AAPonAzureNameShort} into your Azure subscription.
+The IP ranges change based on the networking address range you set on deployment.
+
 image::aap-on-azure-private-deployment.png[]
 

--- a/downstream/modules/aap-on-azure/con-aap-public-access.adoc
+++ b/downstream/modules/aap-on-azure/con-aap-public-access.adoc
@@ -8,6 +8,7 @@ No configuration is required to access {PlatformNameShort}.
 Users can navigate to the domain from the public internet and log in to the user interfaces.
 
 The following diagram outlines the application resources and architecture that are deployed into the managed application resource group on a public deployment of {AAPonAzureNameShort} into your Azure subscription.
+The IP ranges change based on the networking address range you set on deployment.
 
 image::aap-on-azure-public-deployment.png[]
 

--- a/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-az-hosted-vm.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-az-hosted-vm.adoc
@@ -9,13 +9,13 @@ Users can remotely log into the publicly accessible virtual machine from on-prem
 
 To access the {PlatformNameShort} web UIs on the Azure private network, users navigate to the URLs using the browser on the jumpbox VM.
 
-The DMZ VNet is connected to other Azure VNets through network peering, with routing rules established to send network traffic for 192.168.0.0/24 to the {PlatformNameShort} VNet.
+The DMZ VNet is connected to other Azure VNets through network peering, with routing rules established to send network traffic to the {PlatformNameShort} VNet.
 
 The following diagram shows the topology for an example configuration of private network access via an Azure virtual machine.
 
 image::aap-on-azure-private-nw-access-vm.png[]
 
-* For more information about perimeter (DMZ) networks, refer to link:https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/perimeter-networks[Perimenter Networks] in the Microsoft _Azure Cloud Adoption Framework_ documentation.
+* For more information about perimeter (DMZ) networks, refer to link:https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/perimeter-networks[Perimeter Networks] in the Microsoft _Azure Cloud Adoption Framework_ documentation.
 
 * For more information about jumpboxes, refer to
 link:https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/cloud-scale-analytics/architectures/connect-to-environments-privately#about-azure-bastion-host-and-jumpboxes[About Azure bastion host and jumpboxes]

--- a/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-vpn.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy-vpn.adoc
@@ -5,7 +5,7 @@
 If your organization requires that many users access {PlatformNameShort} over a private connection, or if your organization already uses VPNs or direct connections with Azure, then this approach might be suitable.
 
 In this configuration, your on-premises infrastructure is connected to Azure through a Network Application Gateway and has routing rules that can enable access to {PlatformNameShort} to any connected computer on the local network.
-The VNet connected to the Virtual Network Gateway is connected to other Azure VNets through network peering, with routing rules established to send network traffic for 192.168.0.0/24 to the {PlatformNameShort} VNet.
+The VNet connected to the Virtual Network Gateway is connected to other Azure VNets through network peering, with routing rules established to send network traffic to the {PlatformNameShort} VNet.
 
 With this configuration, users can access {PlatformNameShort} through the application URLs as if they were using the public access approach.
 

--- a/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-nw-private-deploy.adoc
@@ -3,7 +3,7 @@
 = Private deployments
 
 If you selected private access when deploying {AAPonAzureNameShort},
-then the DNS record issued to the {AAPonAzureName} application points to a private Class C network address: 192.168.0.68.
+then the DNS record issued to the {AAPonAzureName} application points to a private address within the CIDR block selected when the managed application was deployed.
 You must configure access to this address after you have created network peering.
 // This address is not accessible from external sources
 

--- a/downstream/modules/aap-on-azure/proc-azure-provisioning-aap.adoc
+++ b/downstream/modules/aap-on-azure/proc-azure-provisioning-aap.adoc
@@ -10,6 +10,9 @@ Before you fill in the form, decide whether you want to create a public or priva
 * Public deployments allow ingress to the {AAPonAzureNameShort} user interfaces over the public internet. No configuration is required to access the application URLs.
 * Private deployments are created in an isolated Azure VNet that blocks access from the public internet. To access {AAPonAzureNameShort} user interfaces, you must configure network peering and routing.
 
+You create the network configuration for the {AAPonAzureNameShort} VNet when you initiate the deployment.
+Refer to your network configuration plan before deploying the managed application. For information about planning your network configuration, see xref:con-aap-azure-network_aap-azure-intro[Networking configuration].
+
 Complete the form to provision {PlatformName} infrastructure and resources into your Azure tenant.
 
 . Enter values for your deployment in the following fields in the form:
@@ -26,10 +29,12 @@ The _Administrator Password_ must contain at least 8 characters, and must includ
 +
 Keep this resource group isolated from other resource groups, including the _Resource Group_ where you will deploy the managed application.
 . Store the information that you entered in the form in a secure place. You will need to provide the _Administrator password_ to access {ControllerName} and private {HubName}.
-. Click *Review + Create*.
+. Click btn:[Next]
+. Follow the steps in link:https://access.redhat.com/articles/6973251[Red Hat Ansible Automation Platform on Microsoft Azure VNet Preparation] to configure your network configuration.
+. Click btn:[Review + Create].
 . If the information you entered in the form is valid, the window displays *Validation Passed*.
 . Select *I agree* to accept the Co-Admin Access Permissions terms and conditions.
-. Click *Create* to begin the provisioning process for the application.
+. Click btn:[Create] to begin the provisioning process for the application.
 
 The application will begin provisioning.
 

--- a/downstream/modules/aap-on-azure/proc-peer-vwan-hub-to-aap.adoc
+++ b/downstream/modules/aap-on-azure/proc-peer-vwan-hub-to-aap.adoc
@@ -17,10 +17,10 @@ Before peering, you must connect a hub network, and at least one spoke network, 
 . Navigate to the *Virtual Network Connections* page for the VWAN that you want to peer with your {PlatformNameShort} instance.
 . To create a connection between the VWAN hub and your {PlatformNameShort} instance, use the following settings:
 ** *Connection Name*: _<Ansible_Automation_Platform_connection_name>_
-** *Hubs*: Select one or more VWAN hub networks that the managed application VNET will peer with.
+** *Hubs*: Select one or more VWAN hub networks that the managed application VNet will peer with.
 ** *Subscription*: Select the subscription where {AAPonAzureNameShort} has been deployed.
 ** *Resource group*: The managed resource group of the managed application. It is typically prefixed with “mrg-”.
-** *Virtual network*: The VNET of the managed application. There is only one VNET in the managed resource group.
+** *Virtual network*: The VNet of the managed application. There is only one VNet in the managed resource group.
 ** *Propagate to none*: _No_
 ** *Associate Route Table*: Select the default route table or the appropriate route table that your organization has configured for VWAN. 
 ** *Propagate to Route Tables*: Select one or more default route tables or the appropriate route table that your organization has configured for VWAN. 


### PR DESCRIPTION
Backports #505 to `2.1`

AAP-5465
Affects Ansible on Azure guide (/titles/aap-on-azure/)

In previous versions of the Azure docs, the CIDR range for the VNET was fixed.
Users can now configure the VNET CIDR block for their AAP on Azure managed application.