### PR TITLE
Removed geerlingguy.php_role

### DIFF
--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -17,8 +17,8 @@ See example below.
 -----
 collections:
   # Install a collection from Ansible Galaxy.
-  - name: geerlingguy.php_roles
-    version: 0.9.3
+  - name: community.aws
+    version: 5.2.0
     source: https://galaxy.ansible.com
 -----
 


### PR DESCRIPTION
Replace with community.aws
This change is only made in 2.2. Changes in main and 2.3 are part of AAP-5046

ansible builder docs change/remove geerlingguy.java

https://issues.redhat.com/browse/AAP-421