### PR TITLE
AAP-4941 - Restructure of the AAP Install Guide

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -2,12 +2,11 @@
 = Inventory file variables
 
 The following tables contain information about the pre-defined variables used in Ansible installation inventory files.
-
 Not all of these variables are required.
 
-include::platform/ref-general-inventory-variables.adoc[leveloffset=+2]
-include::platform/ref-hub-variables.adoc[leveloffset=+2]
-include::platform/ref-sso-variables.adoc[leveloffset=+2]
-include::platform/ref-catalog-variables.adoc[leveloffset=+2]
-include::platform/ref-controller-variables.adoc[leveloffset=+2]
-include::platform/ref-ansible-inventory-variables.adoc[leveloffset=+2]
+include::platform/ref-general-inventory-variables.adoc[leveloffset=+1]
+include::platform/ref-hub-variables.adoc[leveloffset=+1]
+include::platform/ref-sso-variables.adoc[leveloffset=+1]
+include::platform/ref-catalog-variables.adoc[leveloffset=+1]
+include::platform/ref-controller-variables.adoc[leveloffset=+1]
+include::platform/ref-ansible-inventory-variables.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-installing-aap-components.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-components.adoc
@@ -1,0 +1,33 @@
+
+ifdef::context[:parent-context: {context}]
+
+
+
+[id="installing-aap-components"]
+= Installing {PlatformName} components
+
+
+:context: installing-components
+
+[role="_abstract"]
+After you have completed installing {PlatformName}, you can install {PlatformName} components.
+
+.Prerequisites
+
+* You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
+* You are installing on a machine that meets base system requirements.
+* You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
+
+include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
+include::assembly-single-machine-scenarios.adoc[leveloffset=+1]
+include::assembly-multi-machine-cluster-scenario.adoc[leveloffset=+1]
+include::platform/ref-setup-script-args.adoc[leveloffset=+1]
+include::platform/proc-running-setup-script.adoc[leveloffset=+1]
+include::platform/proc-verify-controller-installation.adoc[leveloffset=+1]
+include::platform/ref-controller-configs.adoc[leveloffset=+2]
+include::platform/proc-verify-hub-installation.adoc[leveloffset=+1]
+include::platform/ref-hub-configs.adoc[leveloffset=+2]
+include::assembly-platform-whats-next.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-multi-machine-cluster-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-multi-machine-cluster-scenario.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="assembly-multi-machine-cluster-scenario"]
-= Multi-machine cluster installation
+= Installing {PlatformName} components on a multi-machine cluster
 
 
 :context: cluster-scenario
@@ -17,7 +17,7 @@ You can install {PlatformNameShort} as clustered {ControllerName} with {HubName}
 The {PlatformNameShort} installer allows you to deploy *only one* {HubName} per inventory. You can use the {PlatformNameShort} installer for a standalone instance of {HubName} and run the installer any number of times with any number of different inventories to deploy multiple {HubName} nodes.
 ====
 
-include::assembly-multi-machine-install.adoc[leveloffset=+1]
+include::platform/ref-multi-node-cluster-installation.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-multi-machine-install.adoc
+++ b/downstream/assemblies/platform/assembly-multi-machine-install.adoc
@@ -9,13 +9,6 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 You can use these instructions to install {PlatformName} as multiple {ControllerName} nodes and {HubName} with an external managed database.
 
-
-== Prerequisites
-
-* You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
-* You are installing on a machine that meets base system requirements.
-* You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
-
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]
 include::platform/ref-multi-node-cluster-installation.adoc[leveloffset=3]
 include::platform/ref-setup-script-args.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
+++ b/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
@@ -2,7 +2,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="assembly-platform-ext-database"]
-= Installing {PlatformName} with an external managed database
+= Installing {PlatformName} with an externally managed database
 
 :context: standalone-controller-ext-database
 

--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -22,10 +22,32 @@ The {PlatformNameShort} installer allows you to deploy *only one* {HubName} per 
 Installer does not require a user to be logged in as root to run `./setup.sh`. The user will need to properly configure the environment variable `ANSIBLE_BECOME_METHOD` for the preferred method of privilege escalation to root. The default method is `sudo`.
 ====
 
-This installation option includes two supported scenarios:
+.Prerequisites
 
