### PR TITLE
Correct statement about database location

### DIFF
--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -4,7 +4,7 @@
 
 .Databases
 * When using an external database, ensure the `[database]` sections of your inventory file are properly set up.
-* To improve performance, do not place the database server and the automation controller server on the same network.
+* To improve performance, do not colocate the database and the {ControllerName} on the same server.
 
 .{HubName}
 * Add {HubNameMain} information in the `[automationhub]` group


### PR DESCRIPTION
Change made for 2.2 when originally in Installation Guide

Note in documentation about database and automation controller location is incorrect

https://issues.redhat.com/browse/AAP-8783