### PR TITLE
Corrected Keycloak client instructions

### DIFF
--- a/downstream/modules/platform/proc-create-keycloak-client.adoc
+++ b/downstream/modules/platform/proc-create-keycloak-client.adoc
@@ -119,7 +119,7 @@ spec:
           id.token.claim: 'true'
           access.token.claim: 'true'
           userinfo.token.claim: 'true'
-          usermodel.clientRoleMapping.clientId:  '{HubName}'
+          usermodel.clientRoleMapping.clientId:  'automation-hub'
           claim.name: client_roles
           jsonType.label: String
         name: client_roles
@@ -128,7 +128,7 @@ spec:
       - config:
           id.token.claim: "true"
           access.token.claim: "true"
-          included.client.audience: '{HubName}'
+          included.client.audience: 'auutomation-hub'
         protocol: openid-connect
         name: audience mapper
         protocolMapper: oidc-audience-mapper

--- a/downstream/modules/platform/proc-create-keycloak-client.adoc
+++ b/downstream/modules/platform/proc-create-keycloak-client.adoc
@@ -128,7 +128,7 @@ spec:
       - config:
           id.token.claim: "true"
           access.token.claim: "true"
-          included.client.audience: 'auutomation-hub'
+          included.client.audience: 'automation-hub'
         protocol: openid-connect
         name: audience mapper
         protocolMapper: oidc-audience-mapper


### PR DESCRIPTION
Changed {HubName} to automation-hub

Docs for using RH-SSO Operator w/PAH Operator involve using a breaking change

https://issues.redhat.com/browse/AAP-10768