-include::assembly-platform-non-inst-database.adoc[leveloffset=+1]
-include::assembly-platform-ext-database-install.adoc[leveloffset=+1]
+* You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
+* You are installing on a machine that meets base system requirements.
+* You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
+
+There are a number of supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario using one of the examples below:
+
+* xref:ref-standlone-platform-inventory_{context}[Example inventory file for a database on the automation controller node or a non-installer managed database]
+* xref:ref-standlone-platform-ext-database-inventory_{context}[Example {PlatformName} inventory file with an external managed database]
+
+include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
+include::platform/ref-platform-non-inst-database-inventory.adoc[leveloffset=+2]
+include::platform/ref-example-platform-ext-database-inventory.adoc[leveloffset=+2]
+include::platform/ref-single-node-inventory.adoc[leveloffset=+2]
+include::platform/ref-standalone-controller-ext-db.adoc[leveloffset=+2]
+include::platform/ref-standalone-hub-inventory.adoc[leveloffset=+2]
+include::platform/ref-standalone-hub-ext-database-inventory.adoc[leveloffset=+2]
+include::platform/ref-multi-node-cluster-installation.adoc[leveloffset=+2]
+include::platform/proc-running-setup-script.adoc[leveloffset=+1]
+include::platform/proc-verify-controller-installation.adoc[leveloffset=+1]
+include::platform/ref-controller-configs.adoc[leveloffset=+2]
+include::platform/proc-verify-hub-installation.adoc[leveloffset=+1]
+include::platform/ref-hub-configs.adoc[leveloffset=+2]
+include::assembly-platform-whats-next.adoc[leveloffset=+1]
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-single-machine-scenarios.adoc
+++ b/downstream/assemblies/platform/assembly-single-machine-scenarios.adoc
@@ -12,11 +12,10 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 You can install {PlatformName} components on a single machine in one of the following supported scenarios.
 
-
-include::assembly-standalone-controller-non-inst-database-installation.adoc[leveloffset=+1]
-include::assembly-standalone-controller-ext-database.adoc[leveloffset=+1]
-include::assembly-standalone-hub-non-inst-database.adoc[leveloffset=+1]
-include::assembly-standalone-hub-ext-database.adoc[leveloffset=+1]
+include::platform/ref-single-node-inventory.adoc[leveloffset=+1]
+include::platform/ref-standalone-controller-ext-db.adoc[leveloffset=+1]
+include::platform/ref-standalone-hub-inventory.adoc[leveloffset=+1]
+include::platform/ref-standalone-hub-ext-database-inventory.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/ref-controller-configs.adoc
+++ b/downstream/modules/platform/ref-controller-configs.adoc
@@ -10,7 +10,8 @@ See the following resources to explore additional {ControllerName} configuration
 |Link|Description
 |https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Automation Controller Quick Setup Guide]|Set up {ControllerName} and run your first playbook
 |https://docs.ansible.com/automation-controller/latest/html/administration/index.html[Automation Controller Administration Guide]|Configure {ControllerName} administration through customer scripts, management jobs, etc.
-|xref:assembly-configuring-proxy-support[Configuring proxy support for {PlatformName}]|Set up {ControllerName} with a proxy server
-|xref:assembly-controlling-data-collection[Managing usability analytics and data collection from {ControllerName}]|Manage what {ControllerName} information you share with Red Hat
+//12/2/22 [dcd: add links to sections in new Operations Guide once published.]
+//|xref:assembly-configuring-proxy-support[Configuring proxy support for {PlatformName}]|Set up {ControllerName} with a proxy server
+//|xref:assembly-controlling-data-collection[Managing usability analytics and data collection from {ControllerName}]|Manage what {ControllerName} information you share with Red Hat
 |https://docs.ansible.com/automation-controller/latest/html/userguide/index.html[Automation Controller User Guide]|Review {ControllerName} functionality in more detail
 |====

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -19,9 +19,7 @@ include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]
 
 include::platform/assembly-platform-install-scenario.adoc[leveloffset=+1]
-include::platform/assembly-single-machine-scenarios.adoc[leveloffset=+1]
-include::platform/assembly-multi-machine-cluster-scenario.adoc[leveloffset=+1]
-include::platform/assembly-disconnected-installation.adoc[leveloffset=+1]
+include::platform/assembly-installing-aap-components.adoc[leveloffset=+1]
 include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
 include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
 include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
@@ -29,5 +27,4 @@ include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset
 include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
 
 [appendix]
-include::platform/assembly-appendix-inventory-file-vars.adoc[]
-
+include::platform/assembly-appendix-inventory-file-vars.adoc[leveloffset=1]

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -16,15 +16,16 @@ This guide helps you to understand the installation requirements and processes b
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
-include::platform/assembly-planning-installation.adoc[leveloffset=+1]
-
+//12/2/22 [dcd: moved following assembly to new planning guide]
+//include::platform/assembly-planning-installation.adoc[leveloffset=+1]
 include::platform/assembly-platform-install-scenario.adoc[leveloffset=+1]
-include::platform/assembly-installing-aap-components.adoc[leveloffset=+1]
-include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
-include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
-include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
-include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset=+1]
-include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
+//12/2/22 [dcd: moved following assemblies to new operations guide]
+//include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
+//include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
+//include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
+//12/2/22 [dcd: removed the following assemblies]
+//include::platform/assembly-supported-inventory-plugins-template.adoc[leveloffset=+1]
+//include::platform/assembly-supported-attributes-custom-notifications.adoc[leveloffset=+1]
 
 [appendix]
 include::platform/assembly-appendix-inventory-file-vars.adoc[leveloffset=1]


### PR DESCRIPTION
This PR handles the restructuring of the AAP Installation Guide based on meetings with Mike Silmser and Lydie-Mode Malivert and outlined in the Installation Guide Restructuring Plan (https://docs.google.com/document/d/1Su7oAjC7MwIREGpW8NpC71OJfHRSvAatCZFI1-LXXZM/edit#heading=h.gaobgjjc253x)

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/IG4941/master.html