### PR TITLE
Backport - AAP-8221 - Refining Planning Guide structure (#735)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -1,0 +1,30 @@
+ifdef::context[:parent-context: {context}]
+
+[id="ref-aap-components"]
+
+= {PlatformName} platform components
+
+:context: planning
+
+
+[role="_abstract"]
+{PlatformNameShort} is a modular platform composed of separate components that can be connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName} which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Then, you can add to your deployment any combination of the following automation platform components:
+
+include::platform/con-about-automation-hub.adoc[leveloffset=+1]
+
+include::platform/con-about-pa-hub.adoc[leveloffset=+1]
+
+//[dcd-moved this description to the intro to platform components since it is the only "required" component. include::platform/con-about-automation-controller.adoc[leveloffset=+1]
+
+include::platform/con-about-services-catalog.adoc[leveloffset=+1]
+
+include::platform/con-overview-automation-mesh.adoc[leveloffset=+1]
+
+include::platform/con-about-execution-env.adoc[leveloffset=+1]
+
+include::platform/con-about-galaxy.adoc[leveloffset=+1]
+
+include::platform/con-about-navigator.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-attaching-subscriptions.adoc
+++ b/downstream/assemblies/platform/assembly-attaching-subscriptions.adoc
@@ -1,0 +1,70 @@
+
+
+[id="proc-attaching-subscriptions_{context}"]
+
+= Attaching your {PlatformName} subscription
+
+[role="_abstract"]
+You *must* have valid subscriptions attached on all nodes before installing {PlatformName}. Attaching your {PlatformNameShort} subscription allows you to access subcription-only resources necessary to proceed with the installation.
+
+NOTE: Attaching a subscription is unnecessary if you have enabled link:https://access.redhat.com/articles/simple-content-access[Simple Content Access Mode] on your Red Hat account. Once enabled, you will need to register your systems to either Red Hat Subscription Management (RHSM) or Satellite before installing the {PlatformNameShort}. See link:https://access.redhat.com/articles/simple-content-access[Simple Content Access Mode] for more information.
+
+.Procedure
+
+. Obtain the `pool_id` for your {PlatformName} subscription:
++
+-----
+# subscription-manager list --available --all | grep "Ansible Automation Platform" -B 3 -A 6
+-----
++
+[NOTE]
+====
+Do not use MCT4022 as a `pool_id` for your subscription because it can cause {PlatformNameShort} subscription attachment to fail.
+====
++
+.Example
+An example output of the `*subsciption-manager list*` command. Obtain the `pool_id` as seen in the `Pool ID:` section:
++
+-----
+Subscription Name: Red Hat Ansible Automation, Premium (5000 Managed Nodes)
+  Provides: Red Hat Ansible Engine
+  Red Hat Ansible Automation Platform
+  SKU: MCT3695
+  Contract: ````
+  Pool ID: <pool_id>
+  Provides Management: No
+  Available: 4999
+  Suggested: 1
+-----
++
+. Attach the subscription:
++
+-----
+# subscription-manager attach --pool=<pool_id>
+-----
+
+You have now attached your {PlatformName} subscriptions to all nodes.
+
+.Verification
+
+* Verify the subscription was successfully attached:
+
+-----
+# subscription-manager list --consumed
+-----
+
+.Troubleshooting
+
+* If you are unable to locate certain packages that came bundled with the {PlatformNameShort} installer, or if you are seeing a `_Repositories disabled by configuration_` message, try enabling the repository using the command:
++
+Red Hat Ansible Automation Platform 2.3 for RHEL 8
++
+----
+subscription-manager repos --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms
+----
++
+Red Hat Ansible Automation Platform 2.3 for RHEL 9
++
+----
+subscription-manager repos --enable ansible-automation-platform-2.3-for-rhel-9-x86_64-rpms
+----

