### PR TITLE
Backport 2.2 603 - based on Updated EE storage location for controller #603 (AAP-6156)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -45,7 +45,7 @@ The following table provides recommendations for node sizing:
 
 [NOTE]
 ====
-On all nodes except hop nodes, allocate a minimum of 20 GB to `/home/awx` for execution environment storage.
+On all nodes except hop nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
 ====
 
 [cols="a,a,a"]

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -13,7 +13,7 @@ include::attributes/attributes.adoc[]
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
 This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
- 
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry-picked update to note in the 2.2 version of the Installation Guide, Section 1.1.1 Automation Controller, to include the correct name of the directory for EE storage, per request in [AAP-6156](https://issues.redhat.com/browse/AAP-6156). 

Changed from `/home/awx` to `/var/lib/awx`