### PR TITLE
Update release in docinfo only for docs in 2.3 (#641)

### DIFF
--- a/downstream/titles/aap-installation-guide/docinfo.xml
+++ b/downstream/titles/aap-installation-guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Installation Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for Red Hat Ansible Automation Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/aap-operator-backup/docinfo.xml
+++ b/downstream/titles/aap-operator-backup/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Operator Backup and Recovery Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide provides procedures and reference information to backup and recover installations of the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/aap-operator-installation/docinfo.xml
+++ b/downstream/titles/aap-operator-installation/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide provides procedures and reference information for the supported installation scenarios for the Red Hat Ansible Automation Platform operator on OpenShift Container Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/analytics/automation-savings-planner/docinfo.xml
+++ b/downstream/titles/analytics/automation-savings-planner/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Planning your automation jobs using the automation savings planner</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Plan your organization's automation initiatives, and get an accurate estimation of your time and monetary savings when switching to automation.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/analytics/automation-savings/docinfo.xml
+++ b/downstream/titles/analytics/automation-savings/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Using the Automation Calculator</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Evaluate costs and automated processes that determine the return on investment automation brings to your organization.</subtitle>
 <abstract>
     <para>Evaluate how automation is deployed across your environments and the savings associated with it. The Automation Calculator produces a total savings based on default values, but allows you to tune your cost analysis based on real numbers.</para>

--- a/downstream/titles/analytics/job-explorer/docinfo.xml
+++ b/downstream/titles/analytics/job-explorer/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Evaluating your Ansible Tower job runs using the Job Explorer</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Review jobs and templates in greater detail by applying filters and sorting by attributes.</subtitle>
 <abstract>
     <para>Use the Job Explorer to drill deeper into the information from your Ansible Tower automation initiatives. Explore the details behind visualizations to evaluate contextual data and link out to jobs and templates on your Ansible Tower clusters.</para>

--- a/downstream/titles/analytics/reports/docinfo.xml
+++ b/downstream/titles/analytics/reports/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Viewing reports about your Ansible automation environment</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Use the reports feature on Insights for Red Hat Ansible Automation Platform to generate an overview report to monitor your automation environment.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/automation-mesh/docinfo.xml
+++ b/downstream/titles/automation-mesh/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Automation Mesh Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide provides information used to deploy automation mesh as part of your Ansible Automation Platform environment</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/builder/docinfo.xml
+++ b/downstream/titles/builder/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Creating and Consuming Execution Environments</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
   <subtitle>Create consistent and reproducible automation execution environments for your Red Hat Ansible Automation Platform.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/catalog/getting-started/docinfo.xml
+++ b/downstream/titles/catalog/getting-started/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Getting started with Automation Services Catalog</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Initial configurations and workflows</subtitle>
 <abstract>
     <para>This guide provides instructions to begin using Automation Services Catalog, including prerequisites and procedures for connecting your Ansible Tower provider, as well as configuring users and permissions. We also provide instructions for working with platforms, portfolios, and products.</para>

--- a/downstream/titles/catalog/itsm-integration/docinfo.xml
+++ b/downstream/titles/catalog/itsm-integration/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Integrating Automation Services Catalog with your IT Service Management (ITSM) systems</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Incorporate Automation Services Catalog into your IT Service Management system toolchain using a workflow defined by order processes and substitutable variables.</subtitle>
 <abstract>
     <para>This guide describes the workflows for how to use order processes and substitutable variables to pass data from job templates in you Ansible Automation Platform to an IT Service Management (ITM) system.</para>

--- a/downstream/titles/catalog/support-matrix/docinfo.xml
+++ b/downstream/titles/catalog/support-matrix/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Automation Services Catalog product support matrix</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Supported products for Automation Services Catalog</subtitle>
 <abstract>
     <para></para>

--- a/downstream/titles/central-auth/docinfo.xml
+++ b/downstream/titles/central-auth/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing and Configuring Central Authentication for the Ansible Automation Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
   <subtitle>Enable central authentication functions for your Ansible Automation Platform</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/dev-guide/docinfo.xml
+++ b/downstream/titles/dev-guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Creator Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide is intended for developers looking to learn how to use Ansible in creating content for automation.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Configure Automation Hub to deliver curated Red Hat Certified and Ansible Galaxy collections content to your users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/getting-started/docinfo.xml
+++ b/downstream/titles/hub/getting-started/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Getting started with automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Configuring Red Hat automation hub as your default server for Ansible collections content</subtitle>
 <abstract>
     <para>This guide walks you through the initial steps required to use Red Hat automation hub as the default source for certified Ansible collections content.</para>

--- a/downstream/titles/hub/high-availability/docinfo.xml
+++ b/downstream/titles/hub/high-availability/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Deploying a high availability automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Overview of the requirements and procedures for a high availability deployment of automation hub.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/install/docinfo.xml
+++ b/downstream/titles/hub/install/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing and upgrading Private Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>1.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Installing an instance of Private Automation Hub or upgrading to a new version on online or offline Red Hat Enterprise Linux 7 and 8 physical or virtual machines.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/lifecycle/docinfo.xml
+++ b/downstream/titles/hub/lifecycle/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Private Automation Hub life cycle</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>1.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Maintenance and Updates Statement for Automation Hub</subtitle>
 <abstract>
     <para>This document describes the maintenance schedule for security patches and feature enhancements that Red Hat will provide for the Private Automation Hub.</para>

--- a/downstream/titles/hub/manage-containers/docinfo.xml
+++ b/downstream/titles/hub/manage-containers/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing containers in private automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Administrator workflows and processes for configuring private automation hub container registry and repositories.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/managing-user-access/docinfo.xml
+++ b/downstream/titles/hub/managing-user-access/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing user access in Private Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Create groups for your automation hub users to provide them with appropriate system permissions, or allow view-only access to unauthorized users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/publishing-internal-content/docinfo.xml
+++ b/downstream/titles/hub/publishing-internal-content/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Publishing proprietary content collections in Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Use Automation Hub to publish content collections developed within your organization and intended for internal distribution and use.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/uploading-collections/docinfo.xml
+++ b/downstream/titles/hub/uploading-collections/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Uploading content to Red Hat Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Uploading your collections to Automation Hub</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/hub/uploading-internal-collections/docinfo.xml
+++ b/downstream/titles/hub/uploading-internal-collections/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Curating collections using namespaces in Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Use namespaces to organize the collections created by automation developers in your organization. Create namespaces, upload collections and add additional information and resources that help your end users in their automation tasks.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/navigator-guide/docinfo.xml
+++ b/downstream/titles/navigator-guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Early Access Ansible Navigator Creator Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Using Ansible Navigator in the Ansible Creator Workflow.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/security-guide/docinfo.xml
+++ b/downstream/titles/security-guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Security Automation Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>This guide provides procedures for automating and streamlining various security processes needed to identify, triage, and respond to security events using Ansible.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/upgrade/docinfo.xml
+++ b/downstream/titles/upgrade/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Red Hat Ansible Automation Platform Upgrade and Migration Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Upgrading to the latest version of Ansible Automation Platform and migrating legacy virtual environments to automation execution environments</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>

--- a/downstream/titles/worker-install/docinfo.xml
+++ b/downstream/titles/worker-install/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing the automation services catalog worker</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>2.2</productnumber>
+<productnumber>2.3</productnumber>
 <subtitle>Extend your Red Hat Ansible Automation Platform to connect with automation services catalog on cloud.redhat.com using the Ansible Automation Platform 2.0 Setup or Setup Bundle Installers</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>


### PR DESCRIPTION
Backports #641 
Updates the release version for the docs published in the AAP 2.3 page of the customer portal.

The release number is not updated for docs that are not to be published for 2.3.