--- a/downstream/assemblies/platform/assembly-choosing-obtaining-installer.adoc
+++ b/downstream/assemblies/platform/assembly-choosing-obtaining-installer.adoc
@@ -1,0 +1,10 @@
+// [id="proc-choosing-obtaining-installer_{context}"]
+
+
+= Choosing and obtaining a {PlatformName} installer
+
+[role="_abstract"]
+Choose the {PlatformName} installer you need based on your Red Hat Enterprise Linux environment internet connectivity. Review the scenarios below and determine which {PlatformName} installer meets your needs.
+
+include::platform/proc-installing-with-internet.adoc[leveloffset=+1]
+include::platform/proc-installing-without-internet.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -1,0 +1,62 @@
+//[id="con-inventory-introduction_{context}"]
+
+= About the installer inventory file
+
+{PlatformName} works against a list of managed nodes or hosts in your infrastructure that are logically organized, using an inventory file.
+You can use the {PlatformName} installer inventory file to specify your installation scenario and describe host deployments to Ansible.
+By using an inventory file, Ansible can manage a large number of hosts with a single command.
+Inventories also help you use Ansible more efficiently by reducing the number of command line options you have to specify.
+
+The inventory file can be in one of many formats, depending on the inventory plugins that you have.
+The most common formats are `INI` and `YAML`.
+Inventory files listed in this document are shown in INI format.
+
+The location of the inventory file depends on the installer you used.
+The following table shows possible locations:
+
+[cols="30%,70%",options="header"]
+|====
+| Installer | Location
+| *Bundle tar* | `/ansible-automation-platform-setup-bundle-<latest-version>`
+| *Non-bundle tar* | `/ansible-automation-platform-setup-<latest-version>`
+| *RPM* | `/opt/ansible-automation-platform/installer`
+|====
+
+You can verify the hosts in your inventory using the command:
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+ansible all -i <path-to-inventory-file. --list-hosts
+----
+
+.Example inventory file
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+[automationcontroller]
+host1.example.com
+host2.example.com
+Host4.example.com
+
+[automationhub]
+host3.example.com
+
+[database]
+Host5.example.com
+
+[all:vars]
+admin_password='<password>'
+
+pg_host=''
+pg_port=''
+
+pg_database='awx'
+pg_username='awx'
+pg_password='<password>'
+
+registry_url='registry.redhat.io'
+registry_username='<registry username>'
+registry_password='<registry password>'
+----
+
+The first part of the inventory file specifies the hosts or groups that Ansible can work with.

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -1,0 +1,265 @@
+
+[id="ref-network-ports-protocols_{context}"]
+
+= Network ports and protocols
+
+[role="_abstract"]
+
+{PlatformName} (AAP) uses a number of ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+
+The following tables provide the default {PlatformName} destination ports required for each application.
+
+[NOTE]
+The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you may experience a change in behavior.
+
+
+
+.PostgreSQL
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`pg_port`
+|Remote access during installation
+|5432
+|TCP
+|Postgres
+|Inbound and Outbound
+|`pg_port`
+a|Default port
+
+ALLOW connections from controller(s) to database port
+|===
+
+.{ControllerNameStart}
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|80
+|TCP
+|HTTP
+|Inbound
+|`nginx_http_port`
+|UI/API
+
+|443
+|TCP
+|HTTPS
+|Inbound
+|`nginx_https_port`
+|UI/API
+
+|5432
+|TCP
+|PostgreSQL
+|Inbound and Outbound
+|`pg_port`
+a|Open *only* if the internal database is used along with another component. Otherwise, this port should not be open
+
+Hybrid mode in a cluster
+
+|27199
+|TCP
+|Receptor
+|Inbound and Outbound
+|`receptor_listener_port`
+|ALLOW receptor listener port across all controllers for mandatory & automatic control plane clustering
+|===
+
+.Hop Nodes
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|27199
+|TCP
+|Receptor
+|Inbound and Outbound
+|`receptor_listener_port`
+a|Mesh
+
+ALLOW connection from controller(s) to Receptor port
+|===
+
+.Execution Nodes
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|27199
+|TCP
+|Receptor
+|Inbound and Outbound
+|`receptor_listener_port`
+a|Mesh - Nodes directly peered to controllers. No hop nodes involved. 27199 is bi-directional for the execution nodes
+
+ALLOW connections from controller(s) to Receptor port (non-hop connected nodes)
+
+ALLOW connections from hop node(s) to Receptor port (if relayed through hop nodes)
+|===
+
+.Control Nodes
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|27199
+|TCP
+|Receptor
+|Inbound and Outbound
+|`receptor_listener_port`
+a|Mesh - Nodes directly peered to controllers. Direct nodes involved. 27199 is bi-diretional for execution nodes
+
+ENABLE connections from controller(s) to Receptor port for non-hop connected nodes
+
+ENABLE connections from hop node(s) to Receptor port if relayed through hop nodes
+|443
+|TCP
+|Podman
+|Inbound
+|`nginx_https_port`
+|UI/API
+|===
+
+.Hybrid Nodes
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|27199
+|TCP
+|Receptor
+|Inbound and Outbound
+|`receptor_listener_port`
+a|Mesh - Nodes directly peered to controllers. No hop nodes involved. 27199 is bi-directional for the execution nodes
+
+ENABLE connections from controller(s) to Receptor port for non-hop connected nodes
+
+ENABLE connections from hop node(s) to Receptor port if relayed through hop nodes
+
+|443
+|TCP
+|Podman
+|Inbound
+|`nginx_https_port`
+|UI/API
+|===
+
+.{HubNameStart}
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+
+|80
+|TCP
+|HTTP
+|Inbound
+|`nginx_http_port`
+|User interface
+|443
+|TCP
+|HTTPS
+|Inbound
+|`nginx_https_port`
+|User interface
+|5432
+|TCP
+|PostgreSQL
+|Inbound and Outbound
+|`pg_port`
+a|Open *only* if the internal database is used along with another component. Otherwise, this port should not be open
+|===
+
+.Services Catalog
+[options="header"]
+|===
+|Port |Protocol |Service |Direction |Installer Inventory Variable |Required for
+|22
+|TCP
+|SSH
+|Inbound and Outbound
+|`ansible_port`
+|Installation
+|443
+|TCP
+|HTTPS
+|Inbound
+|`nginx_https_port`
+|Access to Service Catalog user interface
+|5432
+|TCP
+|PostgreSQL
+|Inbound and Outbound
+|`pg_port`
+a|Open *only* if the internal database is used. Otherwise, this port should not be open
+|===
+
+.{InsightsName}
+[options="header"]
+|===
+|URL |Required for
+|link:http://api.access.redhat.com:443[http://api.access.redhat.com:443] |General account services, subscriptions
+|link:https://cert-api.access.redhat.com:443[https://cert-api.access.redhat.com:443] |Insights data upload
+|link:https://cert.cloud.redhat.com:443[https://cert.cloud.redhat.com:443] |Inventory upload and Cloud Connector connection
+|link:https://cloud.redhat.com[https://cloud.redhat.com] |Access to Insights dashboard
+|===
+
+.Automation Hub
+[options="header"]
+|===
+|URL |Required for
+|link:https://console.redhat.com:443[https://console.redhat.com:443] |General account services, subscriptions
+|link:https://sso.redhat.com:443[https://sso.redhat.com:443] |TCP
+|link:https://automation-hub-prd.s3.amazonaws.com[https://automation-hub-prd.s3.amazonaws.com] |
+|link:https://galaxy.ansible.com[https://galaxy.ansible.com] |Ansible Community curated Ansible content
+|link:https://ansible-galaxy.s3.amazonaws.com[https://ansible-galaxy.s3.amazonaws.com] |
+|link:https://registry.redhat.io:44[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
+|link:https://cert.cloud.redhat.com:443[https://cert.cloud.redhat.com:443] |Red Hat and partner curated Ansible Collections
+|===
+
+.Execution Environments (EE)
+[options="header"]
+|===
+|URL |Required for
+|link:https://registry.redhat.io:44[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
+|===

