### PR TITLE
AAP-8656 updated version numbers across document (#788)

### DIFF
--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -12,14 +12,14 @@ Bundled installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-bundle-<latest-version>
+$ cd ansible-automation-platform-setup-bundle-2.3-1.2
 -----
 +
 Online installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-<latest-version>
+$ cd ansible-automation-platform-setup-2.3-1.2
 -----
 
 . Open the `inventory` file for editing.

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -19,8 +19,8 @@ The download and installation of the setup bundle needs to be located on the aut
 +
 ----
 $ tar xvf \
-   ansible-automation-platform-setup-bundle-2.3-1.1.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.3-1.1
+   ansible-automation-platform-setup-bundle-2.3-1.2.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.3-1.2
 ----
 +
 . Edit the inventory file to include the required options
@@ -70,7 +70,7 @@ NOTE: The inventory should be kept intact after installation since it is used fo
 +
 ----
 $ sudo -i
-# cd /path/to/ansible-automation-platform-setup-bundle-2.1.2-1
+# cd /path/to/ansible-automation-platform-setup-bundle-2.3-1.2
 # ./setup.sh
 ----
 +

--- a/downstream/modules/platform/proc-installing-the-ansible-builder-rpm.adoc
+++ b/downstream/modules/platform/proc-installing-the-ansible-builder-rpm.adoc
@@ -19,8 +19,8 @@ This is preferred if a Satellite exists because the EE images can leverage RHEL 
 . Install the ansible-builder RPM and its dependencies from the included content:
 +
 ----
-$ tar -xzvf ansible-automation-platform-setup-bundle-2.1.2-1.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.1.2-1/bundle/el8/repos/
+$ tar -xzvf ansible-automation-platform-setup-bundle-2.3-1.2.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.3-1.2/bundle/el8/repos/
 $ sudo yum install ansible-builder-1.0.1-2.el8ap.noarch.rpm
 python38-requirements-parser-0.2.0-3.el8ap.noarch.rpm
 ----
@@ -198,32 +198,32 @@ To upgrade between minor releases of AAP 2, use this general workflow.
 
 . Run `./setup.sh` to upgrade the installation.
 
-For example, to upgrade from version 2.1.2-1 to 2.2.0-7, make sure that both setup bundles are on the initial controller node where the installation occurred:
+For example, to upgrade from version 2.2.0-7 to 2.3-1.2, make sure that both setup bundles are on the initial controller node where the installation occurred:
 
 ----
     $ ls -1F
-ansible-automation-platform-setup-bundle-2.1.2-1/
-ansible-automation-platform-setup-bundle-2.1.2-1.tar.gz
 ansible-automation-platform-setup-bundle-2.2.0-7/
 ansible-automation-platform-setup-bundle-2.2.0-7.tar.gz
+ansible-automation-platform-setup-bundle-2.3-1.2/
+ansible-automation-platform-setup-bundle-2.3-1.2.tar.gz
 ----
 
-Back up the 2.1.2-1 installation:
+Back up the 2.2.0-7 installation:
 ----
-$ cd ansible-automation-platform-setup-bundle-2.1.2-1
+$ cd ansible-automation-platform-setup-bundle-2.2.0-7
 $ sudo ./setup.sh -b
 $ cd ..
 ----
 
-Copy the 2.1.2-1 inventory file into the 2.2.0-7 bundle directory:
+Copy the 2.2.0-7 inventory file into the 2.3-1.2 bundle directory:
 ----
-$ cd ansible-automation-platform-setup-bundle-2.1.2-1
-$ cp inventory ../ansible-automation-platform-setup-bundle-2.2.0-7/
+$ cd ansible-automation-platform-setup-bundle-2.2.0-7
+$ cp inventory ../ansible-automation-platform-setup-bundle-2.3-1.2/
 $ cd ..
 ----
 
-Upgrade from 2.1.2-1 to 2.2.0-7 with the setup.sh script:
+Upgrade from 2.2.0-7 to 2.3-1.2 with the setup.sh script:
 ----
-$ cd ansible-automation-platform-setup-bundle-2.2.0-7
+$ cd ansible-automation-platform-setup-bundle-2.3-1.2
 $ sudo ./setup.sh
 ----


### PR DESCRIPTION
Per [AAP-8656](https://issues.redhat.com/browse/AAP-8656) and [PR 788](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/788), updated the [Red Hat Ansible Automation Platform Installation Guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/index) to remove version number artefacts where appropriate.

* AAP-8656 updated version numbers across document

* AAP-8656 updated version number placeholders

* AAP-8656 updated version numbers

* AAP-8565 updated version numbers

* AAP-8656 updated version numbers