### PR TITLE
2.3 Release notes: replace pulp_firewalld_zone with automationhub_firewal…

### DIFF
--- a/release-notes/topics/hub-460.adoc
+++ b/release-notes/topics/hub-460.adoc
@@ -28,3 +28,4 @@ Automation Hub allows you to discover and utilize new certified automation conte
 * Updated the pulp_container package to 2.14.
 * Upgraded pulpcore to 3.21.x.
 * Fixed problem in which the released date for collections in private automation hub was the same as the released date for that collection and its versions in the console.redhat.com automation hub.
+* Deprecated the pulp_firewalld_zone parameter, replacing it with the automationhub_firewalld_zone parameter.


### PR DESCRIPTION
…ld_zone (#840)

* Added entry to release notes

Added entry deprecating the  pulp_firewalld_zone parameter

[doc] Add a note in the AAP 2.3 release notes that says "pulp_firewalld_zone" has been deprecated

https://issues.redhat.com/browse/AAP-8892