### PR TITLE
Backport-2.1-657 Add link to "Import a subscription" to 2.1 Installation Guide

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -118,7 +118,7 @@ h| Database | PostgreSQL version 12 |
 ////
 Optional. Delete if not used.
 ////
-* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+* To authorize the use of {ControllerName}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription]. 
 
 
 .Automation hub

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -113,6 +113,14 @@ h| Database | PostgreSQL version 12 |
 
 |===
 
+[role="_additional-resources"]
+.Additional resources
+////
+Optional. Delete if not used.
+////
+* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+
+
 .Automation hub
 
 [cols="a,a,a"]
@@ -196,3 +204,4 @@ Upon new installations, {ControllerName} installs the latest release package of 
 If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
+

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -13,7 +13,7 @@ include::attributes/attributes.adoc[]
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
 This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
- 
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]


### PR DESCRIPTION
Based on original ticket [AAP-6015](https://issues.redhat.com/browse/AAP-6015) (PR #657 ) in which developers requested a link to the Import a subscription topic be added to the planning chapter of the Installation Guide. 

Added the link right after the end of the section 1.1.1 Automation controller. 