### PR TITLE
2.1 AAP-1939: Update proxy support docs on AAP installer (#232)

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-known-proxies.adoc
+++ b/downstream/assemblies/platform/assembly-configure-known-proxies.adoc
@@ -5,18 +5,19 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="assembly-configuring-known-proxies"]
-= Configuring known proxies
+= Known proxies
 
 :context: known-proxies
 
-
 [role="_abstract"]
-You can configure a list of known proxies that are allowed to reach your {ControllerName}. Load balancers and hosts that are not on the list will result in a rejected request.
 
-include::platform/con-known-proxies.adoc[leveloffset=+1]
-
+include::platform/con-known-proxies.adoc[leveloffset=+2]
 
 include::platform/proc-configure-known-proxies.adoc[leveloffset=+2]
+
+
+
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-configuring-proxy-support.adoc
+++ b/downstream/assemblies/platform/assembly-configuring-proxy-support.adoc
@@ -10,8 +10,10 @@ ifdef::context[:parent-context: {context}]
 :context: configuring-proxy-support
 
 [role="_abstract"]
-You can configure {PlatformName} to communicate with traffic using a proxy. This section describes the supported proxy configurations and how to set them up.
+You can configure {PlatformName} to communicate with traffic using a proxy. Proxy servers act as an intermediary for requests from clients seeking resources from other servers. A client connects to the proxy server, requesting some service or available resource from a different server, and the proxy server evaluates the request as a way to simplify and control its complexity. The following sections describe the supported proxy configurations and how to set them up.
 
+
+include::platform/proc-enable-proxy-support.adoc[leveloffset=+1]
 
 include::assembly-configure-known-proxies.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/con-known-proxies.adoc
+++ b/downstream/modules/platform/con-known-proxies.adoc
@@ -1,15 +1,17 @@
 
 [id="con-known-proxies_{context}"]
 
-= Known proxies
+= About known proxies
 
 
 [role="_abstract"]
 
 When Tower is configured with `REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR', 'REMOTE_HOST']`, it assumes that the value of `X-Forwarded-For` has originated from the proxy/load balancer sitting in front of Tower. In a scenario where Tower is still reachable without use of the proxy/load balancer or when the proxy does not validate the header, `X-Forwarded-For` can be spoofed fairly easily to fake the originating IP addresses. Using `HTTP_X_FORWARDED_FOR` in the `REMOTE_HOST_HEADERS` setting poses a vulnerability that essentially gives users access to certain resources that they should not have.
 
-.Example vulnerabilities:
+To avoid this, you can configure a list of known proxies that are allowed using the *PROXY_IP_ALLOWED_LIST* field in the settings menu on your {ControllerName}. Load balancers and hosts that are not on the known proxies list will result in a rejected request.
 
-* The host config key for a job template
-* The hostname or ansible_(ssh_)host of a host in the job template's linked inventory
-* The url of the job template's provisioning callback
+//.Example vulnerabilities:
+
+//* The host config key for a job template
+//* The hostname or ansible_(ssh_)host of a host in the job template's linked inventory
+//* The url of the job template's provisioning callback

--- a/downstream/modules/platform/proc-configure-known-proxies.adoc
+++ b/downstream/modules/platform/proc-configure-known-proxies.adoc
@@ -3,34 +3,29 @@
 
 = Configuring known proxies
 
-
 [role="_abstract"]
-You can configure a list of "known proxies" that are allowed using the `PROXY_IP_WHITELIST` setting via the settings API. Load balancers and hosts that are not on the list will result in a rejected request.
+
+To configure a list of known proxies for your {ControllerName}, add the proxy IP addresses to the *PROXY_IP_ALLOWED_LIST* field in the settings page for your {ControllerName}.
+
+.Procedure
+
+. On your {ControllerName}, navigate to *Settings* > *Miscellaneous System*.
+. In the *PROXY_IP_ALLOWED_LIST* field, enter IP addresses that are allowed to connect to your {ControllerName}, following the syntax in the example below:
++
+.Example *PROXY_IP_ALLOWED_LIST* entry
+----
+[
+  "example1.proxy.com:8080",
+  "example2.proxy.com:8080"
+]
+----
 
 
 [IMPORTANT]
 ====
