### PR TITLE
AAP-6015 Add link to "Import a subscription" to Install Guide

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -1,4 +1,4 @@
-[id="assembly-appendix-inventory-files-vars"]
+[id="appendix-inventory-files-vars"]
 = Inventory file variables
 
 The following tables contain information about the pre-defined variables used in Ansible installation inventory files.

--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -1,4 +1,4 @@
-[id="appendix-inventory-files-vars"]
+[id="assembly-appendix-inventory-files-vars"]
 = Inventory file variables
 
 The following tables contain information about the pre-defined variables used in Ansible installation inventory files.

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -113,6 +113,14 @@ h| Database | PostgreSQL version 13 |
 
 |===
 
+[role="_additional-resources"]
+.Additional resources
+////
+Optional. Delete if not used.
+////
+* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+
+
 .Automation hub
 
 [cols="a,a,a"]
@@ -194,9 +202,3 @@ If performing a bundled {PlatformNameShort} installation, the installation progr
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
 
-[role="_additional-resources"]
-.Additional resources
-////
-Optional. Delete if not used.
-////
-* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -193,3 +193,10 @@ Upon new installations, {ControllerName} installs the latest release package of 
 If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
+
+[role="_additional-resources"]
+.Additional resources
+////
+Optional. Delete if not used.
+////
+* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].


### PR DESCRIPTION
Added an "Additional Resources" section with a link to the "Import a subscription" (Controller docs) to the section "1.1.1 Automation controller" topic in the Installation Guide, per development request.