### PR TITLE
AAP-7618 Include information regarding component options with AAP

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 :context: platform-install-scenario
 
 [role="_abstract"]
-{PlatformName} installation involves deploying {ControllerName} and {HubName}.
+{PlatformNameShort} is a modular platform and installation involves deploying {ControllerName} with other automation platform components, such as {HubName}. For more information about the components provided with {PlatformNameShort}, see _Red Hat Ansible Automation Platform platform components_ in the {PlatformName} Planning Guide.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
This PR addresses the changes required by https://issues.redhat.com/browse/AAP-7618.

Change includes:

When user installs RH AAP, they can install controller with other automation platform components ...not just Hub. The AAP is modular - the user can choose which components they want to install.

 