### PR TITLE
AAP-7610 Added troubleshooting topic and included procedure

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-troubleshoot-backup-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-troubleshoot-backup-recovery.adoc
@@ -1,0 +1,17 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="aap-troubleshoot-backup-recover"]
+
+:context: troubleshooting
+
+= Troubleshooting
+
+[role="_abstract"]
+
+Use this information to diagnose and resolve issues during backup and recovery.
+
+include::platform/proc-troubleshoot-same-name.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-aap-controller-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-restore.adoc
@@ -7,7 +7,7 @@ Use this procedure to restore a previous controller deployment from an Automatio
 
 [NOTE]
 ====
-The name specified for the new AutomationController custom resource must not match an existing deployment or the recovery process will fail.
+The name specified for the new AutomationController custom resource must not match an existing deployment or the recovery process will fail. Ifthe name specified does match an existing deployment, see xref:aap-troubleshoot-backup-recover[Troubleshooting] for steps to resolve the issue.
 ====
 
 .Prerequisites

--- a/downstream/modules/platform/proc-aap-controller-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-restore.adoc
@@ -7,7 +7,7 @@ Use this procedure to restore a previous controller deployment from an Automatio
 
 [NOTE]
 ====
-The name specified for the new AutomationController custom resource must not match an existing deployment or the recovery process will fail. Ifthe name specified does match an existing deployment, see xref:aap-troubleshoot-backup-recover[Troubleshooting] for steps to resolve the issue.
+The name specified for the new AutomationController custom resource must not match an existing deployment or the recovery process will fail. If the name specified does match an existing deployment, see xref:aap-troubleshoot-backup-recover[Troubleshooting] for steps to resolve the issue.
 ====
 
 .Prerequisites

--- a/downstream/modules/platform/proc-troubleshoot-same-name.adoc
+++ b/downstream/modules/platform/proc-troubleshoot-same-name.adoc
@@ -1,0 +1,23 @@
+[id="troubleshoot-same-name"]
+
+= {ControllerNameStart} custom resource has the same name as an existing deployment
+
+The name specified for the new AutomationController custom resource must not match an existing deployment or the recovery process will fail.
+
+[role=_abstract]
+If your AutomationController customer resource matches an existing deployment, perform the following steps to resolve the issue.
+
+.Procedure
+. Delete the existing AutomationController and the associated postgres PVC:
++
+-----
+oc delete automationcontroller <YOUR_DEPLOYMENT_NAME> -n <YOUR_NAMESPACE>
+
+oc delete pvc postgres-13-<YOUR_DEPLOYMENT_NAME>-13-0 -n <YOUR_NAMESPACE>
+-----
++
+. Use AutomationControllerRestore with the same deployment_name in it:
++
+-----
+oc apply -f restore.yaml
+-----

--- a/downstream/titles/aap-operator-backup/master.adoc
+++ b/downstream/titles/aap-operator-backup/master.adoc
@@ -22,4 +22,4 @@ include::platform/assembly-aap-backup.adoc[leveloffset=+1]
 
 include::platform/assembly-aap-recovery.adoc[leveloffset=+1]
 
-include::platform/assembly-troubleshoot-backup-recovery.adoc[leveloffset=+1]
+include::platform/assembly-aap-troubleshoot-backup-recovery.adoc[leveloffset=+1]

--- a/downstream/titles/aap-operator-backup/master.adoc
+++ b/downstream/titles/aap-operator-backup/master.adoc
@@ -21,3 +21,5 @@ include::platform/assembly-aap-backup-recovery.adoc[leveloffset=+1]
 include::platform/assembly-aap-backup.adoc[leveloffset=+1]
 
 include::platform/assembly-aap-recovery.adoc[leveloffset=+1]
+
+include::platform/assembly-troubleshoot-backup-recovery.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses the changes required by https://issues.redhat.com/browse/AAP-7610.

Changes include:

- Added a Troubleshooting topic
- Added procedure to recover when the CR name matches an existing resource
- Added a link within the Backup section pointing to troubleshooting

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP7610/master.html

Affects `/titles/aap-operator-backup`