### PR TITLE
[Backport] AAP-6074 added subscription manifest procedures to activate aap (#822)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-activate.adoc
+++ b/downstream/assemblies/platform/assembly-aap-activate.adoc
@@ -1,0 +1,18 @@
+ifdef::context[:parent-context: {context}]
+
+[id="assembly-aap-activate"]
+= Activating {PlatformName}
+
+:context: activate-aap
+
+[role="_abstract"]
+{PlatformName} uses available subscriptions or a subscription manifest to authorize the use of {PlatformNameShort}. To obtain a subscription, you can do either of the following:
+
+. Use your Red Hat customer or Satellite credentials when you launch {PlatformNameShort}.
+. Upload a subscriptions manifest file either using the {PlatformName} interface or manually in an Ansible playbook.
+
+include::platform/proc-aap-activate-with-credentials.adoc[leveloffset=+1]
+include::platform/proc-aap-activate-with-manifest.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-aap-manifest-files.adoc
+++ b/downstream/assemblies/platform/assembly-aap-manifest-files.adoc
@@ -1,0 +1,24 @@
+
+
+ifdef::context[:parent-context: {context}]
+
+
+
+[id="assembly-aap-obtain-manifest-files"]
+= Obtaining a manifest file
+
+:context: obtain-manifest
+
+[role="_abstract"]
+You can obtain a subscription manifest in the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] section of Red Hat Subscription Management. After you obtain a subscription allocation, you can download its manifest file and upload it to activate {PlatformNameShort}.
+
+To begin, login to the link:https//www.access.redhat.com[Red Hat Customer Portal] using your administrator user account and follow the procedures in this section.
+
+include::platform/proc-aap-create-subscription-allocation.adoc[leveloffset=+1]
+
+include::platform/proc-aap-add-merge-subscriptions.adoc[leveloffset=+1]
+
+include::platform/proc-aap-generate-manifest-file.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-aap-post-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-post-installation.adoc
@@ -1,0 +1,15 @@
+ifdef::context[:parent-context: {context}]
+
+[id="assembly-aap-post-installation"]
+= Post installation tasks
+
+:context: post-installation
+
+[role="_abstract"]
+After installing {PlatformName}, your system might need extra configuration to ensure your deployment runs smoothly.
+
+include::assembly-aap-activate.adoc[leveloffset=+1]
+include::assembly-aap-manifest-files.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
+++ b/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
@@ -1,0 +1,20 @@
+
+[id="proc-aap-activate-with-credentials_{context}"]
+
+= Activate with credentials
+
+When {PlatformNameShort} launches for the first time, the {PlatformNameShort} Subscription screen automatically displays. You can use your Red Hat credentials to retrieve and import your subscription directly into {PlatformNameShort}.
+
+.Procedures
+. Enter your Red Hat username and password.
+. Click btn:[Get Subscriptions].
++
+[NOTE]
+====
+You can also use your Satellite username and password if your cluster nodes are registered to Satellite through Subscription Manager.
+====
++
+. Review the End User License Agreement and select *I agree to the End User License Agreement*.
+. The Tracking and Analytics options are checked by default. These selections help Red Hat improve the product by delivering you a much better user experience. You can opt out by deselecting the options.
+. Click btn:[Submit].
+. Once your subscription has been accepted, the license screen displays and navigates you to the Dashboard of the {PlatformNameShort} interface. You can return to the license screen by clicking image:cog.png[Settings] and selecting the *License* tab from the Settings screen.

--- a/downstream/modules/platform/proc-aap-activate-with-manifest.adoc
+++ b/downstream/modules/platform/proc-aap-activate-with-manifest.adoc
@@ -1,0 +1,33 @@
+
+[id="proc-aap-activate-with-manifest_{context}"]
+
+= Activate with a manifest file
+
+If you have a subscriptions manifest, you can upload the manifest file either using the {PlatformName} interface or manually in an Ansible playbook.
+
+.Prerequisites
+You must have a Red Hat Subscription Manifest file exported from the Red Hat Customer Portal. For more information, see xref:assembly-aap-obtain-manifest-files[Obtaining a manifest file].
+
+.Uploading with the interface
+
+. Complete steps to generate and download the manifest file
+. Log in to {PlatformName}.
+. If you are not immediately prompted for a manifest file, go to menu:Settings[License].
+. Make sure the *Username* and *Password* fields are empty.
+. Click btn:[Browse] and select the manifest file.
+. Click btn:[Next].
+
+[NOTE]
+====
+If the btn:[BROWSE] button is disabled on the License page, clear the *USERNAME* and *PASSWORD* fields.
+====
+
+.Uploading manually
+
+If you are unable to apply or update the subscription info using the {PlatformName} interface, you can upload the subscriptions manifest manually in an Ansible playbook using the `license` module in the `ansible.controller` collection.
+
+-----
+- name: Set the license using a file
+  license:
+  manifest: "/tmp/my_manifest.zip"
+-----

