### PR TITLE
AAP-4360 - Add section & info for AAP Operator to release notes for 2.2

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -16,6 +16,9 @@ include::topics/catalog-05-2022.adoc[leveloffset=+2]
 
 include::topics/controller-420.adoc[leveloffset=+2]
 
+include::topics/operator-220.adoc[leveloffset=+2]
+
+
 [[anchor-february-2022-release]]
 == February 2022 release
 

--- a/release-notes/topics/operator-220.adoc
+++ b/release-notes/topics/operator-220.adoc
@@ -1,0 +1,14 @@
+[[operator-220-intro]]
+= Automation Platform Operator 2.2
+
+The Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
+
+.Deprecated functionality
+
+* The `image_pull_secret` (string) variable has been deprecated and will no longer be supported in a future release. You should now use the `image_pull_secrets` (array) variable on the spec when creating an Automation Hub or Automation Controller custom resource. This new variable allows you to specify multiple pull secrets as an array, for example:
+-----
+spec:
+  image_pull_secrets:
+    - redhat-operators-pull-secret
+    - my-other-pull-secret
+-----


### PR DESCRIPTION
This PR addresses the changes requested in https://issues.redhat.com/browse/AAP-4360.

Changes in this pull request include the following:

- Adding a section for Operator to the release notes for v2.2.
- Adding information regarding deprecation of the image_pull_secret variable.

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP4360/master.html