### PR TITLE
Backport-2.3-818 AAP-4882 Added link to the Pulp file system layout info

### DIFF
--- a/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
+++ b/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
@@ -105,3 +105,4 @@ NOTE: You must repeat this command to reattach the proper SELinux labels wheneve
 
 .Additional Resources
 * See the link:https://docs.pulpproject.org/en/2.16/user-guide/scaling.html#selinux-requirements[SELinux Requirements on the Pulp Project documentation] for a list of SELinux contexts.
+* See the link:https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout[Filesystem Layout] for a full description of Pulp folders. 

--- a/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
+++ b/downstream/modules/automation-hub/proc-install-ha-hub-selinux.adoc
@@ -105,4 +105,4 @@ NOTE: You must repeat this command to reattach the proper SELinux labels wheneve
 
 .Additional Resources
 * See the link:https://docs.pulpproject.org/en/2.16/user-guide/scaling.html#selinux-requirements[SELinux Requirements on the Pulp Project documentation] for a list of SELinux contexts.
-* See the link:https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout[Filesystem Layout] for a full description of Pulp folders. 
+* See the link:https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout[Filesystem Layout information] for a full description of Pulp folders. 


### PR DESCRIPTION
Backporting (cherry-picking) the following update in the original PR https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/812 :

In response to [AAP-4882](https://issues.redhat.com/browse/AAP-4882) - In the [Deploying a high availability automation hub guide, chapt. 2.2](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/deploying_a_high_availability_automation_hub/index#install_a_high_availability_ha_deployment_of_automation_hub_on_selinux), added the following link to the Additional resources section after the "Troubleshooting" topic: [Filesystem Layout](https://docs.pulpproject.org/pulpcore/installation/hardware-requirements.html#filesystem-layout).