--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -1,8 +1,6 @@
 
 ifdef::context[:parent-context: {context}]
 
-
-
 [id="planning-installation"]
 = Planning your {PlatformName} installation
 
@@ -13,80 +11,6 @@ ifdef::context[:parent-context: {context}]
 Red Hat Ansible Automation Platform is supported on both Red Hat Enterprise Linux and Red Hat Openshift. Use this guide to plan your Red Hat Ansible Automation Platform installation on Red Hat Enterprise Linux.
 
 To install {PlatformName} on your Red Hat OpenShift Container Platform environment, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
-
-include::platform/ref-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-platform-components.adoc[leveloffset=+1]
-include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-automation-hub-requirements.adoc[leveloffset=+1]
-include::platform/ref-postgresql-requirements.adoc[leveloffset=+1]
-include::platform/ref-network-ports-protocols.adoc[leveloffset=+1]
-
-include::platform/proc-attaching-subscriptions.adoc[leveloffset=+1]
-
-include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
-
-//New section here
-include::platform/con-inventory-introduction.adoc[leveloffset=+1]
-include::platform/ref-guidelines-hosts-groups.adoc[leveloffset=+2]
-include::platform/ref-deprovisioning.adoc[leveloffset=+2]
-include::platform/con-inventory-variables-intro.adoc[leveloffset=+2]
-include::platform/con-declaring-variables.adoc[leveloffset=+2]
-include::platform/proc-securing-secrets-in-inventory.adoc[leveloffset=+2]
-include::platform/con-editing-inventory-files.adoc[leveloffset=+2]
-//End of new section
-
-== Supported installation scenarios
-
-Red Hat supports the following installation scenarios for {PlatformName}:
-
-[role="_additional-resources"]
-.Additional resources
-To edit inventory file parameters to specify a supported installation scenario, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#con-install-scenario-examples[Inventory file examples based on installation scenarios] in the _{PlatformName} Installation Guide_.
-
-//[dcd 12/8/2022 Removing links until new guides are published because some topics were removed and others were added.]
-include::platform/con-SM-standalone-contr-non-inst-database.adoc[leveloffset=+2]
-
-//[dcd 12/7/22] Changing xrefs to links because information is in a separate document due to restructuring.
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] to get started.
-
-//See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
-
-include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] to get started.
-
-//See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
-
-include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] to get started.
-
-//See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
-
-include::platform/con-SM-standalone-hub-ext-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-ext-database[Installing {HubName} with an external database] to get started.
-
-//See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
-
-include::platform/con-platform-non-inst-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] to get started.
-
-//See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
-
-include::platform/con-platform-ext-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-ext-database[Installing {PlatformName} with an external managed database] to get started.
-
-//See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
-
-include::platform/con-cluster-platform-ext-database.adoc[leveloffset=+2]
-
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] to get started.
-
-//See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster installation_ to get started.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
+++ b/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
@@ -1,0 +1,54 @@
+[id="supported-installation-scenarios_{context}"]
+
+= Supported installation scenarios
+
+Red Hat supports the following installations scenarios for {PlatformName}:
+
+[role="_additional-resources"]
+.Additional resources
+To edit inventory file parameters to specify a supported installation scenario, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#con-install-scenario-examples[Inventory file examples based on installation scenarios] in the _{PlatformName} Installation Guide_.
+
+//[dcd 12/8/2022 Removing links until new guides are published because some topics were removed and others were added.]
+include::platform/con-SM-standalone-contr-non-inst-database.adoc[leveloffset=+1]
+
+//[dcd 12/7/22] Changing xrefs to links because information is in a separate document due to restructuring.
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] to get started.
+
+//See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
+
+include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] to get started.
+
+//See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
+
+include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] to get started.
+
+//See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
+
+include::platform/con-SM-standalone-hub-ext-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-ext-database[Installing {HubName} with an external database] to get started.
+
+//See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
+
+include::platform/con-platform-non-inst-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] to get started.
+
+//See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
+
+include::platform/con-platform-ext-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-ext-database[Installing {PlatformName} with an external managed database] to get started.
+
+//See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
+
+include::platform/con-cluster-platform-ext-database.adoc[leveloffset=+1]
+
+//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] to get started.
+
+//See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster installation_ to get started.

