### PR TITLE
2.2 Minor last minute correction to AAP-3675 (#575)

### DIFF
--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -6,7 +6,7 @@
 . Search for the {PlatformName} operator and click *Install*.
 . Select an *Update Channel*:
 +
-* *stable-2.x*: deploys only one {HubName} or {ControllerName} instance and is suitable for most cases. The stable-2.x channel does not require administrator privileges and utilizes fewer resources because it only monitors a single namespace.
+* *stable-2.x*: installs a namespace-scoped operator, which limits deployments of {HubName} and {ControllerName} instances to the namespace the operator is installed in. This is suitable for most cases. The stable-2.x channel does not require administrator privileges and utilizes fewer resources because it only monitors a single namespace.
 * *stable-2.x-cluster-scoped*: deploys {HubName} and {ControllerName} across multiple namespaces in the cluster and requires administrator privileges for all namespaces in the cluster.
 . Select *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
 . Click *Install*.


### PR DESCRIPTION
Backports #575 to 2.2
Affects Operator guide
* Minor last minute correction to AAP-3675
* AAP-3675A - Fixed description of stable-2.x channel