### PR TITLE
Add newline, brackets to fix install guide build failure

### DIFF
--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -28,4 +28,5 @@ include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset
 include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
 
 [appendix]
-include::platform/assembly-appendix-inventory-file-vars.adoc
+include::platform/assembly-appendix-inventory-file-vars.adoc[]
+


### PR DESCRIPTION
The AAP installation guide was failing to build locally and on Pantheon.
Build error message when building with ccutil: 
```
asciidoctor: WARNING: master.adoc: line 31: invalid style for paragraph: appendix
Unknown ID or title "appendix-inventory-files-vars", used as an internal cross reference
/Users/ariordan/repos/red-hat-ansible-automation-platform-documentation/downstream/titles/aap-installation-guide/build/en-US/master.xml fails to validate
```

That is, the internal cross reference was flagged as the error. But the cross reference had worked in a previously published version of the doc on the customer portal.

The build error actually originated from a missing newline at the end of master.adoc.