### PR TITLE
AAP-7870 updated installation guide

### DIFF
--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -19,8 +19,8 @@ The download and installation of the setup bundle needs to be located on the aut
 +
 ----
 $ tar xvf \
-   ansible-automation-platform-setup-bundle-2.2.1.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.2.1-1
+   ansible-automation-platform-setup-bundle-2.3.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.3-1
 ----
 +
 . Edit the inventory file to include the required options

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -19,8 +19,8 @@ The download and installation of the setup bundle needs to be located on the aut
 +
 ----
 $ tar xvf \
-   ansible-automation-platform-setup-bundle-2.3.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.3-1
+   ansible-automation-platform-setup-bundle-2.3-1.1.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.3-1.1
 ----
 +
 . Edit the inventory file to include the required options

--- a/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
+++ b/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
@@ -32,6 +32,7 @@ To perform a reposync you need a RHEL host that has access to the Internet. Afte
 
 .. jb-eap-7.3-for-rhel-8-x86_64-rpms
 .. rh-sso-7.4-for-rhel-8-x86_64-rpms
+
 +
 After the reposync is completed your repositories are ready to use with a web server.
 


### PR DESCRIPTION
Updated [1] [proc-installing-the-aap-setup-bundle.adoc](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/disconnected-installation#installing_the_setup_bundle) and [2] p[roc-synchronizing-rpm-repositories-by-using-reposync.adoc](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/disconnected-installation#proc-synchronizing-rpm-repositories-by-using-reposync_disconnected-installation) within the AAP Installation Guide

[1] Updated command to untar the bundle 
[2] Fixed git merge conflict