### PR TITLE
AAP-6697 updated builder guide section 2.1 (#719)

### DIFF
--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -11,11 +11,11 @@ NOTE: You must have valid subscriptions attached on the host before installing `
 . In your terminal, run the following command to activate your {PlatformNameShort} repo:
 +
 ----
-$ dnf config-manager --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms 
+# dnf config-manager --enable ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms 
 ----
 +
 . Then enter the following command to install {Builder}:
 +
 ----
-$ dnf install ansible-builder
+# dnf install ansible-builder
 ----


### PR DESCRIPTION
Changes made under https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/719 as per [AAP-6697](https://issues.redhat.com/browse/AAP-6697).

Backporting to 2.3.