### PR TITLE
2.1 Fix image ref in analytics module

### DIFF
--- a/downstream/modules/analytics/proc-link-plan-job-template.adoc
+++ b/downstream/modules/analytics/proc-link-plan-job-template.adoc
@@ -10,5 +10,5 @@ You can associate a job template to a savings plan to allow {InsightsShort} to p
 
 .Procedure
 . Navigate to menu:Red Hat Insights[Savings Planner].
-. Click image:ellipses.png[More,10,25] and select *Link Template*.
+. Click image:ellipsis.png[More,10,25] and select *Link Template*.
 . Click btn:[Save].


### PR DESCRIPTION
Backports #957 to 2.1

Fix a typo in an image reference.

Affects `titles/analytics/automation-savings-planner`
