### PR TITLE
Updating prerequisites for a synclist in hub (#884)

### DIFF
--- a/downstream/modules/automation-hub/proc-create-synclist.adoc
+++ b/downstream/modules/automation-hub/proc-create-synclist.adoc
@@ -20,6 +20,7 @@ All {CertifiedName} are included by default in your initial organization synclis
 ** `sso.redhat.com`
 * {HubNameMain} resources are stored in Amazon Simple Storage and the following domain name is in the allow list:
 ** `automation-hub-prd.s3.us-east-2.amazonaws.com`
+** `ansible-galaxy.s3.amazonaws.com`
 * SSL inspection is disabled either when using self signed certificates or for the Red Hat domains.
 
 .Procedure


### PR DESCRIPTION
* Updating prerequisites for a synclist in hub

ansible-galaxy.s3.amazonaws.com added to the list

Add ansible-galaxy.s3.amazonaws.com to list of opening

https://issues.redhat.com/browse/AAP-9697

Affects `titles/hub/create-synclist`