### PR TITLE
AAP-10305 updated example script

### DIFF
--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -66,8 +66,10 @@ After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameSh
 automationhub_create_default_collection_signing_service = True
 automationhub_auto_sign_collections = True
 automationhub_require_content_approval = True
-automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_service.gpg
-automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
+automationhub_collection_signing_service_key = /absolute/path/to/key/to/sign
+automationhub_collection_signing_service_script =  /absolute/path/to/script/that/signs
+automationhub_container_signing_service_key = /absolute/path/to/key/to/sign
+automationhub_container_signing_service_script =  /absolute/path/to/script/that/signs
 ----
 +
 The two new keys (*automationhub_auto_sign_collections* and *automationhub_require_content_approval*) indicate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.


### PR DESCRIPTION
AAP-10305

Updated example script in Step 2 of [4.1. Configuring content signing on private automation hub](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/assembly-collections-and-content-signing-in-pah#proc-configure-content-signing-on-pah) to include script for Container as well as Collection.