### PR TITLE
AAP-2606 Added section on OCP version compatibility for operator guide

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -17,6 +17,7 @@ OpenShift operators help install and automate day-2 operations of complex, distr
 You can use this section to help plan your {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
 
 include::platform/con-about-operator.adoc[leveloffset=2]
+include::platform/ref-operator-ocp-version.adoc[leveloffset=2]
 include::platform/con-ocp-supported-install.adoc[leveloffset=2]
 include::platform/con-operator-custom-resources.adoc[leveloffset=2]
 include::platform/con-operator-additional-resources.adoc[leveloffset=2]

--- a/downstream/modules/platform/ref-operator-ocp-version.adoc
+++ b/downstream/modules/platform/ref-operator-ocp-version.adoc
@@ -1,0 +1,11 @@
+[id="ref-operator-ocp-version_{context}"]
+
+= {OCPShort} version compatibility
+
+[role="_abstract"]
+
+The {OperatorPlatform} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.7 and later versions.
+
+[role="_additional-resources"]
+.Additional resources
+* See the link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle] for the most current compatibility details.


### PR DESCRIPTION
For [AAP-2606](https://issues.redhat.com/browse/AAP-2606), added the module `ref-operator-ocp-version.adoc` to the 2.1 doc "Red Hat Ansible Automation Platform Operator Installation Guide" in the planning-installation assembly in the same place as in the renamed/refactored 2.2 (and later versions) "Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform." This new subsection provides customers with the version requirements for containers, per request from the field.