### PR TITLE
[Backport] CA-FIX - removed extra space to fix broken attribute (#866)

### DIFF
--- a/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
@@ -5,7 +5,7 @@
 To enable {AAPCentralAuth} for your {HubName}, start by downloading the {PlatformName} installer then proceed with the necessary set up procedures as detailed in this guide.
 
 [IMPORTANT]
-The installer in this guide will install {CentralAuth} for a basic standalone deployment. Standalone mode only runs one {CentralAuth} server instance, and thus will not be usable for clustered deployments. Standalone mode can be useful to test drive and play with the features of { CentralAuth}, but it is not recommended that you use standalone mode in production as you will only have a single point of failure.
+The installer in this guide will install {CentralAuth} for a basic standalone deployment. Standalone mode only runs one {CentralAuth} server instance, and thus will not be usable for clustered deployments. Standalone mode can be useful to test drive and play with the features of {CentralAuth}, but it is not recommended that you use standalone mode in production as you will only have a single point of failure.
 
 To install {CentralAuth} in a different deployment mode, please see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/operating-mode[this guide] for more deployment options.
 


### PR DESCRIPTION
This PR backports the changes from PR866 to the 2.2 branch.