### PR TITLE
Backport - AAP-PG - Fixed typo in Ansible version (#741)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -24,7 +24,7 @@ h| Subscription | Valid Red Hat Ansible Automation Platform |
 
 h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version 2.2 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
+h| Ansible | version 2.12 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
 
 h| Python | 3.8 or later |
 


### PR DESCRIPTION
This PR backports the changes from #741 into the 2.3 branch.