### PR TITLE
2.1 AAP-2081  Fix image syntax in hub and builder guides (#793)

### DIFF
--- a/downstream/modules/automation-hub/proc-delete-container.adoc
+++ b/downstream/modules/automation-hub/proc-delete-container.adoc
@@ -7,6 +7,6 @@
 * You have permissions to manage repositories.
 
 .Procedure
-. Navigate to *Execution Environments*.
-. On the container repository you would like to delete, click image:images/more_actions.png[more actions] > *Delete*.
-. When presented with the confirmation message, click the checkbox then click *Delete*.
+. Navigate to menu:Execution Environments[].
+. On the container repository you would like to delete, click image:more_actions.png[more actions], then click btn:[Delete].
+. When presented with the confirmation message, click the checkbox, then click btn:[Delete].

--- a/downstream/modules/automation-hub/proc-delete-user.adoc
+++ b/downstream/modules/automation-hub/proc-delete-user.adoc
@@ -11,10 +11,10 @@ When you delete a user account, the name and email of the user are permanently r
 
 .Procedure
 . Log in to {HubName}.
-. Expand the *User Access* menu.
-. Click *Users* to display a list of the current users.
-. Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
-. Click *Delete* in the warning message to permanently delete the user.
+. Expand menu:User Access[].
+. Click btn:[Users] to display a list of the current users.
+. Click the action menu (image:more_actions.png[more actions]) beside the user that you want to remove, then click btn:[Delete].
+. Click btn:[Delete] in the warning message to permanently delete the user.
 
-// . Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove and click *Delete*.
+// . Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove, then click btn:[Delete].
 

--- a/downstream/modules/automation-hub/proc-delete-user.adoc
+++ b/downstream/modules/automation-hub/proc-delete-user.adoc
@@ -15,6 +15,3 @@ When you delete a user account, the name and email of the user are permanently r
 . Click btn:[Users] to display a list of the current users.
 . Click the action menu (image:more_actions.png[more actions]) beside the user that you want to remove, then click btn:[Delete].
 . Click btn:[Delete] in the warning message to permanently delete the user.
-
-// . Click the action menu (image:images/more_actions.png[more actions]) beside the user that you want to remove, then click btn:[Delete].
-

--- a/downstream/modules/automation-hub/proc-edit-namespace.adoc
+++ b/downstream/modules/automation-hub/proc-edit-namespace.adoc
@@ -13,7 +13,7 @@ You can add information and provide resources for your users to accompany collec
 .Procedure
 . Log in to your local Automation Hub.
 . Navigate to *My Namespaces*.
-. Click image:images/more_actions.png[More actions] and select *Edit namespace*.
+. Click image:more_actions.png[More actions] and select *Edit namespace*.
 . In the *Edit details* tab, provide information in the fields to enhance your namespace experience.
 . Click the *edit resources* tab to enter markdown in the text field.
 . Click btn:[Save] when finished.

--- a/downstream/modules/automation-hub/proc-edit-namespace.adoc
+++ b/downstream/modules/automation-hub/proc-edit-namespace.adoc
@@ -16,6 +16,6 @@ You can add information and provide resources for your users to accompany collec
 . Click image:images/more_actions.png[More actions] and select *Edit namespace*.
 . In the *Edit details* tab, provide information in the fields to enhance your namespace experience.
 . Click the *edit resources* tab to enter markdown in the text field.
-. Click *Save* when finished.
+. Click btn:[Save] when finished.
 
 Your content developers can now proceed to upload collections to your new namespace, or allow users in groups assigned as owners to upload collections.

--- a/downstream/modules/automation-hub/proc-obtaining-org-collection-url.adoc
+++ b/downstream/modules/automation-hub/proc-obtaining-org-collection-url.adoc
@@ -13,9 +13,9 @@ You can sync Red Hat certified collections curated by your organization from con
 
 . Log in to console.redhat.com as an Organization Administrator.
 . Navigate to menu:Automation Hub[Repo Management].
-. Locate the *Sync URL* and click the btn:[Copy to clipboard] icon (image:images/copy.png[Copy,10,25]). 
+. Locate the *Sync URL* and click the btn:[Copy to clipboard] icon (image:copy.png[Copy,10,25]). 
 Paste the *Sync URL* in a file to use when configuring the rh-certified remote.
-. Click the btn:[More actions] icon (image:images/more_actions.png[More,10,25]) and click btn:[Get token].
+. Click the btn:[More actions] icon (image:more_actions.png[More,10,25]) and click btn:[Get token].
 . On the *Token management* page, click btn:[Load token].
 . Click btn:[Copy to clipboard] to copy the API token.
 . Paste the API token into a file and store in a secure location.

--- a/downstream/modules/automation-hub/proc-tag-image.adoc
+++ b/downstream/modules/automation-hub/proc-tag-image.adoc
@@ -16,7 +16,7 @@ Tag images to add an additional name to images stored in your {HubName} containe
 . Navigate to *Execution Environments*.
 . Select your container repository.
 . Click the *Images* tab.
-. Click image:images/more_actions.png[more actions] > *Manage tags*.
+. Click image:more_actions.png[more actions] > *Manage tags*.
 . Add a new tag in the text field and click *Add*.
 ** Optional: Remove *current tags* by clicking the *x* on any of the tags for that image.
 . Click *Save*.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,4 +1,5 @@
 = Managing Red Hat Certified and Ansible Galaxy collections in automation hub
+:imagesdir: images
 :numbered:
 :experimental:
 

--- a/downstream/titles/hub/lifecycle/master.adoc
+++ b/downstream/titles/hub/lifecycle/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 [[hub_life_cycle]]
 
 = Private Automation Hub life cycle

--- a/downstream/titles/hub/manage-containers/master.adoc
+++ b/downstream/titles/hub/manage-containers/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 :numbered:
 :toclevels: 4
 :experimental:

--- a/downstream/titles/hub/managing-user-access/master.adoc
+++ b/downstream/titles/hub/managing-user-access/master.adoc
@@ -1,5 +1,5 @@
 = Managing user access in Private Automation Hub
-// :imagesdir: images
+:imagesdir: images
 :numbered:
 include::attributes/attributes.adoc[]
 

--- a/downstream/titles/hub/uploading-collections/master.adoc
+++ b/downstream/titles/hub/uploading-collections/master.adoc
@@ -1,4 +1,5 @@
 = Uploading content to Red Hat Automation Hub
+:imagesdir: images
 :numbered:
 :experimental:
 include::attributes/attributes.adoc[]

--- a/downstream/titles/hub/uploading-internal-collections/master.adoc
+++ b/downstream/titles/hub/uploading-internal-collections/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 = Curating collections using namespaces in Automation Hub
 :numbered:
 :experimental:


### PR DESCRIPTION
Backports #793 to 2.1

Modify paths to images in catalog guides.
Part of AAP-2081

Affects
titles/builder
/titles/hub/uploading-internal-collections
/titles/hub/configuring-private-hub-rh-certified
/titles/hub/uploading-collections
/titles/hub/managing-user-access
/titles/hub/manage-containers
/titles/hub/uploading-internal-collections
