### PR TITLE
AAP 9652: clarify websocket configuration in operations guide

### DIFF
--- a/downstream/modules/platform/con-websocket-setup.adoc
+++ b/downstream/modules/platform/con-websocket-setup.adoc
@@ -5,6 +5,8 @@
 [role="_abstract"]
 {ControllerNameStart} nodes are interconnected through websockets to distribute all websocket-emitted messages throughout your system. This configuration setup enables any browser client websocket to subscribe to any job that might be running on any {ControllerName} node. Websocket clients are not routed to specific {ControllerName} nodes. Instead, any {ControllerName} node can handle any websocket request and each {ControllerName} node must know about all websocket messages destined for all clients.
 
+You can configure websockets at `/etc/tower/conf.d/websocket_config.py` in all of your {ControllerName} nodes and the changes will be effective after the service restarts.
+
 {ControllerNameStart} automatically handles discovery of other {ControllerName} nodes through the Instance record in the database.
 
 [IMPORTANT]


### PR DESCRIPTION
This request is to clarify language around configuring websockets in the Operations Guide. Link to JIRA: https://issues.redhat.com/browse/AAP-9652

Link to google doc with drafted language: https://docs.google.com/document/d/1zdfpXi6mQthql1O0-bcWbB6gJTIsKKjJk0UNXApc8oo/edit#

A technical SME has reviewed and approved the language. 