### PR TITLE
AAP-7870 updated installation guide (#717)

### DIFF
--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -19,8 +19,8 @@ The download and installation of the setup bundle needs to be located on the aut
 +
 ----
 $ tar xvf \
-   ansible-automation-platform-setup-bundle-2.2.1.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.2.1-1
+   ansible-automation-platform-setup-bundle-2.3-1.1.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.3-1.1
 ----
 +
 . Edit the inventory file to include the required options

--- a/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
+++ b/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
@@ -36,6 +36,7 @@ To perform a reposync you need a RHEL host that has access to the Internet. Afte
 
 .. jb-eap-7.3-for-rhel-8-x86_64-rpms
 .. rh-sso-7.4-for-rhel-8-x86_64-rpms
+
 +
 After the reposync is completed your repositories are ready to use with a web server.
 


### PR DESCRIPTION
* AAP-7870 updated installation guide

* AAP-7870 updated version number

Changes made in [PR 717](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/717). Backporting to 2.3 as per [AAP-7870](https://issues.redhat.com/browse/AAP-7870).