### PR TITLE
AAP-2948 Add step to activate AAP repo

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -8,7 +8,7 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 
 .Procedure
 
-. First, in your terminal, run the following command to activate your Ansible Automation Platform repo:
+. In your terminal, run the following command to activate your Ansible Automation Platform repo:
 +
 ----
 $ ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -4,14 +4,17 @@
 
 You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-attaching-subscriptions_planning/[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
 
-NOTE: You must have valid subscriptions attached on the host before installing `ansible-builder`.
+[NOTE]
+====
+ You must have valid subscriptions attached on the host before installing `ansible-builder`.
+ ====
 
 .Procedure
 
 . In your terminal, run the following command to activate your {PlatformNameShort} repo:
 +
 ----
-$ ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
+$ dnf config-manager --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms 
 ----
 +
 . Then enter the following command to install {Builder}:

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -8,13 +8,13 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 
 .Procedure
 
-. In your terminal, run the following command to activate your Ansible Automation Platform repo:
+. In your terminal, run the following command to activate your {PlatformNameShort} repo:
 +
 ----
 $ ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
 ----
 +
-. Then run the following command:
+. Then enter the following command to install {Builder}:
 +
 ----
 $ dnf install ansible-builder

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -8,7 +8,13 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 
 .Procedure
 
-. In your terminal, run the following command:
+. First, in your terminal, run the following command to activate your Ansible Automation Platform repo:
++
+----
+$ ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms
+----
++
+. Then run the following command:
 +
 ----
 $ dnf install ansible-builder


### PR DESCRIPTION
Added a new first step in the **Ansible Builder Guide** in "Chapt 2.1 Installing Ansible Builder"  to activate the AAP repo. 