### PR TITLE
AAP-3514 added links for OCP install of AAP (#693)

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 :context: operator-install-planning
 
 [role="_abstract"]
-{PlatformName} is supported on both Red Hat Enterprise Linux 8 and Red Hat Openshift.
+{PlatformName} is supported on both Red Hat Enterprise Linux and Red Hat Openshift.
 
 OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatform} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
 

--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -10,7 +10,9 @@ ifdef::context[:parent-context: {context}]
 :context: planning
 
 [role="_abstract"]
-You can use this section to help plan your {PlatformName} installation. Before installation, review information on the setup installer, system requirements, and supported installation scenarios.
+Red Hat Ansible Automation Platform is supported on both Red Hat Enterprise Linux and Red Hat Openshift. Use this guide to plan your Red Hat Ansible Automation Platform installation on Red Hat Enterprise Linux.
+
+To install {PlatformName} on your Red Hat OpenShift Container Platform environment, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
 
 include::platform/ref-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-network-ports-protocols.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -135,7 +135,6 @@ h| RAM | 8 GB minimum |
 
 h| CPUs | 2 minimum |
 
-<<<<<<< HEAD
 * For capacity based on forks in your configuration, see additional resources
 
 h| Disk: service node | 60 GB dedicated hard disk space |
@@ -203,7 +202,6 @@ If performing a bundled {PlatformNameShort} installation, the installation progr
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
 
-=======
 * If you choose to install Ansible on your own, the {PlatformNameShort} installation program detects that Ansible has been installed and does not attempt to reinstall it.
 
 [NOTE]
@@ -211,4 +209,3 @@ If you choose to install Ansible on your own, the {PlatformNameShort} installati
 You must install Ansible using a package manager such as `yum`, and the latest stable version of the package manager must be installed for {PlatformName} to work properly.
 Ansible version 2.9 is required for versions 3.8 and later.
 ====
->>>>>>> 4dbe23d (AAP-3514 added links for OCP install of AAP (#693))

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -21,7 +21,7 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid Red Hat Ansible Automation Platform |
 
-h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |
+h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
 h| Ansible | version 2.2 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
 
@@ -135,6 +135,7 @@ h| RAM | 8 GB minimum |
 
 h| CPUs | 2 minimum |
 
+<<<<<<< HEAD
 * For capacity based on forks in your configuration, see additional resources
 
 h| Disk: service node | 60 GB dedicated hard disk space |
@@ -202,3 +203,12 @@ If performing a bundled {PlatformNameShort} installation, the installation progr
 
 If you choose to install Ansible on your own, the {PlatformNameShort} installation program will detect that Ansible has been installed and will not attempt to reinstall it. Note that you must install Ansible using a package manager like ``yum`` and that the latest stable version must be installed for {PlatformName} to work properly. Ansible version 2.9 is required for |at| versions 3.8 and later.
 
+=======
+* If you choose to install Ansible on your own, the {PlatformNameShort} installation program detects that Ansible has been installed and does not attempt to reinstall it.
+
+[NOTE]
+====
+You must install Ansible using a package manager such as `yum`, and the latest stable version of the package manager must be installed for {PlatformName} to work properly.
+Ansible version 2.9 is required for versions 3.8 and later.
+====
+>>>>>>> 4dbe23d (AAP-3514 added links for OCP install of AAP (#693))


### PR DESCRIPTION
This PR backports the changes from PR693 to the 2.2 branch. Changes include the following:

* AAP-3514 added links for OCP install of AAP

* AAP-3514 Removed version number for RHEL per SME comment