### PR TITLE
AAP-6697 updated builder guide section 2.1

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -11,11 +11,11 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 . In your terminal, run the following command to activate your {PlatformNameShort} repo:
 +
 ----
-$ dnf config-manager --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms 
+# dnf config-manager --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms 
 ----
 +
 . Then enter the following command to install {Builder}:
 +
 ----
-$ dnf install ansible-builder
+# dnf install ansible-builder
 ----


### PR DESCRIPTION
Updated command to use root (#) instead of normal user ($) within Ansible Builder Guide section 2.1 (https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/ansible_builder_guide/index#proc-installing-builder)