### PR TITLE
[2.3] AAP-4206: Add alt-text to images (#833)

### DIFF
--- a/downstream/modules/analytics/proc-add-roles-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-roles-to-group.adoc
@@ -11,8 +11,8 @@ Adding roles to an existing group will grant new permissions to existing users i
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:cog.png[] > *Settings*.
-. From the sidebar, navigate to *User Access* > *Groups*.
+. Click image:cog.png[Settings] and select *Settings*.
+. From the sidebar, navigate to menu:User Access[Groups].
 . Click the group you want to add users to.
 . Click *Add role*.
 . Select one or more roles to add to this group, then click *Add to group*.

--- a/downstream/modules/analytics/proc-add-user-to-group.adoc
+++ b/downstream/modules/analytics/proc-add-user-to-group.adoc
@@ -11,8 +11,8 @@ You can add users to groups when creating a group or by manually adding users to
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:cog.png[] > *Settings*.
-. From the sidebar, navigate to *User Access* > *Groups*.
+. Click image:cog.png[Settings], then click:[Settings].
+. From the sidebar, navigate to menu:User Access[Groups].
 . Click the group you want to add users to.
 . Navigate to the Members tab, then click *Add member*.
 . Select one or more users to add to this group, then click *Add to group*.

--- a/downstream/modules/analytics/proc-create-groups.adoc
+++ b/downstream/modules/analytics/proc-create-groups.adoc
@@ -11,11 +11,11 @@ You can create and assign roles to a group that enables users to access specific
 .Procedure
 
 . Log in to cloud.redhat.com
-. Click image:cog.png[] > *Settings*.
-. From the sidebar, navigate to *User Access* > *Groups*.
-. Click *Create group*.
-. A setup wizard will now appear. Enter a group name and description, then click *Next*.
-. Select one or more roles to add to this group, then click *Next*.
+. Click image:cog.png[Settings], then click btn:[Settings].
+. From the sidebar, navigate to menu:User Access[Groups].
+. Click btn:[Create group].
+. A setup wizard will now appear. Enter a group name and description, then click btn:[Next].
+. Select one or more roles to add to this group, then click btn:[Next].
 
 [NOTE]
 ====

--- a/downstream/modules/automation-hub/proc-delete-collection.adoc
+++ b/downstream/modules/automation-hub/proc-delete-collection.adoc
@@ -13,7 +13,7 @@ You can further manage your collections by deleting unwanted  collections, provi
 . Log in to {PlatformName}.
 . Navigate to *Automation Hub* -> *Collections*.
 . Click a collection to delete.
-. Click image:more_actions.png[] then select an option:
+. Click image:more_actions.png[More actions] then select an option:
 .. *Delete entire collection* to delete all versions in this collection.
 .. *Delete version [number]* to delete the current version of this collection. You can change versions using the *Version* dropdown menu.
 +

--- a/downstream/modules/automation-hub/proc-delete-namespace.adoc
+++ b/downstream/modules/automation-hub/proc-delete-namespace.adoc
@@ -14,7 +14,7 @@ You can delete unwanted namespaces to manage storage on your {hubname} server. T
 . Log in to your local {hubname}.
 . Navigate to menu:Collections[Namespaces].
 . Click the namespace to be deleted.
-. Click image:more_actions.png[], then click btn:[Delete namespace].
+. Click image:more_actions.png[More actions], then click btn:[Delete namespace].
 +
 NOTE: If the btn:[Delete namespace] button is disabled, it means that this namespace contains a collection with dependencies. Review the collections in this namespace and delete any dependencies to proceed with the namespace deletion. See _Managing collections on automation hub_ in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform[Red Hat Ansible Automation Platform documentation] for information about deleting collections.
 

--- a/downstream/modules/navigator/con-navigator-collections.adoc
+++ b/downstream/modules/navigator/con-navigator-collections.adoc
@@ -11,4 +11,4 @@ SHADOWED:: Indicates that an additional copy of the collection is higher in the 
 TYPE:: Shows if the collection is contained within an {ExecEnvNameSing} or volume mounted on onto the {ExecEnvNameSing} as a `bind_mount`.
 PATH:: Reflects the collections location within the {ExecEnvNameSing} or local file system based on the collection TYPE field.
 
-image::navigator-collections-shadow.png[]
+image::navigator-collections-shadow.png[Automation content navigator collections display]

--- a/downstream/modules/navigator/con-navigator-modes.adoc
+++ b/downstream/modules/navigator/con-navigator-modes.adoc
@@ -23,7 +23,7 @@ subcommand help:: Accessible from the subcommand, for example `ansible-navigator
 
 The text-based user interface mode provides enhanced interaction with {ExecEnvName}, collections, playbooks, and inventory. This mode is compatible with integrated development environments (IDE), such as Visual Studio Code.
 
-image::navigator-welcome.png[]
+image::navigator-welcome.png[Text-based user interface mode]
 
 This mode includes a number of helpful user interface options:
 

--- a/downstream/modules/navigator/proc-browse-collections-tui.adoc
+++ b/downstream/modules/navigator/proc-browse-collections-tui.adoc
@@ -28,7 +28,7 @@ $ ansible-navigator
 $ :collections
 ----
 +
-image::navigator-collection-list.png[]
+image::navigator-collection-list.png[A list of Ansible collections shown in the Automation content navigator]
 
 . Type the number of the collection you want to explore.
 +
@@ -36,7 +36,7 @@ image::navigator-collection-list.png[]
 :4
 ----
 +
-image::navigator-plugin-list.png[]
+image::navigator-plugin-list.png[A collection shown in the Automation content navigator]
 
 . Type the number corresponding to the module you want to delve into.
 +
@@ -91,13 +91,13 @@ ANSIBLE.UTILS.IP_ADDRESS: Test if something in an IP address
 :open
 ----
 +
-image::navigator-vscode-example.png[]
+image::navigator-vscode-example.png[Documentation example shown in the editing tool]
 
 .Verification
 
 *  Browse the collection list.
 +
-image::navigator-collection-list.png[]
+image::navigator-collection-list.png[Collection list]
 
 
 [role="_additional-resources"]

--- a/downstream/modules/navigator/proc-execute-playbook-tui.adoc
+++ b/downstream/modules/navigator/proc-execute-playbook-tui.adoc
@@ -45,16 +45,16 @@ INVENTORY OR PLAYBOOK NOT FOUND, PLEASE CONFIRM THE FOLLOWING
 
 . Tab to `Submit` and hit Enter. You should see the tasks executing.
 +
-image::navigator-play-list.png[]
+image::navigator-play-list.png[Executing playbook tasks]
 . Type the number next to a play to step into the play results, or type `:<number>` for numbers above 9.
 +
-image::navigator-task-list.png[]
+image::navigator-task-list.png[Task list]
 +
 Notice failed tasks show up in red if you have colors enabled for {Navigator}.
 
 . Type the number next to a task to review the task results, or type `:<number>` for numbers above 9.
 +
-image::navigator-task-output-failed.png[]
+image::navigator-task-output-failed.png[Failed task results]
 
 . Optional: type `:doc` bring up the documentation for the module or plugin used in the task to aid in troubleshooting.
 +

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -45,4 +45,4 @@ $ ansible-navigator --help
 
 The following example demonstrates a successful installation:
 
-image::navigator-stdout.png[]
+image::navigator-stdout.png[Automation content navigator successful installation]

--- a/downstream/modules/navigator/proc-review-ansible-config-tui.adoc
+++ b/downstream/modules/navigator/proc-review-ansible-config-tui.adoc
@@ -30,7 +30,7 @@ Optional: type `ansible-navigator config` from the command line to access the An
  :config
 ----
 +
-image::navigator-ansible-config.png[]
+image::navigator-ansible-config.png[Ansible configuration]
 +
 Some values reflect settings from within the {ExecEnvName} needed for the {ExecEnvName} to function.  These display as non-default settings you cannot set in your Ansible configuration file.
 
@@ -56,7 +56,7 @@ The output shows the current `setting` as well as the `default`. Note the `sourc
 
 *  Review the configuration output.
 +
-image::navigator-ansible-config.png[]
+image::navigator-ansible-config.png[Configuration output]
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/navigator/proc-review-artifact.adoc
+++ b/downstream/modules/navigator/proc-review-artifact.adoc
@@ -24,7 +24,7 @@ $ ansible-navigator replay simple_playbook_artifact.json
 
 . Review the playbook results that match when the playbook ran.
 +
-image::navigator-artifact-replay.png[]
+image::navigator-artifact-replay.png[Playbook results]
 
 You can now type the number next to the plays and tasks to step into each to review the results, as you would after executing the playbook.
 

--- a/downstream/modules/navigator/proc-review-docs-tui.adoc
+++ b/downstream/modules/navigator/proc-review-docs-tui.adoc
@@ -79,7 +79,7 @@ ANSIBLE.UTILS.IP_ADDRESS: Test if something in an IP address
 :open
 ----
 +
-image::navigator-vscode-example.png[]
+image::navigator-vscode-example.png[Documentation example in editor]
 +
 See xref:ref-navigator-general-settings_settings-navigator[Automation content navigator general settings] for details on how to set up your editor.
 

--- a/downstream/modules/navigator/proc-review-ee-tui.adoc
+++ b/downstream/modules/navigator/proc-review-ee-tui.adoc
@@ -21,11 +21,11 @@ You can review your {ExecEnvNameStart} with the {Navigator} text-based user inte
 $ ansible-navigator images
 ----
 +
-image::navigator-images-list.png[]
+image::navigator-images-list.png[List of automation execution environments]
 
 . Type the number of the {ExecEnvNameSing} you want to delve into for more details.
 +
-image::navigator-image-details.png[]
+image::navigator-image-details.png[Automation execution environment details]
 +
 You can review the packages and versions of each installed {ExecEnvNameSing} and the Ansible version any included collections.
 
@@ -41,4 +41,4 @@ $ ansible-navigator images --eei  registry.example.com/example-enterprise-ee:lat
 
 *  Review the {ExecEnvNameSing} output.
 +
-image::navigator-image-details.png[]
+image::navigator-image-details.png[Automation execution environment output]

--- a/downstream/modules/security/con-automate-idps-rules.adoc
+++ b/downstream/modules/security/con-automate-idps-rules.adoc
@@ -20,7 +20,7 @@ The following lab environment demonstrates what an Ansible security automation i
 
 Keep in mind that a real world setup will feature other vendors and technologies.
 
-image::security-ids-sample-demo.png[]
+image::security-ids-sample-demo.png[Sample Ansible security automation integration]
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/security/con-automating-firewall-rules.adoc
+++ b/downstream/modules/security/con-automating-firewall-rules.adoc
@@ -18,7 +18,7 @@ The below lab environment is a simplified example of a real-world enterprise sec
 
 Your entire team can use Ansible security automation to address investigations, threat hunting, and incident response all on one platform. https://www.redhat.com/en/technologies/management/ansible[Red Hat Ansible Automation Platform] provides you with certified content collections that are easy to consume and reuse within your security team.
 
-image::security-lab-environment.png[]
+image::security-lab-environment.png[Simplified security lab environment]
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/security/proc-creating-firewall-rule.adoc
+++ b/downstream/modules/security/proc-creating-firewall-rule.adoc
@@ -46,7 +46,7 @@ $ ansible-galaxy install ansible_security.acl_manager
 
 . Run the playbook ``$ ansible-navigator run --ee false <playbook.yml>``.
 +
-image::security-create-rule.png[]
+image::security-create-rule.png[Playbook with new firewall rule]
 
 .Verification
 

--- a/downstream/modules/security/proc-deleting-firewall-rule.adoc
+++ b/downstream/modules/security/proc-deleting-firewall-rule.adoc
@@ -45,7 +45,7 @@ $ ansible-galaxy install ansible_security.acl_manager
 
 . Run the playbook $ ansible-navigator run --ee false <playbook.yml>:
 +
-image::security-delete-rule.png[]
+image::security-delete-rule.png[Playbook with deleted firewall rule]
 
 .Verification
 


### PR DESCRIPTION
Backporting requested changes in [AAP-4206](https://issues.redhat.com/browse/AAP-4206) to 2.3. These changes add alt-text to images in Analytics, the Navigator Guide, the Security Guide, and Automation Hub.

Backports #833 