### PR TITLE
Fix master.adoc attributes for configuring-private-hub-rh-certified

### DIFF
--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 = Managing Red Hat Certified and Ansible Galaxy collections in automation hub
 :numbered:
 :experimental:


### PR DESCRIPTION
Add imagesdir sttribute for images in titles/configuring-private-hub-rh-certified