### PR TITLE
AAP-357 added links to builder and navigator guides

### DIFF
--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -23,7 +23,7 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 
 You can define and create an automation execution environment using {Builder}.
 
-////
+/////
 [role="_additional-resources"]
 .Additional resources
 
@@ -34,4 +34,4 @@ You can define and create an automation execution environment using {Builder}.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
-////
+/////

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -33,4 +33,5 @@ You can define and create an automation execution environment using {Builder}.
 * Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* For more information on {Builder}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
 ////

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -33,5 +33,5 @@ You can define and create an automation execution environment using {Builder}.
 * Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* For more information on {Builder}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
 ////

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -23,7 +23,7 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 
 You can define and create an automation execution environment using {Builder}.
 
-/////
+////
 [role="_additional-resources"]
 .Additional resources
 
@@ -34,4 +34,4 @@ You can define and create an automation execution environment using {Builder}.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
-/////
+////

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -26,10 +26,4 @@ You can define and create an automation execution environment using {Builder}.
 [role="_additional-resources"]
 .Additional resources
 
- CONSIDER FOR USE TO LINK TO BUILDER DOCS
-
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -23,7 +23,6 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 
 You can define and create an automation execution environment using {Builder}.
 
-////
 [role="_additional-resources"]
 .Additional resources
 
@@ -33,5 +32,4 @@ You can define and create an automation execution environment using {Builder}.
 * Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
-////
+* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -16,5 +16,5 @@ As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {B
 .Additional resources
 
 * See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
-* For more information on {Builder}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
 ////

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -11,10 +11,8 @@ Before {PlatformName} 2.0, an automation content developer may have needed so ma
 As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {Builder} ensure that you can take advantage of those {ExecEnvName} locally within your own development system.
 
 
-/////
 [role="_additional-resources"]
 .Additional resources
 
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
-* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
-/////
+* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
+* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -11,10 +11,10 @@ Before {PlatformName} 2.0, an automation content developer may have needed so ma
 As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {Builder} ensure that you can take advantage of those {ExecEnvName} locally within your own development system.
 
 
-////
+/////
 [role="_additional-resources"]
 .Additional resources
 
 * See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
-////
+/////

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -11,10 +11,10 @@ Before {PlatformName} 2.0, an automation content developer may have needed so ma
 As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {Builder} ensure that you can take advantage of those {ExecEnvName} locally within your own development system.
 
 
-/////
+////
 [role="_additional-resources"]
 .Additional resources
 
-* See the link:[Ansible Navigator Creator Guide] for more on using {Navigator}.
-* For more information on {Builder}, see the link:[Ansible Builder Creator Guide].
-/////
+* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
+* For more information on {Builder}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+////


### PR DESCRIPTION
1. modules/dev-guide/con-content-workflows.adoc:

**Under Additional resources**
Added links to [Ansible Navigator Creator Guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/ansible_navigator_creator_guide) and [Creating and Consuming Execution Environments](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index).

2. modules/core/execution-environments.adoc:

**Under Additional resources**
Added link to [Creating and Consuming Execution Environments](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/%7BPlatformVers%7D/html/creating_and_consuming_execution_environments/index).