-* `PROXY_IP_WHITELIST` requires proxies in the list are properly sanitizing header input and correctly setting an ``X-Forwarded-For`` value equal to the real source IP of the client. {ControllerNameStart} can rely on the IP addresses and hostnames in `PROXY_IP_WHITELIST` to provide non-spoofed values for the `X-Forwarded-For` field.
+* `PROXY_IP_ALLOWED_LIST` requires proxies in the list are properly sanitizing header input and correctly setting an ``X-Forwarded-For`` value equal to the real source IP of the client. {ControllerNameStart} can rely on the IP addresses and hostnames in `PROXY_IP_ALLOWED_LIST` to provide non-spoofed values for the `X-Forwarded-For` field.
 * Do not configure `HTTP_X_FORWARDED_FOR` as an item in `REMOTE_HOST_HEADERS`unless *all* of the following conditions are satisfied:
 ** You are using a proxied environment with ssl termination;
 ** The proxy provides sanitization or validation of the `X-Forwarded-For` header to prevent client spoofing;
-** `/etc/tower/conf.d/remote_host_headers.py` defines `PROXY_IP_WHITELIST` that contains only the originating IP addresses of trusted proxies or load balancers.
+** `/etc/tower/conf.d/remote_host_headers.py` defines `PROXY_IP_ALLOWED_LIST` that contains only the originating IP addresses of trusted proxies or load balancers.
 ====
-
-
-
-.Procedure
-
-. On the {ControllerName} node, open `/etc/tower/conf.d/remote_host_headers.py` using a text editor.
-
-
-
-[role="_additional-resources"]
-.Additional resources
-////
-Optional. Delete if not used.
-////
-* A bulleted list of links to other material closely related to the contents of the procedure module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/downstream/modules/platform/proc-configuring-reverse-proxy.adoc
+++ b/downstream/modules/platform/proc-configuring-reverse-proxy.adoc
@@ -7,19 +7,18 @@
 = Configuring a reverse proxy
 
 [role="_abstract"]
-You can support a reverse proxy server configuring using a header field for `HTTP_X_FORWARDED_FOR`. The ``X-Forwarded-For`` (XFF) HTTP header field identifies the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer.
+You can support a reverse proxy server configuration by adding `HTTP_X_FORWARDED_FOR` to the *REMOTE_HOST_HEADERS* field in your {ControllerName} settings. The ``X-Forwarded-For`` (XFF) HTTP header field identifies the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer.
 
 
 .Procedure
 
-. On the {ControllerName} node, open  `remote_host_headers.py` in a text editor:
+. On your {ControllerName}, navigate to *Settings* > *Miscellaneous System*.
+. In the *REMOTE_HOST_HEADERS* field, enter the following values:
 +
------
-$ vi /etc/tower/conf.d/remote_host_headers.py`
------
-+
-. Setup `REMOTE_HOST_HEADERS` as follows:
-+
------
-`REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR', 'REMOTE_HOST']`
------
+----
+[
+  "HTTP_X_FORWARDED_FOR",
+  "REMOTE_ADDR",
+  "REMOTE_HOST"
+]
+----

--- a/downstream/modules/platform/proc-enable-proxy-support.adoc
+++ b/downstream/modules/platform/proc-enable-proxy-support.adoc
@@ -1,0 +1,23 @@
+
+[id="proc-enable-proxy-support_{context}"]
+
+= Enable proxy support
+
+To provide proxy server support, {ControllerName} handles proxied requests (such as ALB, NLB , HAProxy, Squid, Nginx and tinyproxy in front of {ControllerName}) via the *REMOTE_HOST_HEADERS* list variable in the {ControllerName} settings. By default, *REMOTE_HOST_HEADERS* is set to `["REMOTE_ADDR", "REMOTE_HOST"]`.
+
+To enable proxy server support, edit the *REMOTE_HOST_HEADERS* field in the settings page for your {ControllerName}:
+
+.Procedure
+
+. On your {ControllerName}, navigate to *Settings* > *Miscellaneous System*.
+. In the *REMOTE_HOST_HEADERS* field, enter the following values:
++
+----
+[
+  "HTTP_X_FORWARDED_FOR",
+  "REMOTE_ADDR",
+  "REMOTE_HOST"
+]
+----
+
+{ControllerNameStart} determines the remote host’s IP address by searching through the list of headers in *REMOTE_HOST_HEADERS* until the first IP address is located.


### PR DESCRIPTION
Backport AAP-1939 #232 to `2.1`
Affects installation guide (`/titles/aap-installation-guide/`)
