### PR TITLE
AAP-7617 Minor edits to new AAP Guides

### DIFF
--- a/downstream/modules/platform/proc-attaching-subscriptions.adoc
+++ b/downstream/modules/platform/proc-attaching-subscriptions.adoc
@@ -17,6 +17,11 @@ NOTE: Attaching a subscription is unnecessary if you have enabled link:https://a
 # subscription-manager list --available --all | grep "Ansible Automation Platform" -B 3 -A 6
 -----
 +
+[NOTE]
+====
+Do not use MCT4022 as a `pool_id` for your subscription because it can cause {PlatformNameShort} subscription attachment to fail.
+====
++
 .Example
 An example output of the `*subsciption-manager list*` command. Obtain the `pool_id` as seen in the `Pool ID:` section:
 +
@@ -52,14 +57,14 @@ You have now attached your {PlatformName} subscriptions to all nodes.
 
 * If you are unable to locate certain packages that came bundled with the {PlatformNameShort} installer, or if you are seeing a `_Repositories disabled by configuration_` message, try enabling the repository using the command:
 +
-Red Hat Ansible Automation Platform 2.2 for RHEL 8
+Red Hat Ansible Automation Platform 2.3 for RHEL 8
 +
 ----
-subscription-manager repos --enable ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms
+subscription-manager repos --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms
 ----
 +
-Red Hat Ansible Automation Platform 2.2 for RHEL 9
+Red Hat Ansible Automation Platform 2.3 for RHEL 9
 +
 ----
-subscription-manager repos --enable ansible-automation-platform-2.2-for-rhel-9-x86_64-rpms
+subscription-manager repos --enable ansible-automation-platform-2.3-for-rhel-9-x86_64-rpms
 ----

--- a/downstream/modules/platform/proc-running-setup-script.adoc
+++ b/downstream/modules/platform/proc-running-setup-script.adoc
@@ -10,7 +10,7 @@ You can run the setup script once you finish updating the `inventory` file with 
 . Run the `setup.sh` script
 +
 -----
-$ ./setup.sh
+$ sudo ./setup.sh
 -----
 
 The installation will begin.


### PR DESCRIPTION
This PR addresses the changes required for https://issues.redhat.com/browse/AAP-7617.

Changes include the following:
In the new AAP planning guide (Introduction to Red Hat Ansible Automation Platform):

- Remove references to AAP version 2.2. This appears in the troubleshooting section.
- Red Hat Ansible Automation Platform Infrastructure Subscription (MCT4022) should not be used as pool ID. Create a note that says not to use.

In the new AAP Installation Guide:

-  In section 2.2 Running the Red Hat Ansible Automation Platform installer setup script - tell the user to use root (sudo).