### PR TITLE
AAP-2336 Fix xref issues

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -1,7 +1,7 @@
 
 ifdef::context[:parent-context: {context}]
 
-[id="operator-upgrade_{context}"]
+[id="operator-upgrade"]
 
 = Upgrading {OperatorPlatform} on {OCPShort}
 

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -1,7 +1,7 @@
 
 ifdef::context[:parent-context: {context}]
 
-[id="operator-upgrade"]
+[id="operator-upgrade_{context}"]
 
 = Upgrading {OperatorPlatform} on {OCPShort}
 

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -8,5 +8,5 @@ Before migrating your current {PlatformNameShort} deployment to {OperatorPlatfor
 
 [NOTE]
 ====
-If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_{context}[Creating a secret key secret] and xref:create-postresql-secret_{context}[Creating a postgresql configuration secret] for both and then proceed to xref:aap-migration_{context}[Migrating data to the {PlatformNameShort} Operator].
+If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_aap-migration[Creating a secret key secret] and xref:create-postresql-secret_aap-migration[Creating a postgresql configuration secret] for both and then proceed to xref:aap-migration_aap-migration[Migrating data to the {PlatformNameShort} Operator].
 ====

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -8,5 +8,5 @@ Before migrating your current {PlatformNameShort} deployment to {OperatorPlatfor
 
 [NOTE]
 ====
-If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_aap-migration[Creating a secret key secret] and xref:create-postresql-secret_aap-migration[Creating a postgresql configuration secret] for both and then proceed to xref:aap-migration_aap-migration[Migrating data to the {PlatformNameShort} Operator].
+If you are migrating both {ControllerName} and {HubName} instances, repeat the steps in xref:create-secret-key-secret_aap-migration[Creating a secret key secret] and xref:create-postresql-secret_aap-migration[Creating a postgresql configuration secret] for both and then proceed to xref:aap-data-migration_aap-migration[Migrating data to the {PlatformNameShort} Operator].
 ====

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref:operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
+{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref:upgrading-operator_operator-upgrade[Upgrading the {OperatorPlatform}] procedure.
 
 If you are using a version of {OCPShort} that is not supported by the version of {PlatformName} to which you are upgrading, you must upgrade your {OCPShort} cluster to a supported version prior to upgrading.
 

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref::operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
+{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref:operator-upgrade_{context}[Upgrading the {OperatorPlatform}] procedure.
 
 If you are using a version of {OCPShort} that is not supported by the version of {PlatformName} to which you are upgrading, you must upgrade your {OCPShort} cluster to a supported version prior to upgrading.
 

--- a/downstream/modules/platform/proc-aap-create_controller.adoc
+++ b/downstream/modules/platform/proc-aap-create_controller.adoc
@@ -13,5 +13,5 @@ Use the following steps to create an AutomationController custom resource object
 . Select the *Automation Controller* tab.
 . Click btn:[Create AutomationController].
 . Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
+. In *Advanced configurations*, select your xref:create-secret-key-secret_{context}[secret key secret] and xref:create-postresql-secret_{context}[postgres configuration secret].
 . Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_controller.adoc
+++ b/downstream/modules/platform/proc-aap-create_controller.adoc
@@ -13,5 +13,5 @@ Use the following steps to create an AutomationController custom resource object
 . Select the *Automation Controller* tab.
 . Click btn:[Create AutomationController].
 . Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref:create-secret-key-secret_{context}[secret key secret] and xref:create-postresql-secret_{context}[postgres configuration secret].
+. In *Advanced configurations*, select your xref:create-secret-key-secret_aap-migration[secret key secret] and xref:create-postresql-secret_aap-migration[postgres configuration secret].
 . Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -13,5 +13,5 @@ Use the following steps to create an AutomationHub custom resource object.
 . Select the *Automation Hub* tab.
 . Click btn:[Create AutomationHub].
 . Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref:create-secret-key-secret_{context}[secret key secret] and xref:create-postresql-secret_{context}[postgres configuration secret].
+. In *Advanced configurations*, select your xref:create-secret-key-secret_aap-migration[secret key secret] and xref:create-postresql-secret_aap-migration[postgres configuration secret].
 . Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -13,5 +13,5 @@ Use the following steps to create an AutomationHub custom resource object.
 . Select the *Automation Hub* tab.
 . Click btn:[Create AutomationHub].
 . Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref::create-secret-key-secret_{context}[secret key secret] and xref::create-postresql-secret_{context}[postgres configuration secret].
+. In *Advanced configurations*, select your xref:create-secret-key-secret_{context}[secret key secret] and xref:create-postresql-secret_{context}[postgres configuration secret].
 . Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -1,4 +1,4 @@
-[id="aap-migration_{context}"]
+[id="aap-data-migration_{context}"]
 
 = Migrating data to the {PlatformNameShort} Operator
 

--- a/downstream/modules/platform/proc-operator-upgrade.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade.adoc
@@ -1,4 +1,4 @@
-[id="operator-upgrade{context}"]
+[id="upgrading-operator_{context}"]
 
 = Upgrading the {OperatorPlatform}
 

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -1,6 +1,7 @@
 :imagesdir: images
 :numbered:
 :toclevels: 1
+:context: operator-platform-doc
 
 :experimental:
 


### PR DESCRIPTION
**Task:** 
Fix xref problems that occurred in AAP-2336.
Affects the following doc: /titles/aap-operator-installation/

**Problem:**
The Operator doc built OK with asciidoctor, but failed to build using bccutil due to bad internal cross-references.

**Note to reviewers:**
When reviewing, please build the doc and check the cross-references in the following sections:

- 6.2 Preparing for migration
- 6.3.1 Creating an AutomationController object
- 6.3.2 Creating an AutomationHub object
- 7.1 Upgrade considerations

**Summary of changes:**
I added some comments to a few files to explain why I made some changes
- Fixed duplicate IDs
- Fixed xref syntax
- Substituted values in place of `{context}` 

I made sure that none of the changes affected any other doc.

**Follow-up tasks**
Once merged, cherry-pick to the `2.3` release branch and to the  branch for the 2.2 backport  PR ( #581 )