--- a/downstream/assemblies/platform/assembly-system-requirements.adoc
+++ b/downstream/assemblies/platform/assembly-system-requirements.adoc
@@ -1,0 +1,16 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="platform-system-requirements"]
+= System requirements
+
+[role="_abstract"]
+Use this information when planning your {PlatformName} installations and designing {AutomationMesh} topologies that fit your use case.
+
+include::platform/ref-system-requirements.adoc[leveloffset=+1]
+include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]
+include::platform/ref-automation-hub-requirements.adoc[leveloffset=+1]
+include::platform/ref-postgresql-requirements.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-about-automation-controller.adoc
+++ b/downstream/modules/platform/con-about-automation-controller.adoc
@@ -1,0 +1,7 @@
+[id="con-about-automation-controller_{context}"]
+
+= {ControllerNameStart}
+
+
+[role="_abstract"]
+{ControllerNameStart} is an enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API).

--- a/downstream/modules/platform/con-about-automation-hub.adoc
+++ b/downstream/modules/platform/con-about-automation-hub.adoc
@@ -1,0 +1,8 @@
+[id="con-about-automation-hub_{context}"]
+
+= {HubNameMain}
+
+[role="_abstract"]
+{HubNameMain} is a repository for certified content of Ansible Content Collections.
+It is the centralized repository for Red Hat and its partners to publish content, and for customers to discover certified, supported Ansible Content Collections.
+{CertifiedCon} provides users with content that has been tested and is supported by Red Hat.

--- a/downstream/modules/platform/con-about-execution-env.adoc
+++ b/downstream/modules/platform/con-about-execution-env.adoc
@@ -1,0 +1,7 @@
+[id="con-about-execution-env_{context}"]
+
+= {ExecEnvNameStart}
+
+[role="_abstract"]
+{ExecEnvNameStart} are container images on which all automation in {PlatformName} is run. They provide a solution that includes the Ansible execution engine and hundreds of modules that help users automate all aspects of IT environments and processes.
+{ExecEnvNameStart} automate commonly used operating systems, infrastructure platforms, network devices, and clouds.

