### PR TITLE
2.1 AAP-2086 Add port 443 access prereq for syncing collections (#857)

### DIFF
--- a/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-set-rhcertified-remote"]
-= Configuring the rh-certified remote repository and syncing Red Hat Certified collections.
+= Configuring the rh-certified remote repository and synchronizing {CertifiedColl}.
 
 You can edit the *rh-certified* remote repository to sync collections from {HubName} hosted on cloud.redhat.com to your local {HubName}.
 By default, your local {HubName} `rh-certified` repository includes the URL for the entire group of Red Hat Certified Collections available on cloud.redhat.com.
@@ -11,7 +11,8 @@ To use only those collections specified by your organization, you must include a
 
 * You have *Modify Ansible repo content* permissions.
 See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Automation Hub] for more information on permissions.
-* You have retrieved the Sync URL and API Token from the {HubName} hosted service on cloud.redhat.com.
+* You have retrieved the Sync URL and API Token from the {HubName} hosted service on {Console}.
+* You have configured access to port 443. This is required for synchronizing certified collections. For more information, see the {HubName} table in the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] chapter of the {PlatformName} Planning Guide.
 
 .Procedure
 . Log in to your local {HubName}.
@@ -22,9 +23,9 @@ See https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_pla
 . Click btn:[Save].
 
 The modal closes and returns you to the *Repo Management* page.
-You can now sync collections between your organization synclist on cloud.redhat.com and your local {HubName}.
-
-. Click btn:[Sync] to sync collections.
+You can now synchronize collections between your organization synclist on {Console} and your {PrivateHubName}.
++
+. Click btn:[Sync] to synchronize collections.
 
 The *Sync status* notification updates to notify you of completion of Red Hat Certified collections sync.
 


### PR DESCRIPTION
Backports https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/857 to 2.2

Automation Hub requires port 443 access for syncing certified collections. Add prereq for syncing procedure.
Affects titles/hub/configuring-private-hub-rh-certified