### PR TITLE
Backport-2.2-657 Add link to "Import a subscription" to 2.2 Installation Guide

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -118,7 +118,7 @@ h| Database | PostgreSQL version 13 |
 ////
 Optional. Delete if not used.
 ////
-* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+* To authorize the use of {ControllerName}}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
 
 
 .Automation hub

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -113,6 +113,14 @@ h| Database | PostgreSQL version 13 |
 
 |===
 
+[role="_additional-resources"]
+.Additional resources
+////
+Optional. Delete if not used.
+////
+* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+
+
 .Automation hub
 
 [cols="a,a,a"]
@@ -193,3 +201,4 @@ Upon new installations, {ControllerName} installs the latest release package of 
 If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
+

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -118,7 +118,7 @@ h| Database | PostgreSQL version 13 |
 ////
 Optional. Delete if not used.
 ////
-* To authorize the use of {ControllerName}}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+* To authorize the use of {ControllerName}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
 
 
 .Automation hub


### PR DESCRIPTION
Based on original ticket [AAP-6015](https://issues.redhat.com/browse/AAP-6015) (PR https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/657 ) in which developers requested a link to the Import a subscription topic be added to the planning chapter of the Installation Guide.

Added the link right after the end of the section 1.1.1 Automation controller.