### PR TITLE
AAP-4995 - Add AWX deployment to list of migration options

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -10,10 +10,11 @@ ifdef::context[:parent-context: {context}]
 
 Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
 
-This guide allows you to migrate:
+Use these procedures to migrate any of the following deployments to the {OperatorPlatform}:
 
 * A VM-based installation of {ControllerName} or {HubName}, or
 * An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
+* An AWX instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
 
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -12,8 +12,8 @@ Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to
 
 Use these procedures to migrate any of the following deployments to the {OperatorPlatform}:
 
-* A VM-based installation of {ControllerName} or {HubName}, or
-* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
+* A VM-based installation of {ControllerName} or {HubName},
+* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2), or
 * An AWX instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
 
 

--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -14,8 +14,7 @@ Use these procedures to migrate any of the following deployments to the {Operato
 
 * A VM-based installation of {ControllerName} or {HubName},
 * An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2), or
-* An AWX instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
-
+* An AWX instance
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses the changes required by https://issues.redhat.com/browse/AAP-4995.

Change includes the following:

Added bullet to Chapter 6 to show that the procedures cover migration of AWX --> Openshift AAP Operator as well as Tower and VM deployments:

- An AWX instance