### PR TITLE
Draft [DO NOT MERGE] Create stories.adoc file to wrap installation guide assemblies

### DIFF
--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -13,21 +13,6 @@ include::attributes/attributes.adoc[]
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
 This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
-
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-
-include::platform/assembly-planning-installation.adoc[leveloffset=+1]
-
-include::platform/assembly-platform-install-scenario.adoc[leveloffset=+1]
-include::platform/assembly-single-machine-scenarios.adoc[leveloffset=+1]
-include::platform/assembly-multi-machine-cluster-scenario.adoc[leveloffset=+1]
-include::platform/assembly-disconnected-installation.adoc[leveloffset=+1]
-include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
-include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
-include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
-include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset=+1]
-include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
-
-[appendix]
-include::platform/assembly-appendix-inventory-file-vars.adoc[]
+ 
+include::stories.adoc[]
 

--- a/downstream/titles/aap-installation-guide/stories.adoc
+++ b/downstream/titles/aap-installation-guide/stories.adoc
@@ -1,0 +1,16 @@
+// Stories / assemblies for installation guide 
+include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+
+include::platform/assembly-planning-installation.adoc[leveloffset=+1]
+include::platform/assembly-platform-install-scenario.adoc[leveloffset=+1]
+include::platform/assembly-single-machine-scenarios.adoc[leveloffset=+1]
+include::platform/assembly-multi-machine-cluster-scenario.adoc[leveloffset=+1]
+include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
+include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
+include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
+include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset=+1]
+include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
+
+[appendix]
+include::platform/assembly-appendix-inventory-file-vars.adoc[]
+


### PR DESCRIPTION
Part of docathon to refactor the Installation Guide.
Affects `/titles/aap-installation-guide/`.

- Remove the assemblies included in `master.adoc` and include them in a file called `stories.adoc`.
- Include the stories.adoc file in master.adoc.

This decouples the Pantheon artifact (master.adoc) from the docs content.

Build the doc in the usual way with bccutil or Asciidoctor.

