### PR TITLE
Add attribute for RH-SSO

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -111,4 +111,5 @@
 
 // Red Hat products
 :RHSSO: Red Hat Single Sign-On
+:RHSSOshort: RH-SSO
 :OperatorRHSSO: Red Hat Single Sign-On Operator


### PR DESCRIPTION
`RH-SSO` is allowed in Red Hat documentation, even though it is not listed in the official Red Hat product names spreadsheet.

Create an attribute for `RH-SSO` in case the abbreviation is changed to something like RHSSO in future.