### PR TITLE
AAP-2458 - removed references to pip install

### DIFF
--- a/downstream/modules/builder/con-definition-dependencies.adoc
+++ b/downstream/modules/builder/con-definition-dependencies.adoc
@@ -21,9 +21,9 @@ collections:
 
 == Python
 
-The `python` entry in the definition file points to a valid requirements file for the `pip install -r ...` command.
+The `python` entry in the definition file points to a valid requirements file for the installation.
 
-The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies. It may be listed as a relative path from the directory of the {ExecEnvNameSing} definition’s folder, or an absolute path. The contents of a `requirements.txt` file should be formatted like the following example, similar to the standard output from a `pip freeze` command:
+The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies. It may be listed as a relative path from the directory of the {ExecEnvNameSing} definition’s folder, or an absolute path. The contents of a `requirements.txt` file should be formatted like the following example:
 
 .A `requirements.txt` file for Python
 [example]


### PR DESCRIPTION
This PR addresses the changes requested in https://issues.redhat.com/browse/AAP-2458.

Changes in this pull request include:
Removed references to pip installation.

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP2458/master.html