--- a/downstream/modules/platform/proc-aap-add-merge-subscriptions.adoc
+++ b/downstream/modules/platform/proc-aap-add-merge-subscriptions.adoc
@@ -1,0 +1,22 @@
+
+[id="proc-add-merge-subscriptions_{context}"]
+
+= Adding subscriptions to a subscription allocation
+
+Once an allocation is created, you can add the subscriptions you need for {PlatformNameShort} to run properly. This step is necessary before you can download the manifest and add it to {PlatformNameShort}.
+
+.Procedure
+. From the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] page, click on the name of the *Subscription Allocation* to which you would like to add a subscription.
+. Click the *Subscriptions* tab.
+. Click btn:[Add Subscriptions].
+. Enter the number of {PlatformNameShort} Entitlement(s) you plan to add.
+. Click btn:[Submit].
+
+.Verification
+After your subscription has been accepted, subscription details are displayed. A status of _Compliant_ indicates your subscription is in compliance with the number of hosts you have automated within your subscription count. Otherwise, your status will show as _Out of Compliance_, indicating you have exceeded the number of hosts in your subscription.
+
+Other important information displayed include the following:
+
+Hosts automated:: Host count automated by the job, which consumes the license count
+Hosts imported:: Host count considering all inventory sources (does not impact hosts remaining)
+Hosts remaining:: Total host count minus hosts automated

--- a/downstream/modules/platform/proc-aap-create-subscription-allocation.adoc
+++ b/downstream/modules/platform/proc-aap-create-subscription-allocation.adoc
@@ -1,0 +1,12 @@
+
+[id="proc-create-subscription-allocation_{context}"]
+
+= Create a subscription allocation
+
+Creating a new subscription allocation allows you to set aside subscriptions and entitlements for a system that is currently offline or air-gapped. This is necessary before you can download its manifest and upload it to {PlatformNameShort}.
+
+.Procedure
+. From the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] page, click btn:[New Subscription Allocation].
+. Enter a name for the allocation so that you can find it later.
+. Select *Type: Satellite 6.8* as the management application.
+. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-generate-manifest-file.adoc
+++ b/downstream/modules/platform/proc-aap-generate-manifest-file.adoc
@@ -1,0 +1,17 @@
+
+[id="proc-generate-manifest-file_{context}"]
+
+= Downloading a manifest file
+
+[role="_abstract"]
+After an allocation is created and has the appropriate subscriptions on it, you can download the manifest from Red Hat Subscription Management.
+
+.Procedure
+. From the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] page, click on the name of the *Subscription Allocation* to which you would like to generate a manifest.
+. Click the *Subscriptions* tab.
+. Click btn:[Export Manifest] to download the manifest file.
+
+[NOTE]
+====
+The file is saved to your default downloads folder and can now be uploaded to xref:proc-aap-activate-with-manifest_activate-aap[activate {PlatformName}].
+====

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -10,11 +10,11 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Red Hat Ansible Automation Platform Operations Guide
 
-This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
+After installing Red Hat Ansible Automation Platform, your system might need extra configuration to ensure your deployment runs smoothly. This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-
+include::platform/assembly-aap-activate.adoc[leveloffset=+1]
+include::platform/assembly-aap-manifest-files.adoc[leveloffset=+1]
 include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]
 include::platform/assembly-configuring-websockets.adoc[leveloffset=+1]
 include::platform/assembly-controlling-data-collection.adoc[leveloffset=+1]
-


### PR DESCRIPTION
This PR backports the changes for PR822 to the 2.3 branch and includes the following changes: 

Add chapter titled "Activating AAP" to the Operations Guide.
Included procedures for activating aap with a subscription manifest in both the aap interface or via manual upload.
Included procedures for activating aap using customer or Satellite credentials.
Add chapter titled "Obtaining a manifest file"
Included procedures for obtaining and downloading a manifest file.