### PR TITLE
Modify module IDs to fix docs build problems

### DIFF
--- a/downstream/modules/automation-hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/automation-hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -1,5 +1,5 @@
 
-[id="configuring-the-client-to-verify-signatures]
+[id="configuring-the-client-to-verify-signatures"]
 
 = Configuring the client to verify signatures
 

--- a/downstream/modules/automation-hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/automation-hub/proc-pushing-container-images-from-your-local.adoc
@@ -1,5 +1,5 @@
 
-[id="pushing-container-images-from-your-local]
+[id="pushing-container-images-from-your-local"]
 
 = Pushing container images from your local
 


### PR DESCRIPTION
Bad syntax in module IDs was causing a docs build to fail.

Affects `titles/hub/manage-containers`