### PR TITLE
Backport 2.1 745 (AAP-8064 Updated code in step 3 of chpt 5.2)

### DIFF
--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -51,19 +51,7 @@ metadata:
   name: example
   namespace: ansible-automation-platform
 spec:
-  create_preload_data: true
-  route_tls_termination_mechanism: Edge
-  garbage_collect_secrets: false
-  loadbalancer_port: 80
-  image_pull_policy: IfNotPresent
-  projects_storage_size: 8Gi
-  task_privileged: false
-  projects_storage_access_mode: ReadWriteMany
-  projects_persistence: false
   replicas: 1
-  admin_user: admin
-  loadbalancer_protocol: http
-  nodeport_port: 30080
 
 -----
 +


### PR DESCRIPTION
Updated "[Chapter 5.2 Subscribing a namespace to an operator using the OpenShift Container Platform CLI](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_operator_installation_guide/installing-aap-operator-cli#proc-install-cli-aap-operatorinstalling-aap-operator-cli)", step 3 code section by replacing lines after the last spec: in the code with replicas: 1 , per SME Shane McDonald (based on [AAP-1332](https://issues.redhat.com/browse/AAP-1332) and [AAP-7741](https://issues.redhat.com/browse/AAP-7741).