### PR TITLE
2.3 AAP-7897 Fix link in installation guide overview chapter (#771)

### DIFF
--- a/downstream/modules/platform/con-aap-installation-prereqs.adoc
+++ b/downstream/modules/platform/con-aap-installation-prereqs.adoc
@@ -10,4 +10,4 @@
 
 [role="_additional-resources"]
 .Additional resources
-For more information about obtaining a platform installer or system requirements, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} system requirements] in the _{PlatformName} Planning Guide_.
+For more information about obtaining a platform installer or system requirements, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements[{PlatformName} system requirements] in the _{PlatformName} Planning Guide_.


### PR DESCRIPTION
Backports #771 to 2.3

https://issues.redhat.com/browse/AAP-7897
Affects `/titles/aap-installation-guide/`

Update a link in the additional resources section of the Prerequisites section in the Installation Guide overview chapter.

The link should point to https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements