### PR TITLE
AAP-7601 - Remediate broken xrefs due to restructuring

### DIFF
--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -39,32 +39,47 @@ Red Hat supports the following installations scenarios for {PlatformName}
 
 include::platform/con-SM-standalone-contr-non-inst-database.adoc[leveloffset=+2]
 
-See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
+//[dcd 12/7/22] Changing xrefs to links because information is in a separate document due to restructuring.
+
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] to get started.
+
+//See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+2]
 
-See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] to get started.
+
+//See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+2]
 
-See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] to get started.
+
+//See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-hub-ext-database.adoc[leveloffset=+2]
 
-See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-ext-database[Installing {HubName} with an external database] to get started.
+
+//See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-platform-non-inst-database.adoc[leveloffset=+2]
 
-See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] to get started.
+
+//See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-platform-ext-database.adoc[leveloffset=+2]
 
-See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-ext-database[Installing {PlatformName} with an external managed database] to get started.
+
+//See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-cluster-platform-ext-database.adoc[leveloffset=+2]
 
-See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster installation_ to get started.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] to get started.
 
+//See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster installation_ to get started.
 
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
This PR addresses the changes required by https://issues.redhat.com/browse/AAP-7601.

Changes include fixing the broken xrefs in the new Planning Guide caused by the restructuring of the AAP Installation Guide.

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP7601/master.html