### PR TITLE
AAP-8472 updated version numbers within Deploying the Red Hat Ansible…

### DIFF
--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -39,7 +39,7 @@ metadata:
   name: ansible-automation-platform
   namespace: ansible-automation-platform
 spec:
-  channel: 'stable-2.2'
+  channel: 'stable-2.3'
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -22,7 +22,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} 2.2 supports PostgreSQL 13.
+{PlatformNameShort} {PlatformVers} supports PostgreSQL 13.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -22,7 +22,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} 2.2 supports PostgreSQL 13.
+{PlatformNameShort} {PlatformVers} supports PostgreSQL 13.
 ====
 
 .Procedure


### PR DESCRIPTION
Backporting commit 71b8859 ([PR 779](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/779)) to 2.3.

[AAP-8472](https://issues.redhat.com/browse/AAP-8472) updated version numbers within [Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index).