### PR TITLE
Added admonition for Catalog docs

### DIFF
--- a/downstream/aap-common/sunset-catalog-content-admonition.adoc
+++ b/downstream/aap-common/sunset-catalog-content-admonition.adoc
@@ -1,0 +1,8 @@
+
+[id="sunset-catalog-content-admonition"]
+[IMPORTANT]
+====
+Support for Automation Services Catalog is no longer available for Ansible Automation Platform from 2.4.
+====
+
+

--- a/downstream/aap-common/sunset-catalog-content-admonition.adoc
+++ b/downstream/aap-common/sunset-catalog-content-admonition.adoc
@@ -2,7 +2,7 @@
 [id="sunset-catalog-content-admonition"]
 [IMPORTANT]
 ====
-Support for Automation Services Catalog is no longer available for Ansible Automation Platform from 2.4.
+Support for {CatalogName} is no longer available for {PlatformNameShort} from 2.4.
 ====
 
 

--- a/downstream/titles/catalog/getting-started/master.adoc
+++ b/downstream/titles/catalog/getting-started/master.adoc
@@ -6,6 +6,8 @@ include::attributes/attributes.adoc[]
 [[getting-started]]
 = Getting started with Automation Services Catalog
 
+include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 == About {CatalogName}

--- a/downstream/titles/catalog/itsm-integration/master.adoc
+++ b/downstream/titles/catalog/itsm-integration/master.adoc
@@ -4,6 +4,8 @@
 
 You can use the order process features of Automation Services Catalog to integrate with an Information Technology Service Management (ITSM) systems such as ServiceNow.
 
+include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::catalog/assembly-planning-ITSM-integration.adoc[leveloffset=+1]

--- a/downstream/titles/catalog/onboarding/master.adoc
+++ b/downstream/titles/catalog/onboarding/master.adoc
@@ -1,6 +1,8 @@
 :imagesdir: images
 = Automation Service Catalog Onboarding
 
+include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 == About Automation Service Catalog

--- a/downstream/titles/catalog/support-matrix/master.adoc
+++ b/downstream/titles/catalog/support-matrix/master.adoc
@@ -6,6 +6,8 @@ This document describes the supported products that Automation Services Catalog 
 
 Automation Services Catalog is a hosted service at cloud.redhat.com and therefore does not itself have any public support matrix. Red Hat will own the maintaining and updating of the hosted service.
 
+include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 == Dependent Products Support Matrix

--- a/downstream/titles/worker-install/master.adoc
+++ b/downstream/titles/worker-install/master.adoc
@@ -16,6 +16,8 @@ This is a Day 2 activity and requires setup of a *service account that has write
 
 The Catalog worker requires a set of variables assigned to hosts in your Red Hat Ansible Automation Platform network. Running the Catalog worker will create an application and an application token, install the necessary packages, and start the service.
 
+include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]
+
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::catalog/assembly-installing-catalog-worker.adoc[leveloffset=+1]


### PR DESCRIPTION
Added IMPORTANT admonition for the sunset of Catalog docs

Add disclaimer or note about the sun-setting of Automation Services Catalog docs in the AAP 2.2 and 2.3 repos

https://issues.redhat.com/browse/AAP-9423

Affects `titles/catalog` and `titles/worker-install`