### PR TITLE
AAP-2081 Catalog Fix image syntax in catalog guides

### DIFF
--- a/downstream/assemblies/catalog/assembly-installing-receptor.adoc
+++ b/downstream/assemblies/catalog/assembly-installing-receptor.adoc
@@ -160,7 +160,7 @@ You can verify that the installation and configuration completed successfully by
 .Procedure
 
 . Log in to cloud.redhat.com.
-. Navigate to image:images/cog.png[Settings,40,40] > *Sources* and refresh the browser.
+. Navigate to image:cog.png[Settings,40,40] > *Sources* and refresh the browser.
 .. Your newly added Ansible Tower will appear with the *Name* provided in the `install_receptor.yml` playbook.
 . Verify that the *Status* is *Available*.
 . Navigate to Automation Services Catalog > Platforms.

--- a/downstream/modules/analytics/proc-add-roles-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-roles-to-group.adoc
@@ -11,7 +11,7 @@ Adding roles to an existing group will grant new permissions to existing users i
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click the group you want to add users to.
 . Click *Add role*.

--- a/downstream/modules/analytics/proc-add-user-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-user-to-group.adoc
@@ -11,7 +11,7 @@ You can add users to groups when creating a group or by manually adding users to
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click the group you want to add users to.
 . Navigate to the Members tab, then click *Add member*.

--- a/downstream/modules/analytics/proc-create-groups.adoc
+++ b/downstream/modules/analytics/proc-create-groups.adoc
@@ -11,7 +11,7 @@ You can create and assign roles to a group that enables users to access specific
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:images/cog.png[] > *Settings*.
+. Click image:cog.png[] > *Settings*.
 . From the sidebar, navigate to *User Access* > *Groups*.
 . Click *Create group*.
 . A setup wizard will now appear. Enter a group name and description, then click *Next*.

--- a/downstream/modules/analytics/proc-edit-savings-plan.adoc
+++ b/downstream/modules/analytics/proc-edit-savings-plan.adoc
@@ -10,5 +10,5 @@ Edit any information about an existing savings plan by clicking on it from the s
 
 .Procedure
 . Navigate to *Red Hat Insights* > *Savings Planner*.
-. On the automation savings plan, click image:images/ellipsis.png[More,10,25] > *Edit*.
+. On the automation savings plan, click image:ellipsis.png[More,10,25] > *Edit*.
 . Make any changes to the automation plan, then click *Save*.

--- a/downstream/modules/analytics/proc-link-plan-job-template.adoc
+++ b/downstream/modules/analytics/proc-link-plan-job-template.adoc
@@ -10,5 +10,5 @@ You can associate a job template to a savings plan to allow {InsightsShort} to p
 
 .Procedure
 . Navigate to *Red Hat Insights* > *Savings Planner*.
-. Click image:images/ellipsis.png[More,10,25] > *Link Template*.
+. Click image:ellipsis.png[More,10,25] > *Link Template*.
 . Click *Save*.

--- a/downstream/modules/catalog/proc_Assigning_approval_workflow.adoc
+++ b/downstream/modules/catalog/proc_Assigning_approval_workflow.adoc
@@ -3,6 +3,6 @@
 Procedure
 
 . Navigate to *Portfolios*.
-. Click image:images/actions.png[More actions] on a portfolio tile and select *Set approval*.
+. Click image:actions.png[More actions] on a portfolio tile and select *Set approval*.
 . From the *Set approval process* drop-down menu, select an approval processes to set to the portfolio.
 . Click *Save*.

--- a/downstream/modules/catalog/proc_Copy_portfolio.adoc
+++ b/downstream/modules/catalog/proc_Copy_portfolio.adoc
@@ -7,7 +7,7 @@ You can copy portfolios from the *Portfolios* list view.
 .Procedure
 
 . Click *Portfolios*.
-. Locate the portfolio and click image:images/actions.png[More Actions].
+. Locate the portfolio and click image:actions.png[More Actions].
 . Select *Copy*.
 
 The new copy will appear in the *Portfolios* list view with the default name: *Copy of {Portfolio Name}*. You can edit the portfolio to assign a new name and share with users. You can also copy products from one portfolio to other portfolios.

--- a/downstream/modules/catalog/proc_Copy_products.adoc
+++ b/downstream/modules/catalog/proc_Copy_products.adoc
@@ -7,7 +7,7 @@ You can copy products from the *Products* detail view.
 .Procedure
 
 . Click *Products* and select a product
-. Click image:images/actions.png[More Actions] and select *Copy*.
+. Click image:actions.png[More Actions] and select *Copy*.
 . Select a *Portfolio* from the list to copy the product to.
 . Click *Submit*.
 

