### PR TITLE
Moved 'routable_hostname' variable

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -99,10 +99,6 @@ Default = `awx`.
 | *`receptor_listener_port`* | Port to use for recptor connection.
 
 Default = 27199.
-| *`routable_hostname`* | `routable hostname` is used if the machine running the installer can only route to the target host through a specific URL,
-for example, if you use shortnames in your inventory, but the node running the installer can only resolve that host using FQDN.
-
-If `routable_hostname` is not set, it should default to `ansible_host`. Then if, and only if `ansible_host` is not set, `inventory_hostname` is used as a last resort.
 | *`supervisor_start_retry_count`* | When specified (no default value exists), adds `startretries = <value specified>` to the supervisor config file (/etc/supervisord.d/tower.ini).
 
 See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for further explanation about `startretries`.

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -28,6 +28,12 @@ User credential for access to `registry_url`.
 Used for both `[automationcontroller]` and `[automationhub]` groups, but only if the value of `registry_url` is `registry.redhat.io`.
 
 Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
+| *`routable_hostname`* | `routable hostname` is used if the machine running the installer can only route to the target host through a specific URL, for example, if you use shortnames in your inventory, but the node running the installer can only resolve that host using FQDN.
+
+If `routable_hostname` is not set, it should default to `ansible_host`. Then if, and only if `ansible_host` is not set, `inventory_hostname` is used as a last resort.
+
+Note that this varible is used as a host variable for particular hosts and not under the `[all:vars]` section. 
+See link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables[Assigning a variable to one machine:host variables]
 |====
 
 

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -32,8 +32,8 @@ Enter your Red Hat Registry Service Account credentials in `registry_username` a
 
 If `routable_hostname` is not set, it should default to `ansible_host`. Then if, and only if `ansible_host` is not set, `inventory_hostname` is used as a last resort.
 
-Note that this varible is used as a host variable for particular hosts and not under the `[all:vars]` section. 
-See link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables[Assigning a variable to one machine:host variables]
+Note that this variable is used as a host variable for particular hosts and not under the `[all:vars]` section. 
+For further information, see link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables[Assigning a variable to one machine:host variables]
 |====
 
 


### PR DESCRIPTION
Moved routable hostname from controller to general variables.

Variable routable_hostname should be moved to A1 general section rather than controller specific

https://issues.redhat.com/browse/AAP-10627