### PR TITLE
Document title changed (#850)

### DIFF
--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in automation hub</title>
+<title>Managing Red Hat Certified and Ansible Galaxy collections in automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.3</productnumber>
 <subtitle>Configure automation hub to deliver curated Red Hat Certified and Ansible Galaxy collections to your users.</subtitle>

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,6 +1,6 @@
 
 :imagesdir: images
-= Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in automation hub
+= Managing Red Hat Certified and Ansible Galaxy collections in automation hub
 :numbered:
 :experimental:
 

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -162,8 +162,8 @@ Once the installation completes, you can verify your Private Automation Hub has 
 
 Your Private Automation Hub is now ready for initial configuration. See the following administration guides for more:
 
-* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_user_access_in_private_automation_hub/index[Managing user access in Private Automation Hub]
-* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub]
+* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/managing_user_access_in_private_automation_hub/index[Managing user access in Private Automation Hub]
+* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub]
 
 == Upgrading to the latest version
 


### PR DESCRIPTION
Backports #850 to 2.3

Title changed from 'Managing Red Hat Ansible Content Collections and Ansible Galaxy collections in automation hub' to 'Managing Red Hat Certified and Ansible Galaxy collections in automation hub'. Also links in the hub install doc updated to 2.3.

Change Document Title

https://issues.redhat.com/browse/AAP-9192

Affects `titles/hub/configuring-private-hub-rh-certified`