### PR TITLE
AAP-4882 Added link to the Pulp file system layout to Ch 2.2 Add'l resources

### DIFF
--- a/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
+++ b/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
@@ -105,3 +105,4 @@ NOTE: You must repeat this command to reattach the proper SELinux labels wheneve
 
 .Additional Resources
 * See the link:https://docs.pulpproject.org/en/2.16/user-guide/scaling.html#selinux-requirements[SELinux Requirements on the Pulp Project documentation] for a list of SELinux contexts.
+* See the link:https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout[Filesystem Layout] for a full description of Pulp folders. 


### PR DESCRIPTION
In response to [AAP-4882](https://issues.redhat.com/browse/AAP-4882) - Added the following link to the Additional resources section after "Troubleshooting" topic: [Filesystem Layout](https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout).