### PR TITLE
2.2 AAP-5145 Fix codeblock delimiter and leveloffset (#468)

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-known-proxies.adoc
+++ b/downstream/assemblies/platform/assembly-configure-known-proxies.adoc
@@ -11,9 +11,9 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-include::platform/con-known-proxies.adoc[leveloffset=+2]
+include::platform/con-known-proxies.adoc[leveloffset=+1]
 
-include::platform/proc-configure-known-proxies.adoc[leveloffset=+2]
+include::platform/proc-configure-known-proxies.adoc[leveloffset=+1]
 
 
 

--- a/downstream/assemblies/platform/assembly-supported-attributes-custom-notifications.adoc
+++ b/downstream/assemblies/platform/assembly-supported-attributes-custom-notifications.adoc
@@ -211,7 +211,8 @@ In addition to the job attributes, there are some other variables that can be ad
  'finished': False,
  'credential': 'Stub credential',
  'created_by': 'admin'}
- -----
+-----
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -26,3 +26,4 @@ include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
 include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
 include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset=+1]
 include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Backports #468  to 2.2
Affects installation guide
AAP-5145

The [Installation guide preface](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/pr01) on access.redhat.com is showing a leveloffset artefact.