### PR TITLE
AAP-2948A Return note syntax to original

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -4,10 +4,7 @@
 
 You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-attaching-subscriptions_planning/[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
 
-[NOTE]
-====
- You must have valid subscriptions attached on the host before installing `ansible-builder`.
- ====
+NOTE: You must have valid subscriptions attached on the host before installing `ansible-builder`.
 
 .Procedure
 


### PR DESCRIPTION
In the original [PR](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/546), the note before the procedures was updated to match syntax suggested in other product's docs (brackets and = signs), but this rendered the content incorrectly. Returned the note back to original and note displays properly.