### PR TITLE
2.3 Fix build issues for 2.3 docs (#647)

### DIFF
--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in Automation Hub</title>
+<title>Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.3</productnumber>
 <subtitle>Configure Automation Hub to deliver curated Red Hat Certified and Ansible Galaxy collections content to your users.</subtitle>

--- a/downstream/titles/hub/uploading-collections/master.adoc
+++ b/downstream/titles/hub/uploading-collections/master.adoc
@@ -2,7 +2,7 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
-= Managing collections on {HubName}
+= Uploading content to Red Hat Automation Hub
 
 {Hubnamestart} distributes certified, supported collections from partners to customers. Each collection includes content such as modules, roles, plugins and documentation. The first time you upload a collection to {HubName}, our Partner Engineering team will start reviewing it for certification.
 


### PR DESCRIPTION
Title mismatches for 2 documents were causing Pantheon builds to fail.
The titles in `master.adoc` and `docinfo.xml` must both match the title in Pantheon. 
Titles are case-sensitive.