--- a/downstream/modules/platform/con-about-galaxy.adoc
+++ b/downstream/modules/platform/con-about-galaxy.adoc
@@ -1,0 +1,8 @@
+[id="con-about-galaxy_{context}"]
+
+= {Galaxy}
+
+
+[role="_abstract"]
+{Galaxy} is a hub for finding, reusing, and sharing Ansible content.
+Community-provided Galaxy content, in the form of prepackaged roles, can help start automation projects. Roles for provisioning infrastructure, deploying applications, and completing other tasks can be dropped into Ansible Playbooks and be applied immediately to customer environments.

--- a/downstream/modules/platform/con-about-navigator.adoc
+++ b/downstream/modules/platform/con-about-navigator.adoc
@@ -1,0 +1,6 @@
+[id="con-about-navigator_{context}"]
+
+= {Navigator}
+
+[role="_abstract"]
+{Navigator} is a _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an execution environment, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).

--- a/downstream/modules/platform/con-about-pa-hub.adoc
+++ b/downstream/modules/platform/con-about-pa-hub.adoc
@@ -1,0 +1,9 @@
+[id="con-about-pa-hub_{context}"]
+
+= {PrivateHubNameStart}
+
+[role="_abstract"]
+{PrivateHubNameStart} provides both disconnected and on premise solution for synchronizing content.
+You can synchronize collections and execution environment images from Red Hat cloud automation hub, storing and serving your own custom automation collections and execution images.
+You can also use other sources such as {Galaxy} or other container registries to provide content to your {PrivateHubName}.
+{PrivateHubNameStart} can integrate into your enterprise directory and your CI/CD pipelines.

--- a/downstream/modules/platform/con-about-services-catalog.adoc
+++ b/downstream/modules/platform/con-about-services-catalog.adoc
@@ -1,0 +1,14 @@
+[id="con-about-services-catalog_{context}"]
+
+= {CatalogNameStart}
+
+[role="_abstract"]
+{CatalogNameStart} is a service within {PlatformName}.
+{CatalogNameStart} enables you to organize and govern product catalog sources on Ansible {ControllerName} across various environments.
+
+Using {CatalogName} you can:
+
+* Apply multi-level approval to individual platform inventories.
+* Organize content in the form of products from your platforms into portfolios.
+* Choose portfolios to share with specific groups of users.
+* Set boundaries around values driving execution of user requests.

--- a/downstream/modules/platform/con-overview-automation-mesh.adoc
+++ b/downstream/modules/platform/con-overview-automation-mesh.adoc
@@ -1,0 +1,14 @@
+[id="con-overview-automation-mesh_{context}"]
+
+= {AutomationMeshStart}
+
+[role="_abstract"]
+{AutomationMeshStart} is an overlay network intended to ease the distribution of work across a large and dispersed collection of workers through nodes that establish peer-to-peer connections with each other using existing networks.
+
+{AutomationMeshStart} provides:
+
+* Dynamic cluster capacity that scales independently, allowing you to create, register, group, ungroup and deregister nodes with minimal downtime.
+* Control and execution plane separation that enables you to scale playbook execution capacity independently from control plane capacity.
+* Deployment choices that are resilient to latency, reconfigurable without outage, and that dynamically re-reroute to choose a different path when outages exist.
+* Mesh routing changes.
+* Connectivity that includes bi-directional, multi-hopped mesh communication possibilities which are Federal Information Processing Standards (FIPS) compliant.

--- a/downstream/modules/platform/proc-installing-with-internet.adoc
+++ b/downstream/modules/platform/proc-installing-with-internet.adoc
@@ -1,0 +1,40 @@
+
+
+[id="proc-installing-with-internet_{context}"]
+
+
+= Installing with internet access
+
+[role="_abstract"]
+Choose the {PlatformName} (AAP) installer if your Red Hat Enterprise Linux environment is connected to the internet. Installing with internet access retrieves the latest required repositories, packages, and dependencies. Choose one of the following ways to set up your AAP installer.
+
+.Tarball install
+
+. Navigate to https://access.redhat.com/downloads/content/480
+. Click *Download Now* for the *Ansible Automation Platform <latest-version> Setup*.
+. Extract the files:
++
+-----
+$ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
+-----
+
+.RPM install
+
+. Install Ansible Automation Platform Installer Package
++
+v.2.3 for RHEL 8 for x86_64
++
+----
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms ansible-automation-platform-installer
+----
++
+v.2.3 for RHEL 9 for x86-64
++
+----
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.3-for-rhel-9-x86_64-rpms ansible-automation-platform-installer
+----
+
+[NOTE]
+`dnf install` enables the repo as the repo is disabled by default.
+
+When you use the RPM installer, the files are placed under the `/opt/ansible-automation-platform/installer` directory. 

