### PR TITLE
AAP-8553 Updated references to 2.2 to 2.3

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -32,7 +32,7 @@ include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/ansible_navigator_creator_guide/index[Ansible Navigator Creator Guide] for more information on migrating to {ExecEnvName}.
+* For more information on migrating to {ExecEnvName}, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/ansible_navigator_creator_guide/index[Ansible Navigator Creator Guide].
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -31,10 +31,8 @@ The below workflow describes how to migrate from legacy venvs to {ExecEnvName} u
 include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-// Remove comments once 2.2 version of the docs are published.
-//== Additional resources
-
-//* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
+.Additional resources
+* For more information, refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/ansible_navigator_creator_guide/index[Ansible Navigator Creator Guide] for more information on migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -32,7 +32,7 @@ $ subscription-manager attach --pool=<sku-pool-id>
 +
 [options="nowrap" subs="+quotes"]
 ----
-# dnf install --enablerepo=ansible-automation-platform-2.2-for-rhel-8-x86_64-rpms ansible-navigator
+# dnf install --enablerepo=ansible-automation-platform-2.3-for-rhel-8-x86_64-rpms ansible-navigator
 ----
 
 .Verification

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -40,10 +40,8 @@ NOTE: By running the setup script, the Installer modified a few fields from your
 ====
 The design of your {AutomationMesh} topology depends on the automation needs of your environment.
 It is beyond the scope of this document to provide designs for all possible scenarios.
-The following is one example {AutomationMesh} design.
+The following is one example {AutomationMesh} design. Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
 ====
-//Remove comment and add to the above note once 2.2 version of the docs are published.
-// Review the full https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide] for information on designing it for your needs.
 +
 .Example inventory file with a standard control plane consisting of three nodes utilizing hop nodes:
 ----
@@ -96,5 +94,4 @@ $ ./setup.sh -i inventory.new.ini -e @credentials.yml -- --ask-vault-pass
 
 .Additional resources
 * For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
-// Remove comments once 2.2 version of the docs are published.
-//* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]
+* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -150,7 +150,7 @@ Same as `web_server_ssl_cert` but for {HubName} UI and API
 `/path/to/automationhub.key`
 
 Same as `web_server_ssl_key` but for {HubName} UI and API
-| *`automationhub_ssl_validate_certs`* | For {PlatformName} 2.2 and later, this value is no longer used.
+| *`automationhub_ssl_validate_certs`* | For {PlatformName} 2.3 and later, this value is no longer used.
 
 If {HubName} should validate certificate when requesting itself because by default, {PlatformNameShort} deploys with self-signed certificates.
 

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -16,7 +16,7 @@ h| Subscription | Valid Red Hat Ansible Automation Platform |
 
 h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version 2.12 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
+h| Ansible | version 2.3 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.14.
 
 h| Python | 3.8 or later |
 
@@ -46,7 +46,7 @@ See link:https://docs.ansible.com/ansible/latest/user_guide/intro_getting_starte
 
 * Although {PlatformName} depends on Ansible Playbooks and requires the installation of the latest stable version of Ansible before installing {ControllerName}, manual installations of Ansible are no longer required.
 
-* For new installations, {ControllerName} installs the latest release package of Ansible 2.2.
+* For new installations, {ControllerName} installs the latest release package of Ansible 2.3.
 
 * If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 


### PR DESCRIPTION
Corrected references from 2.2 to 2.3 in the following modules and 1 assembly:

- ../modules/platform/ref-system-requirements.adoc
- ../modules/platform/ref-hub-variables.adoc
- ../modules/platform/proc-upgrade-installer.adoc
- ../modules/navigator/proc-installing-navigator-rhel-rpm.adoc
- platform/assembly-migrate-legacy-venv-to-ee.adoc