### PR TITLE
Added information about pulling container images (#893)

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -23,11 +23,11 @@ To avoid problems pulling container images, you must enable outbound connections
 * `cdn02.quay.io`
 * `cdn03.quay.io`
 
-This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
+Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
 Use the hostnames instead of IP addresses when configuring firewall rules. 
 
-After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not need a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 ====
 
 == Prerequisites

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -12,6 +12,24 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 By default, private {HubName} does not include container images. To populate your container registry, you need to push a container image to it. The procedures in this section describe how to pull images from the Red Hat Ecosystem Catalog (registry.redhat.io), tag them, and push them to your private {HubName} container registry.
 
+[IMPORTANT]
+====
+Image manifests and filesystem blobs are served directly from `registry.redhat.io` and `registry.access.redhat.com`. 
+However, from 1st of May 2023, filesystem blobs are served from `quay.io` instead. 
+To avoid problems pulling container images, you must enable outbound connections to the following hostnames:
+
+* `cdn.quay.io`
+* `cdn01.quay.io`
+* `cdn02.quay.io`
+* `cdn03.quay.io`
+
+This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
+
+Use the hostnames instead of IP addresses when configuring firewall rules. 
+
+After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+====
+
 == Prerequisites
 
 * You have permissions to create new containers and push containers to private {HubName}.

--- a/downstream/assemblies/hub/assembly-pull-image.adoc
+++ b/downstream/assemblies/hub/assembly-pull-image.adoc
@@ -1,38 +1,18 @@
-////
-Retains the context of the parent assembly if this assembly is nested within another assembly.
-For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
-See also the complementary step on the last line of this file.
-////
-
 ifdef::context[:parent-context: {context}]
-
-////
- Base the file name and the ID on the assembly title. For example:
-* file name: assembly-my-user-story.adoc
-* ID: [id="assembly-my-user-story_{context}"]
-* Title: = My user story
-
-The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken. Include {context} in the ID so the assembly can be reused.
-////
 
 [id="pulling-images-container-repository"]
 = Pulling images from a container repository
 
-
 :context: pulling-images-container-repository
-
-
 
 [role="_abstract"]
 Pull images from the {HubName} container registry to make a copy to your local machine. {HubNameStart} provides the `podman pull` command for each `latest` image in the container repository. You can copy and paste this command into your terminal, or use `podman pull` to copy an image based on an image tag.
 
 == Prerequisites
 
-* You have permission to view and pull from a private container repository.
+You must have permission to view and pull from a private container repository.
 
 include::automation-hub/proc-pull-image.adoc[leveloffset=+1]
-
-
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -275,12 +275,12 @@ Image manifests and filesystem blobs are served directly from `registry.redhat.i
 However, from 1st of May 2023, filesystem blobs are served from `quay.io` instead. 
 To avoid problems pulling container images, you must enable outbound connections to the listed `quay.io` hostnames.
 
-This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io`.
+Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io`.
 
 Use the hostnames instead of IP addresses when configuring firewall rules. 
 
 After making this change you can continue to pull images from `registry.redhat.io`. 
-You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+You do not need a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
 For more information, see the article link:https://access.redhat.com/articles/6999582[here]
 ====

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -262,5 +262,25 @@ a|Open *only* if the internal database is used. Otherwise, this port should not 
 [options="header"]
 |===
 |URL |Required for
-|link:https://registry.redhat.io:44[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
+|link:https://registry.redhat.io:443[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
+| `cdn.quay.io:443` | Access to container images provided by Red Hat and partners
+| `cdn01.quay.io:443` | Access to container images provided by Red Hat and partners
+| `cdn02.quay.io:443` | Access to container images provided by Red Hat and partners
+| `cdn03.quay.io:443` | Access to container images provided by Red Hat and partners
 |===
+
+[IMPORTANT]
+====
+Image manifests and filesystem blobs are served directly from `registry.redhat.io`. 
+However, from 1st of May 2023, filesystem blobs are served from `quay.io` instead. 
+To avoid problems pulling container images, you must enable outbound connections to the listed `quay.io` hostnames.
+
+This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io`.
+
+Use the hostnames instead of IP addresses when configuring firewall rules. 
+
+After making this change you can continue to pull images from `registry.redhat.io`. 
+You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+
+For more information, see the article link:https://access.redhat.com/articles/6999582[here]
+====


### PR DESCRIPTION
* Added information about pulling container images

Added admonition and tidied the content.

Update document to reflect new Red Hat registry network changes

https://issues.redhat.com/browse/AAP-9698

* Added information about pulling container images

Moved orignal information, added it to Planning Guide also

Update document to reflect new Red Hat registry network changes

https://issues.redhat.com/browse/AAP-9698

* Added information about pulling container images

Corrections to planning guide EE table

Update document to reflect new Red Hat registry network changes

https://issues.redhat.com/browse/AAP-9698

* Added information about pulling container images

Added port number

Update document to reflect new Red Hat registry network changes

https://issues.redhat.com/browse/AAP-9698

* Added information on pulling container images

Addressed comments. Added link to acess article.

Update document to reflect new Red Hat registry network changes

https://issues.redhat.com/browse/AAP-9698