### PR TITLE
Modify builder title to match docinfo

### DIFF
--- a/downstream/titles/builder/master.adoc
+++ b/downstream/titles/builder/master.adoc
@@ -6,7 +6,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Creating and consuming execution environments with {PlatformName}
+= Creating and Consuming Execution Environments
 
 Use {Builder} to create consistent and reproducible {ExecEnvName} for your {PlatformName} needs.
 


### PR DESCRIPTION
To fix Pantheon build problems, modify the title in master.adoc for /titles/builder to match docinfo.xml