--- a/downstream/modules/catalog/proc_Delete_order_process.adoc
+++ b/downstream/modules/catalog/proc_Delete_order_process.adoc
@@ -11,6 +11,6 @@ Delete an existing order process.
 
 . Select *Order Processes* from the main navigation.
 
-. Locate your desired order process, then click image:images/actions.png[More actions].
+. Locate your desired order process, then click image:actions.png[More actions].
 
 . Click *Delete*.

--- a/downstream/modules/catalog/proc_Edit_order_process.adoc
+++ b/downstream/modules/catalog/proc_Edit_order_process.adoc
@@ -11,7 +11,7 @@ Edit an existing order process.
 
 . Select *Order Processes* from the main navigation.
 
-. Locate your desired order process, then click image:images/actions.png[More actions].
+. Locate your desired order process, then click image:actions.png[More actions].
 
 . Click *Edit*.
 

--- a/downstream/modules/catalog/proc_Editing_surveys.adoc
+++ b/downstream/modules/catalog/proc_Editing_surveys.adoc
@@ -12,7 +12,7 @@ The product has an associated survey, created in Ansible Tower.
 
 . Click *Products*.
 . Locate the product and click on its title.
-. Click image:images/actions.png[More Actions] and select *Edit survey*.
+. Click image:actions.png[More Actions] and select *Edit survey*.
 . Select a field in the survey. The *Properties editor* will appear.
 . Click *Properties* to view the elements to edit for that field.
 . Select *Validation* to configure the *validator* types used to validate user input.

--- a/downstream/modules/catalog/proc_Generate-ansible-token.adoc
+++ b/downstream/modules/catalog/proc_Generate-ansible-token.adoc
@@ -15,7 +15,7 @@ As an Ansible Tower system administrator, you can create the application token l
 
 . Log in to your Ansible Tower instance.
 . Navigate to *Administration* -> *Applications*.
-. Click image:images/plus_icon.png[Add,40,40].
+. Click image:plus_icon.png[Add,40,40].
 . Enter or select the following in the required fields for the *New Application*:
 .. *Name*: Automation Services Catalog.
 .. *Authorization Grant Type*: Resource owner password-based.
@@ -28,8 +28,8 @@ As an Ansible Tower system administrator, you can create the application token l
 . Navigate to *Access* -> *Users*.
 . In the *Users* list, click the username to create the token for.
 . Click *TOKENS* in the user profile
-. Click image:images/plus_icon.png[Add,40,40].
-. Under *APPLICATION*, click image:images/magnify.png[Search,40,40] and select *Automation Services Catalog* from the modal.
+. Click image:plus_icon.png[Add,40,40].
+. Under *APPLICATION*, click image:magnify.png[Search,40,40] and select *Automation Services Catalog* from the modal.
 . Click *SELECT*.
 . Under *SCOPE* select *Write* from the drop-down.
 . Click *SAVE*.

--- a/downstream/modules/catalog/proc_Set_order_process_portfolio.adoc
+++ b/downstream/modules/catalog/proc_Set_order_process_portfolio.adoc
@@ -11,7 +11,7 @@ Set an order process that will apply to all products in a portfolio.
 
 . Select *Portfolios* from the main navigation, then select a portfolio.
 
-. Click image:images/actions.png[More actions] and select *Set order processes*.
+. Click image:actions.png[More actions] and select *Set order processes*.
 
 . Expand the drop-down menu and select an order process.
 

--- a/downstream/modules/catalog/proc_Set_order_process_product.adoc
+++ b/downstream/modules/catalog/proc_Set_order_process_product.adoc
@@ -11,7 +11,7 @@ Set an order process that will apply to a single product.
 
 . Select *Products* from the main navigation, then select a product.
 
-. Click image:images/actions.png[More actions] and select *Set order processes*.
+. Click image:actions.png[More actions] and select *Set order processes*.
 
 . Expand the drop-down menu and select an order process.
 

--- a/downstream/modules/catalog/proc_Sharing_portfolios.adoc
+++ b/downstream/modules/catalog/proc_Sharing_portfolios.adoc
@@ -1,7 +1,7 @@
 To share a portfolio:
 
 . Click *Portfolios*.
-. Click image:images/actions.png[More actions] on a portfolio, then click *Share*. The icon:[Y] indicates a shared portfolio.
+. Click image:actions.png[More actions] on a portfolio, then click *Share*. The icon:[Y] indicates a shared portfolio.
 . Adding groups:
 .. Under *Invite group* search groups to share the portfolio with.
 .. Select the level of permissions using the drop-down list.

