### PR TITLE
Updating prerequisites for a synclist in hub (#884) (#887) (#889)

### DIFF
--- a/downstream/modules/automation-hub/proc-create-synclist.adoc
+++ b/downstream/modules/automation-hub/proc-create-synclist.adoc
@@ -21,8 +21,8 @@ By default, all Red Hat Certified collections are included in your initial organ
 * {HubNameStart} resources are stored in Amazon Simple Storage.
 Add the following domain name to the allow list:
 ** `automation-hub-prd.s3.us-east-2.amazonaws.com`
-* SSL inspection must be disabled either when using self signed certificates or for the Red Hat domains.
-
+** `ansible-galaxy.s3.amazonaws.com`
+* SSL inspection is disabled either when using self signed certificates or for the Red Hat domains.
 
 .Procedure
 


### PR DESCRIPTION
* Updating prerequisites for a synclist in hub

ansible-galaxy.s3.amazonaws.com added to the list

Add ansible-galaxy.s3.amazonaws.com to list of opening

https://issues.redhat.com/browse/AAP-9697

Affects `titles/hub/create-synclist`

* Updating prerequisites for a synclist in hub

ansible-galaxy.s3.amazonaws.com added to the list

Add ansible-galaxy.s3.amazonaws.com to list of opening

https://issues.redhat.com/browse/AAP-9697

Affects titles/hub/create-synclist