### PR TITLE
AAP-4995 - Add AWX deployment to list of migration options (#703)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -10,11 +10,11 @@ ifdef::context[:parent-context: {context}]
 
 Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
 
-This guide allows you to migrate:
+Use these procedures to migrate any of the following deployments to the {OperatorPlatform}:
 
-* A VM-based installation of {ControllerName} or {HubName}, or
-* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
-
+* A VM-based installation of {ControllerName} or {HubName},
+* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2), or
+* An AWX instance
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR backports the changes from PR 703 to the 2.3 branch and includes the following:

* AAP-4995 - Add AWX deployment to list of migration options

* AAM-4995 - minor grammatical change

* AAP-4995 - Updated bullet based on SME feedback