### PR TITLE
2.3 Added default values of image. (#839)

### DIFF
--- a/downstream/modules/builder/ref-build-args-base-image.adoc
+++ b/downstream/modules/builder/ref-build-args-base-image.adoc
@@ -14,9 +14,12 @@ The `build_arg_defaults` section of the definition file is a dictionary whose ke
 | `EE_BASE_IMAGE`
 | Specifies the parent image for the automation execution environment, enabling a new image to be built that is based off of an already-existing image. This is typically a supported execution environment base image like ee-minimal or ee-supported, but it can also be an execution environment image that you've created previously and want to customize further.
 
-If no `EE_BASE_IMAGE` is specified, `quay.io/ansible/ansible-runner:latest` is used.
+The default image is `registry.redhat.io/ansible-automation-platform-23/ee-minimal-rhel8:latest`.
+
 | `EE_BUILDER_IMAGE`
-| Specifies the intermediate builder image used for Python dependency collection and compilation; must contain a matching Python version with EE_BASE_IMAGE and have ansible-builder installed.
+| Specifies the intermediate builder image used for Python dependency collection and compilation; must contain a matching Python version with `EE_BASE_IMAGE` and have ansible-builder installed.
+
+The default image is `registry.redhat.io/ansible-automation-platform-23/ansible-builder-rhel8:latest`.
 |===
 
 The values given inside `build_arg_defaults` will be hard-coded into the `Containerfile`, so these values will persist if `podman build` is called manually.


### PR DESCRIPTION
* Added default and rpm build values of image.

Updated table with default values (normal and with RH RPM build.

Correct default value for EE_XXXX_IMAGE

Affects `titles/builder/`

https://issues.redhat.com/browse/AAP-8980