### PR TITLE
Updating attribute sym links (#926)

### DIFF
--- a/downstream/titles/catalog/itsm-integration/master.adoc
+++ b/downstream/titles/catalog/itsm-integration/master.adoc
@@ -1,4 +1,9 @@
 :imagesdir: images
+
+:experimental:
+
+include::attributes/attributes.adoc[]
+
 [[configuring-your-tower-infrastructure-to-communicate-with-catalog]]
 = Integrating Automation Services Catalog with your IT Service Management (ITSM) systems
 

--- a/downstream/titles/catalog/onboarding/master.adoc
+++ b/downstream/titles/catalog/onboarding/master.adoc
@@ -1,4 +1,9 @@
 :imagesdir: images
+
+:experimental:
+
+include::attributes/attributes.adoc[]
+
 = Automation Service Catalog Onboarding
 
 include::aap-common/sunset-catalog-content-admonition.adoc[leveloffset=+1]

--- a/downstream/titles/catalog/support-matrix/master.adoc
+++ b/downstream/titles/catalog/support-matrix/master.adoc
@@ -1,4 +1,9 @@
 :imagesdir: images
+
+:experimental:
+
+include::attributes/attributes.adoc[]
+
 [[catalog_support_matrix]]
 = Automation Services Catalog product support matrix
 


### PR DESCRIPTION
Added missing attribute sym links to catalog docs

Add disclaimer or note about the sun-setting of Automation Services Catalog docs in the AAP 2.2 and 2.3 repos

https://issues.redhat.com/browse/AAP-9423

Affects titles/catalog