### PR TITLE
AAP-2081 Fix image syntax in analytics guides

### DIFF
--- a/downstream/modules/analytics/proc-add-roles-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-roles-to-group.adoc
@@ -11,7 +11,7 @@ Adding roles to an existing group will grant new permissions to existing users i
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click the group you want to add users to.
 . Click *Add role*.

--- a/downstream/modules/analytics/proc-add-user-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-user-to-group.adoc
@@ -11,7 +11,7 @@ You can add users to groups when creating a group or by manually adding users to
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click the group you want to add users to.
 . Navigate to the Members tab, then click *Add member*.

--- a/downstream/modules/analytics/proc-create-groups.adoc
+++ b/downstream/modules/analytics/proc-create-groups.adoc
@@ -11,7 +11,7 @@ You can create and assign roles to a group that enables users to access specific
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click *Create group*.
 . A setup wizard will now appear. Enter a group name and description, then click *Next*.

--- a/downstream/modules/analytics/proc-edit-savings-plan.adoc
+++ b/downstream/modules/analytics/proc-edit-savings-plan.adoc
@@ -10,5 +10,5 @@ Edit any information about an existing savings plan by clicking on it from the s
 
 .Procedure
 . Navigate to *Red Hat Insights* > *Savings Planner*.
-. On the automation savings plan, click image:images/ellipsis.png[More,10,25] > *Edit*.
+. On the automation savings plan, click image:ellipsis.png[More,10,25] > *Edit*.
 . Make any changes to the automation plan, then click *Save*.

--- a/downstream/modules/analytics/proc-link-plan-job-template.adoc
+++ b/downstream/modules/analytics/proc-link-plan-job-template.adoc
@@ -10,5 +10,5 @@ You can associate a job template to a savings plan to allow {InsightsShort} to p
 
 .Procedure
 . Navigate to *Red Hat Insights* > *Savings Planner*.
-. Click image:images/ellipsis.png[More,10,25] > *Link Template*.
+. Click image:ellipsis.png[More,10,25] > *Link Template*.
 . Click *Save*.

--- a/downstream/titles/analytics/automation-savings-planner/master.adoc
+++ b/downstream/titles/analytics/automation-savings-planner/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/automation-savings/master.adoc
+++ b/downstream/titles/analytics/automation-savings/master.adoc
@@ -1,6 +1,7 @@
 // This assembly is included in the following assemblies:
 //
 
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/job-explorer/master.adoc
+++ b/downstream/titles/analytics/job-explorer/master.adoc
@@ -1,4 +1,4 @@
-
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/reports/master.adoc
+++ b/downstream/titles/analytics/reports/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/user-access/master.adoc
+++ b/downstream/titles/analytics/user-access/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 


### PR DESCRIPTION
Modify paths to images in analytics guides.
Part of AAP-2081

Affects
```
/titles/analytics/automation-savings
/titles/analytics/automation-savings-planner
/titles/analytics/job-explorer
/titles/analytics/reports
/titles/analytics/user-access
```