### PR TITLE
2.2 AAP-1505 Update docs for using custom SSL certificates in OCP

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -36,7 +36,11 @@ When an instance of {ControllerName} is removed, the associated PVCs are not aut
 
 You can proceed with configuring the instance using either the Form View or YAML view.
 
-include::platform/proc-controller-route-options.adoc[leveloffset=+2]
+
+include::platform/proc-creating-controller-form-view.adoc[leveloffset=+2]
+include::platform/proc-configuring-the-controller-image-pull-policy.adoc[leveloffset=+2]
+include::platform/proc-configuring-controller-ldap-security.adoc[leveloffset=+2]
+include::platform/proc-configuring-controller-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 
 Once you have configured your {ControllerName} operator, click *Create* at the bottom of the form view. {OCP} will now create the pods. This may take a few minutes.

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -38,7 +38,7 @@ You can proceed with configuring the instance using either the Form View or YAML
 
 
 include::platform/proc-creating-controller-form-view.adoc[leveloffset=+2]
-include::platform/proc-configuring-the-controller-image-pull-policy.adoc[leveloffset=+2]
+include::platform/proc-configuring-controller-image-pull-policy.adoc[leveloffset=+2]
 include::platform/proc-configuring-controller-ldap-security.adoc[leveloffset=+2]
 include::platform/proc-configuring-controller-route-options.adoc[leveloffset=+2]
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]

--- a/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
@@ -1,0 +1,28 @@
+[id="proc-configuring-controller-image-pull-policy_{context}"]
+
+= Configuring your controller image pull policy
+
+
+. Under *Image Pull Policy*, click on the radio button to select
+* *Always* 
+* *Never* 
+* *IfNotPresent*
+. To display the option under *Image Pull Secrets*, click the arrow.
+.. Click *+* beside *Add Image Pull Secret* and enter a value.
+. To display fields under the *Web container resource requirements* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display fields under the *Task container resource requirements* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display fields under the *EE Control Plane container resource requirements* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display fields under the *PostgreSQL init container resource requirements (when using a managed service)* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display fields under the *Redis container resource requirements* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display fields under the *PostgreSQL container resource requirements (when using a managed instance)** drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. To display the *PostgreSQL container storage requirements (when using a managed instance)* drop-down list, click the arrow.
+.. Under *Limits*, and *Requests*, enter values for *CPU cores*, *Memory*, and *Storage*.
+. Under Replicas, enter the number of instance replicas.
+. Under *Remove used secrets on instance removal*, select *true* or *false*. The default is false.
+.  Under *Preload instance with data upon creation*, select *true* or *false*. The default is true.

--- a/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
@@ -1,0 +1,13 @@
+[id="proc_configuring-controller-ldap-security_{context}"]
+
+= Configuring your controller LDAP security
+
+
+. Under *LDAP Certificate Authority Trust Bundle* click the drop-down menu and select a secret.
+. Under *LDAP Password Secret*, click the drop-down menu and select a secret.
+. Under *EE Images Pull Credentials Secret*, click the drop-down menu and select a secret.
+. Under *Bundle Cacert Secret*, click the drop-down menu and select a secret.
+. Under *Service Type*, click the drop-down menu and select 
+* *ClusterIP*
+* *LoadBalancer*
+* *NodePort*

--- a/downstream/modules/platform/proc-configuring-controller-route-options.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-route-options.adoc
@@ -1,11 +1,12 @@
-[id="proc-controller-route-options_{context}"]
+[id="proc-configuring-controller-route-options_{context}"]
 
-= Configure your {ControllerName} operator route options
+= Configuring your {ControllerName} operator route options
 
 The {PlatformName} operator installation form allows you to further configure your {ControllerName} operator route options under *Advanced configuration*.
 
 . Click *Advanced configuration*.
 . Under *Ingress type*, click the drop-down menu and select *Route*.
 . Under *Route DNS host*, enter a common host name that the route answers to.
-. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
+. Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*. For most instances *Edge* should be selected.
 . Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