--- a/downstream/modules/platform/proc-installing-without-internet.adoc
+++ b/downstream/modules/platform/proc-installing-without-internet.adoc
@@ -1,0 +1,16 @@
+[id="proc-installing-without-internet_{context}"]
+
+
+= Installing without internet access
+
+[role="_abstract"]
+Use the {PlatformName} (AAP) *Bundle* installer if you are unable to access the internet, or would prefer not to install separate components and dependencies from online repositories. Access to Red Hat Enterprise Linux repositories is still needed. All other dependencies are included in the tar archive.
+
+.Procedure
+. Navigate to https://access.redhat.com/downloads/content/480
+. Click *Download Now* for the *Ansible Automation Platform <latest-version> Setup Bundle*.
+. Extract the files:
++
+-----
+$ tar xvzf ansible-automation-platform-setup-bundle-<latest-version>.tar.gz
+-----

--- a/downstream/modules/platform/ref-automation-hub-requirements.adoc
+++ b/downstream/modules/platform/ref-automation-hub-requirements.adoc
@@ -1,8 +1,8 @@
 [id="ref-automation-hub-requirements"]
 
-== {HubNameStart} system requirements
+= {HubNameStart} system requirements
 
-// Should be introductory text here.
+{HubNameStart} has the following system requirements:
 
 [cols="a,a,a"]
 |===

--- a/downstream/modules/platform/ref-controller-system-requirements.adoc
+++ b/downstream/modules/platform/ref-controller-system-requirements.adoc
@@ -1,6 +1,6 @@
 [id="ref-controller-system-requirements"]
 
-== {ControllerNameStart} system requirements
+= {ControllerNameStart} system requirements
 
 {ControllerNameStart} is a distributed system, where different software components can be co-located or deployed across multiple compute nodes.
 In the installer, node types of control, hybrid, execution, and hop are provided as abstractions to help you design the topology appropriate for your use case.
@@ -18,41 +18,41 @@ Runs automation. Increases memory and CPU to increase capacity for running more 
 [cols="a,a",options="header"]
 |===
 h| Requirement | Required
-| *RAM* | 16 GB  
+| *RAM* | 16 GB
 | *CPUs* | 4
 |===
 
-.Control nodes 
-Processes events and runs cluster jobs including project updates and cleanup jobs. 
+.Control nodes
+Processes events and runs cluster jobs including project updates and cleanup jobs.
 Increasing CPU and memory can help with job event processing.
 
 
 |===
 h| Requirement | Required
-| *RAM* | 16 GB  
+| *RAM* | 16 GB
 | *CPUs* | 4
 |===
 
 .Hybrid nodes
