### PR TITLE
IG-LINKFIX - changed hardcoded 2.3 in links to the PlatformVers

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-overview.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-overview.adoc
@@ -25,7 +25,7 @@ xref:assembly-platform-whats-next_platform-install-scenario[Post-installation st
 
 [role="_additional-resources"]
 .Additional resources
-For more information about the supported installation scenarios, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[{PlatformName} Planning Guide].
+For more information about the supported installation scenarios, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/index[{PlatformName} Planning Guide].
 
 include::platform/con-aap-installation-prereqs.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 :context: platform-install-scenario
 
 [role="_abstract"]
-{PlatformNameShort} is a modular platform and you can deploy {ControllerName} with other automation platform components, such as {HubName}. For more information about the components provided with {PlatformNameShort}, see _Red Hat Ansible Automation Platform platform components_ in the {PlatformName} Planning Guide.
+{PlatformNameShort} is a modular platform and you can deploy {ControllerName} with other automation platform components, such as {HubName}. For more information about the components provided with {PlatformNameShort}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in the {PlatformName} Planning Guide.
 
 [IMPORTANT]
 ====

--- a/downstream/assemblies/platform/assembly-platform-whats-next.adoc
+++ b/downstream/assemblies/platform/assembly-platform-whats-next.adoc
@@ -10,6 +10,5 @@ Whether you are a new {PlatformNameShort} user looking to start automating, or a
 //isolated node migration
 //playbooks to download
 
-
 include::assembly-migrate-platform.adoc[leveloffset=+1]
 include::platform/con-why-automation-mesh.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-aap-installation-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-installation-prereqs.adoc
@@ -4,10 +4,10 @@
 
 [role="_abstract"]
 
-* You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
+* You chose and obtained a platform installer from the link:https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
-* You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
+* You have created a Red Hat Registry Service Account, following the instructions in the link:https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 [role="_additional-resources"]
 .Additional resources
-For more information about obtaining a platform installer or system requirements, refer to the link:https://https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} system requirements] in the _{PlatformName} Planning Guide_.
+For more information about obtaining a platform installer or system requirements, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} system requirements] in the _{PlatformName} Planning Guide_.

--- a/downstream/modules/platform/con-why-automation-mesh.adoc
+++ b/downstream/modules/platform/con-why-automation-mesh.adoc
@@ -6,6 +6,6 @@ The {AutomationMesh} component of the {PlatformName} simplifies the process of d
 
 When upgrading from version 1.x to the latest version of the {PlatformNameShort}, you will need to migrate the data from your legacy isolated nodes into execution nodes necessary for {AutomationMesh}. You can implement {AutomationMesh} by planning out a network of hybrid and control nodes, then editing the inventory file found in the {PlatformNameShort} installer to assign mesh-related values to each of your execution nodes.
 
-For instructions on how to migrate from isolated nodes to execution nodes, see the *upgrade & migration guide*.
+For instructions on how to migrate from isolated nodes to execution nodes, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
 
-For information about automation mesh and the various ways to design your automation mesh for your environment, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[Red Hat Ansible Automation Platform automation mesh guide].
+For information about automation mesh and the various ways to design your automation mesh for your environment, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[Red Hat Ansible Automation Platform automation mesh guide].

--- a/downstream/modules/platform/con-why-migrate-ansible-29.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-29.adoc
@@ -2,4 +2,8 @@
 
 = Migrating to Ansible Engine 2.9 images using {Builder}
 
-To migrate Ansible Engine 2.9 images for use with {PlatformNameShort} {PlatformVers}, the `ansible-builder` tool automates the process of rebuilding images (including its custom plugins and dependencies) for use with {ExecEnvName}. For more information on using Ansible Builder to build execution environments, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+To migrate Ansible Engine 2.9 images for use with {PlatformNameShort} {PlatformVers}, the `ansible-builder` tool automates the process of rebuilding images (including its custom plugins and dependencies) for use with {ExecEnvName}.
+
+[role="_additional-resources"]
+.Additional resources
+For more information on using Ansible Builder to build execution environments, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
@@ -2,4 +2,4 @@
 
 = Migrating to Ansible Core 2.12
 
-When upgrading to Ansible Core 2.12, you will need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.12 compatible, see the https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.12.html[Ansible-core 2.12 Porting Guide].
+When upgrading to Ansible Core 2.12, you will need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.12 compatible, see the link:https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.12.html[Ansible-core 2.12 Porting Guide].

--- a/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
@@ -2,4 +2,4 @@
 
 = Migrating to Ansible Core 2.13
 
-When upgrading to Ansible Core 2.13, you need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content for Ansible Core 2.13 compatibility, see the https://https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.13.html[Ansible-core 2.13 Porting Guide].
+When upgrading to Ansible Core 2.13, you need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content for Ansible Core 2.13 compatibility, see the link:https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.13.html[Ansible-core 2.13 Porting Guide].

