### PR TITLE
Added information on builds

### DIFF
--- a/downstream/modules/builder/con-optional-build-command-arguments.adoc
+++ b/downstream/modules/builder/con-optional-build-command-arguments.adoc
@@ -10,6 +10,11 @@ $ ansible-builder build -t my_first_ee_image
 ----
 ====
 
+[NOTE]
+====
+If you do not use `-t` with `build`, an image called `ansible-execution-env`` is created and loaded into the local container registry.
+====
+
 If you have multiple definition files, you can specify which one to use by utilizing the `-f` flag:
 
 [[example1]]

--- a/downstream/modules/builder/proc-customize-ee-image.adoc
+++ b/downstream/modules/builder/proc-customize-ee-image.adoc
@@ -59,6 +59,12 @@ Since this example uses the community version of `kubernetes.core` and not a cer
 $ ansible-builder build -t registry.redhat.io/_[username]_/_new-ee_
 ----
 where `[username]` specifies your username, and `new-ee` specifies the name of your new container image.
+
+[NOTE]
+====
+If you do not use `-t` with `build`, an image called `ansible-execution-env` is created and loaded into the local container registry.
+====
+
 .. Use the `podman images` command to confirm that your new container image is in that list:
 +
 .Output of a `podman images` command with the image `new-ee`

--- a/downstream/modules/builder/ref-build-args-base-image.adoc
+++ b/downstream/modules/builder/ref-build-args-base-image.adoc
@@ -14,6 +14,7 @@ The `build_arg_defaults` section of the definition file is a dictionary whose ke
 | `EE_BASE_IMAGE`
 | Specifies the parent image for the automation execution environment, enabling a new image to be built that is based off of an already-existing image. This is typically a supported execution environment base image like ee-minimal or ee-supported, but it can also be an execution environment image that you've created previously and want to customize further.
 
+If no `EE_BASE_IMAGE` is specified, `quay.io/ansible/ansible-runner:latest` is used.
 | `EE_BUILDER_IMAGE`
 | Specifies the intermediate builder image used for Python dependency collection and compilation; must contain a matching Python version with EE_BASE_IMAGE and have ansible-builder installed.
 |===


### PR DESCRIPTION
Added text to describe effect of not specifying EE_BASE_IMAGE and not using the -t switch when building.

ansible builder docs EE_BASE_IMAGE implications

https://issues.redhat.com/browse/AAP-419