### PR TITLE
AAP-6156 Updated EE storage location for controller

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -45,7 +45,7 @@ The following table provides recommendations for node sizing:
 
 [NOTE]
 ====
-On all nodes except hop nodes, allocate a minimum of 20 GB to `/home/awx` for execution environment storage.
+On all nodes except hop nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
 ====
 
 [cols="a,a,a"]


### PR DESCRIPTION
Updated note in the Installation Guide, Section 1.1.1 Automation Controller, to include the correct name of the directory for EE storage, per request in [AAP-6156](https://issues.redhat.com/browse/AAP-6156): 

**Note:** 
On all nodes except hop nodes, allocate a minimum of 20 GB to **`/var/lib/awx`** for execution environment storage.

Changed from `/home/awx` 