### PR TITLE
AAP-7533 Docathon Section 1 of Operations Guide

### DIFF
--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Operations Guide
+= Red Hat Ansible Automation Platform Operations Guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
@@ -19,3 +19,4 @@ include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
 include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
 include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
+

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -10,9 +10,8 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Red Hat Ansible Automation Platform Operations Guide
 
-Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
-
-Use the information in this guide to perform post-installation configuration tasks.
+This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
+This document has been updated to include information for the latest release of {PlatformNameShort}.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -11,7 +11,6 @@ include::attributes/attributes.adoc[]
 = Red Hat Ansible Automation Platform Operations Guide
 
 This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
-This document has been updated to include information for the latest release of {PlatformNameShort}.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Part of docathon to refactor Installation guide 

AAP-7533: Affects section 1 of Operations guide (`/titles/aap-operations-guide/`)

- Replace attributes in master.adoc title
- Replace introductory text in master.adoc