+. Under *Enable persistence for __/var/lib/projects__ directory* select either true or false by moving the slider.

--- a/downstream/modules/platform/proc-creating-controller-form-view.adoc
+++ b/downstream/modules/platform/proc-creating-controller-form-view.adoc
@@ -1,0 +1,18 @@
+[id="proc_creating-controller-form-view_{context}"]
+
+= Creating your {ControllerName} form-view
+
+
+. Ensure *Form view* is selected. It should be selected by default.
+. Enter the name of the new controller.
+. Optional: Add any labels necessary.
+. Click *Advanced configuration*.
+. Enter *Hostname* of the instance. The hostname is optional. The default hostname will be generated based upon the deployment name you have selected.
+. Enter the *Admin account username*.
+. Enter the *Admin email address*.
+. Under the *Admin password secret* drop-down menu, select the secret.
+. Under *Database configuration secret* drop-down menu, select the secret.
+. Under *Old Database configuration secret* drop-down menu, select the secret.
+. Under *Secret key secret* drop-down menu, select the secret.
+. Under *Broadcast Websocket Secret* drop-down menu, select the secret.
+. Enter any *Service Account Annotations* necessary.

--- a/downstream/modules/platform/proc-hub-ingress-options.adoc
+++ b/downstream/modules/platform/proc-hub-ingress-options.adoc
@@ -1,8 +1,8 @@
 [id="proc-hub-ingress-options_{context}"]
 
-= Configure the Ingress type for your {HubName} operator
+= Configuring the Ingress type for your {ControllerName} operator
 
-The {PlatformName} operator installation form allows you to further configure your {HubName} operator Ingress under *Advanced configuration*.
+The {PlatformName} operator installation form allows you to further configure your {ControllerName} operator Ingress under *Advanced configuration*.
 
 . Click *Advanced Configuration*.
 . Under *Ingress type*, click the drop-down menu and select *Ingress*.

--- a/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
+++ b/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
@@ -1,0 +1,69 @@
+////
+Base the file name and the ID on the module title. For example:
+* file name: proc-doing-procedure-a.adoc
+* ID: [id="proc-doing-procedure-a_{context}"]
+* Title: = Doing procedure A
+
+The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken. The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in an assembly file.
+
+Indicate the module type in one of the following
+ways:
+Add the prefix proc- or proc_ to the file name.
+Add the following attribute before the module ID:
+////
+:_content-type: PROCEDURE
+
+[id="proc_configuring-tls-with-aap-operator_{context}"]
+= configuring-tls-with-aap-operator
+////
+Start the title of a procedure module with a gerund, such as Creating, Installing, or Deploying.
+////
+
+Write a short introductory paragraph that provides an overview of the module. The introduction should include what the module will help the user do and why it will be beneficial to the user. Include key words that relate to the module to maximize search engine optimization.
+
+.Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts the steps in this module.
+* Prerequisites can be full sentences or sentence fragments; however, prerequisite list items must be parallel.
+
+////
+If you have only one prerequisite, list it as a single bullet point.
+Do not write prerequisites in the imperative.
+You can include links to more information about the prerequisites.
+Delete the .Prerequisites section title and bullets if the module has no prerequisites.
+////
+
+.Procedure
+
+. Make each step an instruction.
+
+. Include one command or action for each step with the exception of simple follow-step, for example:
+.. Do this thing and then select *Next*.
+.. Do this other thing and then select *Next*.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+.Verification
+////
+Delete this section if it does not apply to your module. Provide the user with verification methods for the procedure, such as expected output or commands that confirm success or failure.
+////
+
+. Provide an example of expected command output or a pop-up window that the user receives when the procedure is successful.
+
+. List actions for the user to complete, such as entering a command, to determine the success or failure of the procedure.
+
+. Make each step an instruction.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the verification includes only one step.
+
+[role="_additional-resources"]
+.Additional resources
+////
+Optional. Delete if not used.
+////
+* A bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+


### PR DESCRIPTION
Backports #554 and #558 to `2.2`
Affects operator installation guide (`/titles/aap-operator-installation/`)