### PR TITLE
AAP-2948 Add step to activate AAP repo (#546)

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -4,10 +4,7 @@
 
 You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-attaching-subscriptions_planning/[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
 
-[NOTE]
-====
- You must have valid subscriptions attached on the host before installing `ansible-builder`.
- ====
+NOTE: You must have valid subscriptions attached on the host before installing `ansible-builder`.
 
 .Procedure
 

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -4,11 +4,20 @@
 
 You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-attaching-subscriptions_planning/[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
 
-NOTE: You must have valid subscriptions attached on the host before installing `ansible-builder`.
+[NOTE]
+====
+ You must have valid subscriptions attached on the host before installing `ansible-builder`.
+ ====
 
 .Procedure
 
-. In your terminal, run the following command:
+. In your terminal, run the following command to activate your {PlatformNameShort} repo:
++
+----
+$ dnf config-manager --enable ansible-automation-platform-2.1-for-rhel-8-x86_64-rpms 
+----
++
+. Then enter the following command to install {Builder}:
 +
 ----
 $ dnf install ansible-builder


### PR DESCRIPTION
Cherry-picked updates in original [PR #546](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/546) to 2.1 branch. 

* AAP-2948 Add step to activate AAP repo

* AAP-2948 Tweaked wording of new first step

* AAP-2948 Additional tweaks to instructions

* AAP-2948 Update command in step1 and syntax for note