### PR TITLE
AAP-7625 - added information for RPM installed package

### DIFF
--- a/downstream/modules/platform/proc-editing-inventory-file.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file.adoc
@@ -10,6 +10,12 @@ You can use the {PlatformName} installer inventory file to specify your installa
 .Procedure
 
 . Navigate to the installer:
+.. [RPM installed package]
++
+-----
+$ cd /opt/ansible-automation-platform/installer/
+-----
++
 .. [bundled installer]
 +
 -----


### PR DESCRIPTION
This PR addresses the changes required by https://issues.redhat.com/browse/AAP-7625. Changes include:

Adding information on RPM installed package to section 2.1 Editing the Red Hat Ansible Automation Platform installer inventory file.

Preview link [VPN required]: http://file.rdu.redhat.com/~ddacosta/AAP7625/master.html