### PR TITLE
AAP-2080 added note about 301 redirect

### DIFF
--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server.adoc
@@ -47,3 +47,4 @@ password=my_pass
 <2> Include the `/api/galaxy/` subdirectory in the Galaxy server URL.
 <3> Include the `/api/galaxy/` subdirectory in the {HubName} server URL.
 
+NOTE: All API URLs must end with a trailing slash */* in order to prevent receiving a 301 redirect.


### PR DESCRIPTION
Added a note stating that all api urls must end with a trailing slash or the user will receive a 301 redirect. 