### PR TITLE
Backport AAP 9652: clarify websocket configuration in operations guide (#897)

### DIFF
--- a/downstream/modules/platform/con-websocket-setup.adoc
+++ b/downstream/modules/platform/con-websocket-setup.adoc
@@ -5,6 +5,8 @@
 [role="_abstract"]
 {ControllerNameStart} nodes are interconnected through websockets to distribute all websocket-emitted messages throughout your system. This configuration setup enables any browser client websocket to subscribe to any job that might be running on any {ControllerName} node. Websocket clients are not routed to specific {ControllerName} nodes. Instead, any {ControllerName} node can handle any websocket request and each {ControllerName} node must know about all websocket messages destined for all clients.
 
+You can configure websockets at `/etc/tower/conf.d/websocket_config.py` in all of your {ControllerName} nodes and the changes will be effective after the service restarts.
+
 {ControllerNameStart} automatically handles discovery of other {ControllerName} nodes through the Instance record in the database.
 
 [IMPORTANT]


### PR DESCRIPTION
This PR backports changes requested to the Operations Guide in https://issues.redhat.com/browse/AAP-9652 to the 2.3 release. 

Related PR: https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/897