### PR TITLE
2.2 AAP-3475 Fix operator doc title to match docinfo (#614)

### DIFF
--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Deploying the {OperatorPlatform} on {OCPShort}
+= Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 


### PR DESCRIPTION
Backport #614 to 2.2
Affects titles/aap-operator-installation

Update title in master.adoc to match title in docinfo.xml.

aap-3475 Fix operator doc title to match docinfo