### PR TITLE
AAP4482 - add missing steps for configuring a Container Registry (#710)

### DIFF
--- a/downstream/assemblies/hub/assembly-setup-container-repository.adoc
+++ b/downstream/assemblies/hub/assembly-setup-container-repository.adoc
@@ -23,6 +23,7 @@ You can setup your container repository to add a description, include a README, 
 include::automation-hub/proc-add-container-readme.adoc[leveloffset=+1]
 include::automation-hub/proc-add-group-to-container-repo.adoc[leveloffset=+1]
 include::automation-hub/proc-tag-image.adoc[leveloffset=+1]
+include::automation-hub/proc-create-credential.adoc[leveloffset=+1]
 
 
 

--- a/downstream/modules/automation-hub/proc-create-credential.adoc
+++ b/downstream/modules/automation-hub/proc-create-credential.adoc
@@ -1,0 +1,20 @@
+[id="proc-create-credential"]
+
+= Creating a credential in {ControllerName}
+
+Previously, you were required to deploy a registry to store execution environment images. On {PlatformNameShort} 2.0 and later, it is assumed that you already have a container registry up and running. Therefore, you are only required to add the credentials of a container registry of your choice to store execution environment images.
+
+To pull container images from a password or token-protected registry, create a credential in {ControllerName}:
+
+.Procedure
+. Navigate to {ControllerName}
+. In the side-menu bar, click menu:Resources[Credentials].
+. Click btn:[Add] to create a new credential.
+. Enter an authorization *Name*, *Description*, and *Organization*.
+. Select the *Credential Type*.
+. Enter the *Authentication URL*. This is the container registry address.
+. Enter the *Username* and *Password or Token* required to log in to the container registry.
+. Optionally, select *Verify SSL* to enable SSL verification.
+. Click btn:[Save].
+
+//[dcd-This should be replaced with a link; otherwise, it's not helpful]For more information, please reference the Pulling from Protected Registries section of the Execution Environment documentation.

--- a/downstream/modules/automation-hub/proc-pull-image.adoc
+++ b/downstream/modules/automation-hub/proc-pull-image.adoc
@@ -12,6 +12,11 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 [role="_abstract"]
 You can pull images from the {HubName} container registry to make a copy to your local machine. {HubNameStart} provides the `podman pull` command for each `latest` image in the container repository.
 
+[NOTE]
+====
+If you need to pull container images from a password or token-protected registry, you must xref:proc-create-credential[create a credential in {ControllerName}] before pulling the image. 
+====
+
 .Procedure
 
 . Navigate to *Execution Environments*.

--- a/downstream/modules/builder/proc-pull-protected-registry.adoc
+++ b/downstream/modules/builder/proc-pull-protected-registry.adoc
@@ -10,4 +10,4 @@ To pull container images from a password or token-protected registry, create a c
 . Click btn:[Add] to create a new credential.
 . Supply an authorization URL, username, and password. Click btn:[Save].
 
-For more information, please reference the Pulling from Protected Registries section of the Execution Environment documentation.
+//[dcd-This should be replaced with a link; otherwise, it's not helpful]For more information, please reference the Pulling from Protected Registries section of the Execution Environment documentation.


### PR DESCRIPTION
This PR backports the changes from PR710 to the 2.3 branch and includes the following:

* AAP4482 - added missing steps for configuring a Container Registry

* AAP4482 - relocated new topic