--- a/downstream/titles/analytics/automation-savings-planner/master.adoc
+++ b/downstream/titles/analytics/automation-savings-planner/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/automation-savings/master.adoc
+++ b/downstream/titles/analytics/automation-savings/master.adoc
@@ -1,6 +1,7 @@
 // This assembly is included in the following assemblies:
 //
 
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/job-explorer/master.adoc
+++ b/downstream/titles/analytics/job-explorer/master.adoc
@@ -1,4 +1,4 @@
-
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/reports/master.adoc
+++ b/downstream/titles/analytics/reports/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/analytics/user-access/master.adoc
+++ b/downstream/titles/analytics/user-access/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 

--- a/downstream/titles/catalog/getting-started/master.adoc
+++ b/downstream/titles/catalog/getting-started/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :experimental:
 :toclevels: 4
 include::attributes/attributes.adoc[]
@@ -217,7 +218,7 @@ You can edit the sequence number for an approval process from the Approval proce
 
 . Select *Approval* from the main navigation.
 . Click the *Approval processes* tab.
-. Navigate to the approval process, then click image:images/ellipsis.png[More actions,10,25].
+. Navigate to the approval process, then click image:ellipsis.png[More actions,10,25].
 . Click *Edit*.
 . Enter the desired sequence number under *Enter sequence*.
 . Click *Save*.
@@ -280,7 +281,7 @@ We have now created a portfolio and added some products to it. Our next step is 
 To set an approval processes for the portfolio:
 
 . Navigate to *Portfolios*.
-. Click image:images/ellipsis.png[More actions,10,25] on a portfolio tile and select *Set approval*.
+. Click image:ellipsis.png[More actions,10,25] on a portfolio tile and select *Set approval*.
 . From the *Set approval process* drop-down menu, select an approval processes to set to the portfolio.
 . Click *Save*.
 
@@ -293,7 +294,7 @@ The portfolio is now ready to share with groups of users. These designated user 
 To share a portfolio:
 
 . Click *Portfolios*.
-. Click image:images/ellipsis.png[More actions,10,25] on a portfolio, then click *Share*. The icon:[Y] indicates a shared portfolio.
+. Click image:ellipsis.png[More actions,10,25] on a portfolio, then click *Share*. The icon:[Y] indicates a shared portfolio.
 . Adding groups:
 .. Under *Invite group* search groups to share the portfolio with.
 .. Select the level of permissions using the drop-down list.
@@ -371,7 +372,7 @@ The product has an associated survey, created in Ansible Tower.
 .Procedure
 . Click *Products*.
 . Locate the product and click on its title.
-. Click image:images/ellipsis.png[More actions,10,25] and select *Edit survey*.
+. Click image:ellipsis.png[More actions,10,25] and select *Edit survey*.
 . Select a field in the survey. The *Properties* editor will appear.
 . Click *Properties* to view the elements to edit for that field.
 . Select *Validation* to configure the validator types used to validate user input.

--- a/downstream/titles/catalog/itsm-integration/master.adoc
+++ b/downstream/titles/catalog/itsm-integration/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 [[configuring-your-tower-infrastructure-to-communicate-with-catalog]]
 = Integrating Automation Services Catalog with your IT Service Management (ITSM) systems
 

--- a/downstream/titles/catalog/lifecycle/master.adoc
+++ b/downstream/titles/catalog/lifecycle/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 [[catalog_lifecycle]]
 = Automation Services Catalog life cycle
 

--- a/downstream/titles/catalog/managing-products/master.adoc
+++ b/downstream/titles/catalog/managing-products/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :toc:
 :toclevels: 4
 :numbered:

--- a/downstream/titles/catalog/onboarding/master.adoc
+++ b/downstream/titles/catalog/onboarding/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 = Automation Service Catalog Onboarding
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]

--- a/downstream/titles/catalog/receptor/master.adoc
+++ b/downstream/titles/catalog/receptor/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 [[configuring-your-tower-infrastructure-to-communicate-with-catalog]]
 = TECHNOLOGY PREVIEW Configuring your Ansible Tower infrastructure to communicate with Automation Services Catalog
 

--- a/downstream/titles/catalog/support-matrix/master.adoc
+++ b/downstream/titles/catalog/support-matrix/master.adoc
@@ -1,4 +1,4 @@
-
+:imagesdir: images
 [[catalog_support_matrix]]
 = Automation Services Catalog product support matrix
 


### PR DESCRIPTION
Modify paths to images in catalog guides.
Part of AAP-2081

Affects
`titles/catalog/itsm-integration`

