### PR TITLE
OP-FIX - correction to operator guide (#780)

### DIFF
--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -31,6 +31,8 @@ include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
 
+include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[leveloffset=+1]
+
 include::platform/assembly-aap-migration.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR pushes the changes from PR 780 to the 2.2 branch. 