--- a/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
+++ b/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
@@ -4,4 +4,10 @@
 
 {PlatformNameShort} {PlatformVers} moves you away from custom Python virtual environments (venvs) in favor of automation execution environments - containerized images that packages the necessary components needed to execute and scale your Ansible automation. This includes Ansible Core, Ansible Content Collections, Python dependencies, Red Hat Enterprise Linux UBI 8, and any additional package dependencies.
 
-If you are looking to migrate your venvs to execution environments, you will (1) need to use the `awx-manage` command to list and export a list of venvs from your original instance, then (2) use `ansible-builder` to create execution environments. For more information, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/upgrading-to-ees[Upgrading to Automation Execution Environments guide] and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+If you are looking to migrate your venvs to execution environments, you will (1) need to use the `awx-manage` command to list and export a list of venvs from your original instance, then (2) use `ansible-builder` to create execution environments.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/upgrading-to-ees[Upgrading to Automation Execution Environments guide]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -16,7 +16,7 @@ The {ControllerName} server is accessible from port 80 (*https://<TOWER_SERVER_N
 
 [IMPORTANT]
 ====
-If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the Red Hat Customer portal at https://access.redhat.com/.
+If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the link:https://access.redhat.com/[Red Hat Customer portal].
 ====
 
 Upon a successful login to {ControllerName}, your installation of {PlatformName} {PlatformVers} is complete.

--- a/downstream/modules/platform/proc-verify-hub-installation.adoc
+++ b/downstream/modules/platform/proc-verify-hub-installation.adoc
@@ -12,7 +12,7 @@ Verify that you installed your {HubName} successfully by logging in with the adm
 
 [IMPORTANT]
 ====
-If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the Red Hat Customer portal at https://access.redhat.com/.
+If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the  link:https://access.redhat.com/[Red Hat Customer portal].
 ====
 
 Upon a successful login to {HubName}, your installation of {PlatformName} {PlatformVers} is complete.

--- a/downstream/modules/platform/ref-controller-configs.adoc
+++ b/downstream/modules/platform/ref-controller-configs.adoc
@@ -8,9 +8,9 @@ See the following resources to explore additional {ControllerName} configuration
 [options="header"]
 |====
 |Resource link|Description
-|https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Automation Controller Quick Setup Guide]|Set up {ControllerName} and run your first playbook
-|https://docs.ansible.com/automation-controller/latest/html/administration/index.html[Automation Controller Administration Guide]|Configure {ControllerName} administration through customer scripts, management jobs, etc.
-|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_operations_guide/assembly-configuring-proxy-support[Configuring proxy support for {PlatformName}]|Set up {ControllerName} with a proxy server
-|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_operations_guide/assembly-controlling-data-collection[Managing usability analytics and data collection from {ControllerName}]|Manage what {ControllerName} information you share with Red Hat
-|https://docs.ansible.com/automation-controller/latest/html/userguide/index.html[Automation Controller User Guide]|Review {ControllerName} functionality in more detail
+|link:https://docs.ansible.com/automation-controller/latest/html/quickstart/index.html[Automation Controller Quick Setup Guide]|Set up {ControllerName} and run your first playbook
+|link:https://docs.ansible.com/automation-controller/latest/html/administration/index.html[Automation Controller Administration Guide]|Configure {ControllerName} administration through customer scripts, management jobs, etc.
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-configuring-proxy-support[Configuring proxy support for {PlatformName}]|Set up {ControllerName} with a proxy server
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-controlling-data-collection[Managing usability analytics and data collection from {ControllerName}]|Manage what {ControllerName} information you share with Red Hat
+|link:https://docs.ansible.com/automation-controller/latest/html/userguide/index.html[Automation Controller User Guide]|Review {ControllerName} functionality in more detail
 |====

--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -8,7 +8,7 @@ Use this example to populate the inventory file to install {PlatformName}. This 
 
 [IMPORTANT]
 ====
-This example does not have a host under the database group. This indicates to the installer that the database  already exists, and is being managed elsewhere.
+This example does not have a host under the database group. This indicates to the installer that the database already exists, and is being managed elsewhere.
 ====
 
 -----

--- a/downstream/modules/platform/ref-hub-configs.adoc
+++ b/downstream/modules/platform/ref-hub-configs.adoc
@@ -8,7 +8,7 @@ See the following resources to explore additional {HubName} configurations.
 [options="header"]
 |====
 |Resource link|Description
-|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}]|Configure user access for {HubName}
-|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in {HubName}]|Add content to your {HubName}
-|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}]|Configure user access for {HubName}
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in {HubName}]|Add content to your {HubName}
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}
 |====


### PR DESCRIPTION
This PR updates links to the doc set on the customer portal to always point to the latest version by using the PlatformVers attribute.

Change 2.3 in links to {PlatformVers}
Include the link: for all links.
Include alt text where missing.
Other minor formatting fixes.