-Runs both automation and cluster jobs. 
+Runs both automation and cluster jobs.
 Comments on CPU and memory for execution and control nodes also apply to this node type.
 
 [cols="a,a,options="header"]
 |===
 h| Requirement | Required
-| *RAM* | 16 GB  
+| *RAM* | 16 GB
 | *CPUs* | 4
 |===
 
 .Hop nodes
-Serves to route traffic from one part of the Automation Mesh to another (for example, could be a bastion host into another network). 
-RAM could affect throughput, CPU activity is low. 
+Serves to route traffic from one part of the Automation Mesh to another (for example, could be a bastion host into another network).
+RAM could affect throughput, CPU activity is low.
 Network bandwidth and latency are generally a more important factor than either RAM or CPU.
 
 [cols="a,a,options="header"]
 |===
 h| Requirement | Required
-| *RAM* | 16 GB  
+| *RAM* | 16 GB
 | *CPUs* | 4
 |===
 
@@ -73,17 +73,17 @@ h| Disk: database node | 20 GB dedicated hard disk space |
 |===
 
 
-* All {ControllerName} data is stored in the database. 
+* All {ControllerName} data is stored in the database.
 Database storage increases with the number of hosts managed, number of jobs run, number of facts stored in the fact cache, and number of tasks in any individual job.
 For example, a playbook run every hour (24 times a day) across 250, hosts, with 20 tasks will store over 800000 events in the database every week.
 
-* If not enough space is reserved in the database, old job runs and facts will need cleaned on a regular basis. 
+* If not enough space is reserved in the database, old job runs and facts will need cleaned on a regular basis.
 Refer to link:https://docs.ansible.com/ansible-tower/3.8.3/html/administration/management_jobs.html#ag-management-jobs[Management Jobs] in the _Automation Controller Administration Guide_ for more information
 
-* Actual RAM requirements vary based on how many hosts {ControllerName} will manage simultaneously (which is controlled by the `forks` parameter in the job template or the system `ansible.cfg` file). 
+* Actual RAM requirements vary based on how many hosts {ControllerName} will manage simultaneously (which is controlled by the `forks` parameter in the job template or the system `ansible.cfg` file).
 To avoid possible resource conflicts, Ansible recommends 1 GB of memory per 10 forks + 2 GB reservation for {ControllerName}, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/jobs.html#at-capacity-determination-and-job-impact[Automation controller Capacity Determination and Job Impact] for further details. If `forks` is set to 400, 42 GB of memory is recommended.
-* A larger number of hosts can of course be addressed, though if the fork number is less than the total host count, more passes across the hosts are required. 
-These RAM limitations are avoided when using rolling updates or when using the provisioning callback system built into {ControllerName}, where each system requesting configuration enters a queue and is processed as quickly as possible; or in cases where {ControllerName} is producing or deploying images such as AMIs. 
+* A larger number of hosts can of course be addressed, though if the fork number is less than the total host count, more passes across the hosts are required.
+These RAM limitations are avoided when using rolling updates or when using the provisioning callback system built into {ControllerName}, where each system requesting configuration enters a queue and is processed as quickly as possible; or in cases where {ControllerName} is producing or deploying images such as AMIs.
 All of these are great approaches to managing larger environments. For further questions, please contact Ansible support through the Red Hat Customer portal at https://access.redhat.com/.
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/ref-platform-components.adoc
+++ b/downstream/modules/platform/ref-platform-components.adoc
@@ -1,26 +1,26 @@
-[id="ref-platform-components"]
+//[id="ref-aap-components"]
 
 = {PlatformName} platform components
 
 Red Hat Ansible Automation Platform consists of the following components:
 
 .{HubNameMain}
-A repository for certified content of Ansible Content Collections. 
-{HubNamemain} is the centralized repository for Red Hat and its partners to publish content, and for customers to discover certified, supported Ansible Content Collections. 
+A repository for certified content of Ansible Content Collections.
+{HubNamemain} is the centralized repository for Red Hat and its partners to publish content, and for customers to discover certified, supported Ansible Content Collections.
 {CertifiedCon} provides users with content that has been tested and is supported by Red Hat.
- 
+
 .{PrivateHubNameStart}
 {PrivateHubNameStart} provides both disconnected and on premise solution for synchronizing content.
-You can synchronize collections and execution environment images from Red Hat cloud automation hub, storing and serving your own custom automation collections and execution images. 
-You can also use other sources such as {Galaxy} or other container registries to provide content to your {PrivateHubName}. 
+You can synchronize collections and execution environment images from Red Hat cloud automation hub, storing and serving your own custom automation collections and execution images.
+You can also use other sources such as {Galaxy} or other container registries to provide content to your {PrivateHubName}.
 {PrivateHubNameStart} can integrate into your enterprise directory and your CI/CD pipelines.
 
- 
+
 .{ControllerNameStart}
 An enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API).
- 
+
 .{CatalogNameStart}
-{CatalogNameStart} is a service within {PlatformName}. 
+{CatalogNameStart} is a service within {PlatformName}.
 {CatalogNameStart} enables you to organize and govern product catalog sources on Ansible {ControllerName} across various environments.
 
 Using {CatalogName} you can:
@@ -29,7 +29,7 @@ Using {CatalogName} you can:
 * Organize content in the form of products from your platforms into portfolios.
 * Choose portfolios to share with specific groups of users.
 * Set boundaries around values driving execution of user requests.
- 
+
 .{AutomationMeshStart}
 {AutomationMeshStart} is an overlay network intended to ease the distribution of work across a large and dispersed collection of workers through nodes that establish peer-to-peer connections with each other using existing networks.
 
@@ -37,17 +37,17 @@ Using {CatalogName} you can:
 
 * Dynamic cluster capacity that scales independently, allowing you to create, register, group, ungroup and deregister nodes with minimal downtime.
 * Control and execution plane separation that enables you to scale playbook execution capacity independently from control plane capacity.
-* Deployment choices that are resilient to latency, reconfigurable without outage, and that dynamically re-reroute to choose a different path when outages exist. 
+* Deployment choices that are resilient to latency, reconfigurable without outage, and that dynamically re-reroute to choose a different path when outages exist.
 * Mesh routing changes.
 * Connectivity that includes bi-directional, multi-hopped mesh communication possibilities which are Federal Information Processing Standards (FIPS) compliant.
 
 .{ExecEnvNameStart}
-A solution that includes the Ansible execution engine and hundreds of modules that help users automate all aspects of IT environments and processes. 
-Execution environments automate commonly used operating systems, infrastructure platforms, network devices, and clouds. 
- 
+A solution that includes the Ansible execution engine and hundreds of modules that help users automate all aspects of IT environments and processes.
+Execution environments automate commonly used operating systems, infrastructure platforms, network devices, and clouds.
+
 .{Galaxy}
-A hub for finding, reusing, and sharing Ansible content. 
-Community-provided Galaxy content, in the form of prepackaged roles, can help start automation projects. Roles for provisioning infrastructure, deploying applications, and completing other tasks can be dropped into Ansible Playbooks and be applied immediately to customer environments. 
- 
+A hub for finding, reusing, and sharing Ansible content.
+Community-provided Galaxy content, in the form of prepackaged roles, can help start automation projects. Roles for provisioning infrastructure, deploying applications, and completing other tasks can be dropped into Ansible Playbooks and be applied immediately to customer environments.
+
 .{Navigator}
 A _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an execution environment, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).

