### PR TITLE
Backport updates from AAP-5031-A (PR #652)

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -46,6 +46,12 @@ include::topics/controller-420.adoc[leveloffset=+2]
 include::topics/operator-220.adoc[leveloffset=+2]
 
 
+[[anchor-april-2022-release]]
+== April 2022 release
+
+include::topics/aap-212.adoc[leveloffset=+2]
+
+
 [[anchor-february-2022-release]]
 == February 2022 release
 

--- a/release-notes/topics/aap-212.adoc
+++ b/release-notes/topics/aap-212.adoc
@@ -1,0 +1,56 @@
+[[aap-2.1.2-intro]]
+= Ansible Automation Platform 2.1.2
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements
+* Added architecture support labels for the Ansible Automation Platform operator
+* Updated to Receptor 1.2.1 on all supported versions of the Ansible Automation Platform
+* Removed unnecessary packages from the bundle installer to reduce the file size
+* Updated to version to Ansible Runner 2.1.3
+* Removed the enforcement of license compliance from the Ansible Automation Platform installer
+* Added support to enable an array of pull secrets to pass to the operator
+* Added a preflight check to ensure that the installer is running on a UTF-8 system
+* Removed unnecessary `become_user:root` entries from the Ansible Automation Platform installer
+* Added support to provide a custom secret key when running the `rekey.yml` file
+* Added a preflight check to detect missing username and password variables for service catalog worker, instead of causing an installation failure at a later point of time
+* Updated the collection counts on the *Content* tab when the collection details were filtered
+
+.Bug fixes
+* Fixed an issue where Controller user interface would not load on a few cloud providers
+* Added compatibility with earlier versions for `image_pull_secret` key in `awx-operator`, so that the backup and restore operations are completed successfully
+* Automation controller backups no longer fail when multiple secrets are supported
+* Resolved certification mismatch during upgrade so that every controller dashboard is accessible
+* Improved the labels for Japanese translations
+* Resolved issues when upgrading automation hub from version 2.1.1 to version 2.1.2
+* Resolved issues where the Controller user interface was not accessible, when automation controller was installed through Operator on OpenShift Core Platform 4.10
+* Fixed an issue that caused the upgrade from Ansible Automation Platform 1.2 to 2.1 to fail, when the execution environment was transferred to automation hub
+* Fixed an issue so that a standalone installation of private automation hub can now transfer the execution environments to the hub
+* Fixed an issue when the variable `sslmode` was not configured correctly during automation hub installation
+* Running the ``./setup.sh -b` command from the installer directory no longer fails to load group variables
+* Fixed an issue where the SELinux context was not being configured correctly on subsequent installations
+* The installer no longer fails when IPV6 is disabled
+* Modified the database backup and restore logic to compress the data dump
+* Fixed an issue during installation where a configured proxy would not be used when required
+* Fixed installations of execution environments when installing without internet access
+* Creating default execution environments no longer fails when the password includes special characters
+* Added support to set a parameter to change the temporary directory path, so that the execution environments can be extracted to the bundled installer
+* Upgrading to Ansible Automation Platform 2.1 no longer fails when the Django superuser is missing
+* Fixed an issue where installation of automation hub failed due to symlinks
+* Added explanations for variables of service catalog worker in the installer inventory
+* Fixed an issue where installing automation hub with an external database did not install Postgres as expected
+* Fixed an issue where variables with default values were shown as undefined variables
+* Added support for `ansible_host` in the installer inventory for automation hub
+* Fixed an issue where a few commands were missing on initializing the container
+* Fixed an issue where the TTL controller caused the jobs to run repeatedly
+* Resolved intermittent `500 internal server error` while pulling the execution environments from private automation hub
+* Fixed an issue so that remotes configured with proxy authentication can be edited without re-entering the proxy password
+* Updated the proxy password from text type to password type to make the password more secure
+* Updated the synchronization that is used by authenticated proxy to avoid authentication failures
+* Added message in the Controller user interface to inform users that the community collections do not have docs
+* Resolved intermittent issue while trying to sync community `devsec.hardening` collection on automation hub 4.4.0
+* Added field validation to allow HTTPS URLs only when adding a remote registry
+* Added import result and filenames to the audit log
+* Updated the group categories such as *Namespaces*, *Collections*, *Users*, *Groups*, *Remotes*, and *Containers* in the translatable strings
+* Updated the *Filter by repository* dropdown field in the translatable strings
+* Updated the *Namespaces* label in the translatable strings.

--- a/release-notes/topics/aap-213.adoc
+++ b/release-notes/topics/aap-213.adoc
@@ -1,0 +1,34 @@
+[[aap-2.1.3-intro]]
+= Ansible Automation Platform 2.1.3
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements
+* Updated the version to `Openshift-clients` 4.10.x
+* Updated the version to `pulpcore-selinux` 1.3.2
+* Updated the version to `pulp_installer` 3.15.9-3
+* Updated the version to Receptor 1.2.3
+* Added an enhancement such that execution environment images can now be pulled from automation controller only
+* Modified the base images of execution environments so that the controller backups are executed in the container
+
+.Bug fixes
+* Task container no longer fails for Controller Operator 2.1.3
+* The setup log now gets updated when it is run as `non-root` on bastion host
+* The users' time zones are now populated correctly in the execution environments
+* Installation of automation hub no longer causes SELinux errors
+* Syncing the execution environments from `registry.redhat.io` on automation hub 2.1 no longer causes `[Too many open files]` errors
+* Enhanced the copy process of execution environments so that they require less space in the ``/tmp` directory
+* The receptor no longer fails in FIPS mode
+* Added the `no_proxy` definition in the inventory file so that deployments no longer use proxy when accessing private automation hub and thereby run successfully
+* The bundled installer no longer fails while finding registry details
+* Bundle installation no longer fails with `skopeo` file permissions error
+* Installation of Red Hat Single Sign On (SSO) on private automation hub no longer fails
+* Bundle installation of private automation hub no longer pushes images with missing `ee_image_base` that leads to installation failure
+* When you run the ``./setup.sh -b` command during an upgrade, the API tokens are now maintained
+* The super user role of users can now be changed by administrators only
+* Improved the tasks for collections deletion so that the collections are now deleted from both the repositories and the disks
+* While using automation hub 4.5.0 with central authentication, the hub user interface no longer turns unresponsive when the group permissions are modified
+* Added localization support for *Modules*, *Roles*, *Plugins*, and *Dependencies* counter in container list for both card and list view
+* Updated the documentation link to route to documentation of the correct version
+* Resolved intermittent issue while trying to sync community `devsec.hardening` collection on automation hub 4.4.0
+* Improved import log and status overflow pages in automation controller UI

--- a/release-notes/topics/aap-221.adoc
+++ b/release-notes/topics/aap-221.adoc
@@ -1,0 +1,41 @@
+[[aap-2.2.1-intro]]
+= Ansible Automation Platform 2.2.1
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+.Enhancements
+* Modified installer to include the *ansible-builder* image
+* Updated the `openshift-clients` to 4.10.x
+* Enabled users to use certificates located on destination nodes
+* Updated the version to `pulpcore-selinux` 1.3.2
+* Updated the version to `pulp_installer` 3.18
+* Enhanced the copy process of execution environments so that they require less space in the `/tmp` directory
+* Updated RSA key strength for Ansible Automation Platform certificates
+* Removed `redhat.rhv` collection from supported execution environments due to Python dependencies
+* Modified the base images of execution environments so that controller backups are executed in the container
+* Added the capability to configure LDAP with private automation hub
+
+.Bug fixes
+* Fixed an issue where package dependencies were missing on execution nodes
+* The setup log now gets updated when it is run as `non-root` on bastion host
+* The pulp resource manager now gets removed when the Ansible Automation Platform is upgraded from 2.1 to 2.2
+* The `receptor.service` now restarts as expected when you run the `automation-controller-service` commands
+* The installer no longer fails with permission errors in the ``/home/pulp` directory
+* The receptor no longer fails in FIPS mode
+* Installer no longer fails with error in installing the `semanage` dependency
+* Updated the default configuration of `GALAXY_COLLECTION_SIGNING_SERVICE` to `ansible-default` instead of `TRUE`
+* Installation no longer fails due to conflicting `ansible-builder` Python packages
+* Upgrade from Ansible Tower to Ansible Automation Platform 2.1 no longer fails due to non-root user error
+* Controller database no longer gets unpacked on all nodes and cause disk space issues
+* Installation of high availability automation hub no longer fails on a shared Netapp storage
+* Ansible Automation Platform 1.2 to 2.1 upgrade no longer fails with 502 error due to wrong SELinux content set on nginx
+* Installer no longer fails to generate SSO key pair for IPV6
+* The group permissions editor can now be used to set permissions for the group when external authorization is enabled
+* While using automation hub 4.5.0 with central authentication, the hub user interface no longer turns unresponsive when the group permissions are modified
+* Added localization support for *Modules*, *Roles*, *Plugins*, and *Dependencies* counter in container list for both card and list view
+* The *Deprecated* label now appears immediately after an action click or after the page reload on automation hub UI
+* Upon clicking the *Undeprecate* button for a collection on automation hub UI, an alert is displayed stating that the task has started with a link of the task
+* After syncing the Red Hat certified collections and their versions in private automation hub, the UI now correctly displays the release date of the collection and not the synchronization date
+* Updated the default namespace logo to make it appear similar to the Ansible product logo
+* Automation hub UI now displays the selected collection similar to the rest of the selections
+* Reenabled the *Deprecate* button for collections in Insights mode on automation hub UI


### PR DESCRIPTION
Added missing files from AAP-5031-A (PR #642)
 

- Added the April 2022 release notes info to the master.adoc

- Added missing files aap-212.adoc, aap-213.ado, and aap-221.adoc to the repo so that the build can be completed successfully (thanks, @sayjadha for sending the files)