### PR TITLE
AAP-7538 docathon Modify Operations guide section 3 content

### DIFF
--- a/downstream/assemblies/platform/assembly-controlling-data-collection.adoc
+++ b/downstream/assemblies/platform/assembly-controlling-data-collection.adoc
@@ -1,22 +1,16 @@
-
-
 ifdef::context[:parent-context: {context}]
-
-
 
 [id="assembly-controlling-data-collection"]
 = Managing usability analytics and data collection from {ControllerName}
 
-
 :context: data-collection
-
 
 [role="_abstract"]
 You can change how you participate in usability analytics and data collection from {ControllerName} by opting out or changing your settings in the {ControllerName} user interface.
 
 include::platform/con-user-data-tracking.adoc[leveloffset=+1]
-
 include::platform/proc-control-data-collection.adoc[leveloffset=+2]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+

--- a/downstream/modules/platform/con-user-data-tracking.adoc
+++ b/downstream/modules/platform/con-user-data-tracking.adoc
@@ -1,6 +1,4 @@
-
 [id="con-usability-analytics_{context}"]
-
 
 = Usability analytics and data collection
 

--- a/downstream/modules/platform/proc-control-data-collection.adoc
+++ b/downstream/modules/platform/proc-control-data-collection.adoc
@@ -13,5 +13,5 @@ You can control how {ControllerName} collects data by setting your participation
 ** *Off*: Prevents any data collection.
 ** *Anonymous*: Enables data collection without your specific user data.
 ** *Detailed*: Enables data collection including your specific user data.
-. Click *Save* to apply the settings or *Cancel* to abandon the changes.
+. Click btn:[Save] to apply the settings or btn:[Cancel] to discard the changes.
 

--- a/downstream/modules/platform/proc-control-data-collection.adoc
+++ b/downstream/modules/platform/proc-control-data-collection.adoc
@@ -1,20 +1,17 @@
-
-
 [id="proc-controlling-data-collection_{context}"]
 
 = Controlling data collection from {ControllerName}
 
-
 [role="_abstract"]
-You can control how {ControllerName} collects data by setting your participation level in the **User Interface** tab in the settings menu.
+You can control how {ControllerName} collects data by setting your participation level in the *User Interface* tab in the *Settings* menu.
 
 .Procedure
 
-. Log in to your {ControllerName}
-
-. Navgate to *Settings* -> *User Interface*
-. Select the desired level of data collection from the User Analytics Tracking State drop-down list:
-.. *Off*: Prevents any data collection.
-.. *Anonymous*: Enables data collection without your specific user data.
-.. *Detailed*: Enables data collection including your specific user data.
+. Log in to your {ControllerName}.
+. Navigate to *Settings > User Interface*.
+. Select the desired level of data collection from the *User Analytics Tracking State* drop-down list:
+** *Off*: Prevents any data collection.
+** *Anonymous*: Enables data collection without your specific user data.
+** *Detailed*: Enables data collection including your specific user data.
 . Click *Save* to apply the settings or *Cancel* to abandon the changes.
+

--- a/downstream/modules/platform/proc-control-data-collection.adoc
+++ b/downstream/modules/platform/proc-control-data-collection.adoc
@@ -8,7 +8,7 @@ You can control how {ControllerName} collects data by setting your participation
 .Procedure
 
 . Log in to your {ControllerName}.
-. Navigate to *Settings > User Interface*.
+. Navigate to menu:Settings[User Interface].
 . Select the desired level of data collection from the *User Analytics Tracking State* drop-down list:
 ** *Off*: Prevents any data collection.
 ** *Anonymous*: Enables data collection without your specific user data.


### PR DESCRIPTION
Part of docathon to refactor Installation guide

AAP-7538: Affects section 3 of Operations guide (`/titles/aap-operations-guide/`)

Close this PR if it's out of scope for the docathon: There were no structural/build issues to tackle in this section of the Operations Guide, so I just tidied up some asciidoc in the modules.