--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -1,19 +1,19 @@
 [id="ref-postgresql-requirements"]
 
-== PostgreSQL requirements
+= PostgreSQL requirements
 
 {PlatformName} uses PostgreSQL 13.
 
 * PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
-* Because {ControllerName} and {HubName} use a Software Collections version of PostgreSQL in 3.8, you must enable the `rh-postgresql10` scl to access the database. 
+* Because {ControllerName} and {HubName} use a Software Collections version of PostgreSQL in 3.8, you must enable the `rh-postgresql10` scl to access the database.
 Administrators can use the `awx-manage dbshell` command, which automatically enables the PostgreSQL SCL.
 * To determine if your {ControllerName} instance has access to the database, you can do so with the command, `awx-manage check_db`.
 
 
 .PostgreSQL Configurations
 
-Optionally, you can configure the PostgreSQL database as separate nodes that are not managed by the {PlatformName} installer. 
-When the {PlatformNameShort} installer manages the database server, it configures the server with defaults that are generally recommended for most workloads. 
+Optionally, you can configure the PostgreSQL database as separate nodes that are not managed by the {PlatformName} installer.
+When the {PlatformNameShort} installer manages the database server, it configures the server with defaults that are generally recommended for most workloads.
 However, you can adjust these PostgreSQL settings for standalone database server node where `ansible_memtotal_mb` is the total memory size of the database server:
 
 -----

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -4,16 +4,8 @@
 
 = {PlatformName} system requirements
 
-Use this information when planning your {PlatformName} installations and designing {AutomationMesh} topologies that fit your use case.
-
-
-[role="_abstract"]
-
 Your system must meet the following minimum system requirements to install and run {PlatformName}.
 
-.Red Hat Ansible Automation Platform system requirements
-
-//Do we need this title?
 .Base system
 
 [cols="a,a,a"]

--- a/downstream/titles/aap-planning-guide/master.adoc
+++ b/downstream/titles/aap-planning-guide/master.adoc
@@ -1,7 +1,7 @@
 :imagesdir: images
 :numbered:
 :toclevels: 1
-
+:context: planning
 :experimental:
 
 include::attributes/attributes.adoc[]
@@ -15,5 +15,11 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 Use the information in this guide to plan your Red Hat Ansible Automation Platform installation.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]
+include::platform/assembly-aap-platform-components.adoc[leveloffset=+1]
+include::platform/assembly-system-requirements.adoc[leveloffset=+1]
+include::platform/assembly-network-ports-protocols.adoc[leveloffset=+1]
+include::platform/assembly-attaching-subscriptions.adoc[leveloffset=+1]
+include::platform/assembly-choosing-obtaining-installer.adoc[leveloffset=+1]
+include::platform/assembly-inventory-introduction.adoc[leveloffset=+1]
+include::platform/assembly-supported-installation-scenarios.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR backports the changes from PR735 to the 2.3 branch and includes the following changes:

* Refining Planning Guide structure
* Refactored chapter topics into assemblies