### PR TITLE
2.3 Updated link in installation guide (#712)

### DIFF
--- a/downstream/modules/platform/con-aap-installation-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-installation-prereqs.adoc
@@ -6,7 +6,7 @@
 
 * You chose and obtained a platform installer from the link:https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
-* You have created a Red Hat Registry Service Account, following the instructions in the link:https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
+* You have created a Red Hat Registry Service Account, using the instructions in the link:https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Corrected link

Wrong link towards Red Hat Ansible Automation Platform system requirements

https://issues.redhat.com/browse/AAP-7804