### PR TITLE
AAP4482 added missing steps for configuring a Container Registry

### DIFF
--- a/downstream/modules/builder/proc-pull-protected-registry.adoc
+++ b/downstream/modules/builder/proc-pull-protected-registry.adoc
@@ -6,8 +6,13 @@ To pull container images from a password or token-protected registry, create a c
 
 .Procedure
 . Navigate to {ControllerName}
-. In the side-menu bar, click *Resources* > *Credentials*.
-. Click *Add* to create a new credential.
-. Supply an authorization URL, username, and password. Click *Save*.
+. In the side-menu bar, click menu:Resources[Credentials].
+. Click btn:[Add] to create a new credential.
+. Enter an authorization *Name*, *Description*, and *Organization*.
+. Select the *Credential Type*.
+. Enter the *Authentication URL*. This is the container registry address.
+. Enter the *Username* and *Password or Token* required to log in to the container registry.
+. Optionally, select *Verify SSL* to enable SSL verification.
+. Click btn:[Save].
 
 For more information, please reference the Pulling from Protected Registries section of the Execution Environment documentation.

--- a/downstream/modules/builder/proc-pull-protected-registry.adoc
+++ b/downstream/modules/builder/proc-pull-protected-registry.adoc
@@ -2,6 +2,8 @@
 
 = Pulling from a protected registry
 
+Previously, you were required to deploy a registry to store execution environment images. On {PlatformNameShort} 2.0 and later, it is assumed that you already have a container registry up and running. Therefore, you are only required to add the credentials of a container registry of your choice to store execution environment images.
+
 To pull container images from a password or token-protected registry, create a credential in {ControllerName}:
 
 .Procedure


### PR DESCRIPTION
This PR addresses the changes requested in https://issues.redhat.com/browse/AAP-4482.

Changes in this pull request include:
Added info for locating the admin password to the procedure in Section 3.2.

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP4482/master.html