### PR TITLE
2.2 Fix incorrect reference pg_port -> ansible_port (#599)

### DIFF
--- a/downstream/modules/platform/ref-network-ports-protocols.adoc
+++ b/downstream/modules/platform/ref-network-ports-protocols.adoc
@@ -22,7 +22,7 @@ The default destination ports and installer inventory listed below are configura
 |TCP
 |SSH
 |Inbound and Outbound
-|`pg_port`
+|`ansible_port`
 |Remote access during installation
 |5432
 |TCP


### PR DESCRIPTION
Backports #599 to 2.2
Modify the SSH connection variable from pg_port to ansible_port in the ports and protocols table for the database server.