### PR TITLE
Backport-2.3-852 from AAP-8485 (PR #852) Add new variable to AAP Installer

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -103,6 +103,10 @@ Default = 27199.
 for example, if you use shortnames in your inventory, but the node running the installer can only resolve that host using FQDN.
 
 If `routable_hostname` is not set, it should default to `ansible_host`. Then if, and only if `ansible_host` is not set, `inventory_hostname` is used as a last resort.
+| *`supervisor_start_retry_count`* | When specified (no default value exists), adds `startretries = <value specified>` to the supervisor config file (/etc/supervisord.d/tower.ini).
+
+See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for further explanation about `startretries`.
+
 | *`web_server_ssl_cert`* |  _Optional_ 
 
 `/path/to/webserver.cert`


### PR DESCRIPTION
Backporting updates from the original jira [AAP-8485](https://issues.redhat.com/browse/AAP-8485) (PR #852 ). Adds a new variable "supervisor_start_retry_count" for AAP installer. 