### PR TITLE
Added instructions for adding content

### DIFF
--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -1,5 +1,5 @@
 [id="assembly-creating-tokens-in-automation-hub"]
-= Configuring {HubNameMain} remote repositories to sync content
+= Configuring {HubNameMain} remote repositories to synchronize content
 
 You can configure your {PrivateHubName} to synchronize with {CertifiedName} hosted in your organization repository on `{Console}` or to your choice of collections in {Galaxy}.
 

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -55,6 +55,7 @@ Upload the content and define the variables (this example uses `automationhub_ap
 ----
 ansible-playbook collection_seed.yml 
 -e automationhub_api_token=<api_token>
+-e automationhub_main_url=https://automationhub.example.com
 -e automationhub_require_content_approval=true
 ----
 

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -35,11 +35,13 @@ You require the following variables to run the playbook.
 |====
 | Name | Description 
 | *`automationhub_admin_password`* | Your administration password.
-| *`automation_hub_api_token`* | The API token generated for your {HubName}.
+| *`automationhub_api_token`* | The API token generated for your {HubName}.
 | *`automationhub_main_url`* | For example, `\https://automationhub.example.com`
-| *`automation_hub_require_content_approval`* | Boolean (`true` or `false`)
+| *`automationhub_require_content_approval`* | Boolean (`true` or `false`)
 
 This must match the value used during {HubName} deployment.
+
+This variable is set to `true` by the installer.
 |====
 
 [NOTE]
@@ -47,15 +49,13 @@ This must match the value used during {HubName} deployment.
 Use either `automationhub_admin_password` or `automationhub_api_token`, not both.
 ====
 
-Upload the content and define the variables using the command:
+Upload the content and define the variables (this example uses `automationhub_api_token'):
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
 ansible-playbook collection_seed.yml 
--e automationhub_admin_password=<admin password> 
--e automationhub_main_url=<main_url>
 -e automationhub_api_token=<api_token>
-ansible-playbook collection_seed.yml -e @<name of file where variables are defined>
+-e automationhub_require_content_approval=true
 ----
 
 For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook]

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -25,7 +25,7 @@ If missing both content sets will be uploaded.
 == Installing validated content using the tarball
 
 If you are not using the bundle installer, a standalone tarball, `ansible-validated-content-bundle-1.tar.gz` can be used instead.
-The standalone tarball can be used to update validated contents later in any environment, when a newer tarball becomes available and without having to re-run the bundle installer.
+The standalone tarball can also be used later to update validated contents later in any environment, when a newer tarball becomes available, and without having to re-run the bundle installer.
 
 To obtain the tarball, navigate to https://access.redhat.com/downloads/content/480 and select *Ansible Validated Content*.
 

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -49,7 +49,7 @@ This variable is set to `true` by the installer.
 Use either `automationhub_admin_password` or `automationhub_api_token`, not both.
 ====
 
-Upload the content and define the variables (this example uses `automationhub_api_token'):
+Upload the content and define the variables (this example uses `automationhub_api_token`):
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -59,6 +59,6 @@ ansible-playbook collection_seed.yml
 -e automationhub_require_content_approval=true
 ----
 
-For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook]
+For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook].
 
 When complete, the collections are visible in the validated collection section of {PrivateHubName}.

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -5,7 +5,7 @@
 
 {Valid} provides an expert-led path for performing operational tasks on a variety of platforms including both Red Hat and our trusted partners.
 
-== Configuring validated or certified collections with the installer
+== Configuring validated collections with the installer
 
 When you download and run the bundle installer, certified and validated collections are automatically uploaded. 
 Certified collections are uploaded into the `rh-certified` repository. 
@@ -22,55 +22,42 @@ Possible values are `certified` or `validated`.
 If missing both content sets will be uploaded.
 |====
 
-== {Valid}
+== Installing validated content using the tarball
+
+If you are not using the bundle installer, a standalone tarball, `ansible-validated-content-bundle-1.tar.gz` can be used instead.
+The standalone tarball can be used to update validated contents later in any environment, when a newer tarball becomes available and without having to re-run the bundle installer.
+
+To obtain the tarball, navigate to https://access.redhat.com/downloads/content/480 and select *Ansible Validated Content*.
+
+You require the following variables to run the playbook. 
+
+[cols="20%,50%",options="header"]
+|====
+| Name | Description 
+| *`automationhub_admin_password`* | Your administration password.
+| *`automation_hub_api_token`* | The API token generated for your {HubName}.
+| *`automationhub_main_url`* | For example, `\https://automationhub.example.com`
+| *`automation_hub_require_content_approval`* | Boolean (`true` or `false`)
+
+This must match the value used during {HubName} deployment.
+|====
 
 [NOTE]
 ====
-* {Valid} is only available with a valid subscription to {PlatformName}.
-* Unlike {CertifiedCon}, {Valid} is not supported by Red Hat or our partners. 
-* From the {PlatformName} {PlatformVers} release, {Valid} is preloaded into {PrivateHubName} and can be updated manually by downloading the packages.
+Use either `automationhub_admin_password` or `automationhub_api_token`, not both.
 ====
 
-[cols="20%,30%,30%,20%",options="header"]
-|====
-| Entity | Collection name | Description | Published by
-| Ansible | `cloud.azure_roles.load_balancer` | A role to manage Azure Load Balancer | Red Hat Ansible
-| Ansible | `cloud.azure_roles.managed_postgresql` | A role to manage Azure PostGreSQL Database |Red Hat Ansible
-| Ansible | `cloud.azure_roles.network_interface` | A role to manage Azure Network Interface | Red Hat Ansible 
-| Ansible | `cloud.azure_roles.networking_stack` | A role to manage Azure Networking Stack | Red Hat Ansible
-| Ansible | `cloud.azure_roles.resource_group`  | A role to manage Azure Resource Group | Red Hat Ansible
-| Ansible | `cloud.azure_roles.security_group`  | A role to manage Azure Security Group | Red Hat Ansible
-| Ansible | `cloud.azure_roles.virtual_machine`  | A role to manage Azure Virtual Machine | Red Hat Ansible
-| Ansible | `network.base` | A validated content collection to configure base config related implementation that would be used by other validated content | Red Hat Ansible
-| Ansible | `network.base` | A validated content collection to configure bgp and provide capabilities to do operational state/healthchecks | Red Hat Ansible
-| Ansible | `network.acls` | A validated content collection to configure acls and provide capabilities to do operational state/healthchecks | Red Hat Ansible
-| Ansible | `network.interfaces` | A validated content collection to configure interfaces and provide capabilities to do operational state/healthchecks | Red Hat Ansible
-| Ansible | `network.ospf` | A validated content collection to configure ospf and provide capabilities to do operational state/healthchecks | Red Hat Ansible
-| Ansible | <name yet to decide> | Connectivity between on-prem network device (for ex CSR) and cloud gateway(for ex AWS) | Red Hat Ansible
-| Ansible | <name yet to decide> | A validated content (potentially a role) on Inventory Report that returns statistics and IDs of different edge nodes and servers |Red Hat Ansible
-| Ansible | | Network device Inventory report using html | Red Hat Ansible
-| Ansible | | Network config backup | Red Hat Ansible
-| Ansible | | Network config restore | Red Hat Ansible
-| Ansible | | IOS Updater | Red Hat Ansible
-| Ansible | | NXOS Updater | Red Hat Ansible
-| Ansible | | EOS Updater | Red Hat Ansible
-| Ansible | | Firewall policy automation - A validated content to take care of FW policy hygiene | Red Hat Ansible
-| Ansible | | OSbuilder for RHEL Edge disconnected (customer request) | Red Hat Ansible
-| Ansible | | Middleware collection | Red Hat Ansible
-| Ansible | | Windows and Linux Compliance |Red Hat Ansible
-| Ansible | | SAP Deployment | Red Hat Ansible
-| Ansible | | Automation controller configuration | Red Hat Ansible
-| Ansible | | Execution Environment Utilities | Red Hat Ansible
-| Ansible | | {HubNameStart} configuration | Red Hat Ansible
-| Ansible | | AAP utilities | Red Hat Ansible
-| Ansible | | Role to deploy and migrate a web application on _{AWS}_ (AWS) | Red Hat Ansible 
-| Ansible | | Role to deal with AWS orphaned instances by tag | Red Hat Ansible
-| Ansible | | Role to create a customized _Amazon Machine Images_ (AMI) | Red Hat Ansible
-| Ansible | | Role to detach and delete AWS _Internet Gateway_ (IGW)s |Red Hat Ansible
-| Ansible | | Role to configure a multi-region CloudTrail | Red Hat Ansible
-| Ansible | | Role to configure CloudTrail encryption | Red Hat Ansible
-| Ansible | | Role to troubleshoot EC2 instances failing to join an ECS cluster | Red Hat Ansible
-| Ansible | | Role to troubleshoot _Relational database Service_ (RDS) connectivity from an instance | Red Hat Ansible
-| Ansible | | Role to troubleshoot _Virtual Private Cloud_ (VPC) connectivity issues | Red Hat Ansible
-|====
+Upload the content and define the variables using the command:
 
+[options="nowrap" subs="+quotes,attributes"]
+----
+ansible-playbook collection_seed.yml 
+-e automationhub_admin_password=<admin password> 
+-e automationhub_main_url=<main_url>
+-e automationhub_api_token=<api_token>
+ansible-playbook collection_seed.yml -e @<name of file where variables are defined>
+----
+
+For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook]
+
+When complete, the collections are visible in the validated collection section of {PrivateHubName}.

--- a/downstream/modules/automation-hub/con-rh-certified-synclist.adoc
+++ b/downstream/modules/automation-hub/con-rh-certified-synclist.adoc
@@ -7,9 +7,3 @@ You can use synclists to manage only the content that you want and exclude unnec
 You can design and manage your synclist from the content available as part of Red Hat content on {Console}
 
 Each synclist has its own unique repository URL that you can use to designate as a remote source for content in {HubName} and is securely accessed using an API token.
-
-[NOTE]
-====
-Initially, {Valid} is only available through the {PrivateHubName} installer. 
-Organization Administrators can preload all {Valid} collections at install time and put them into a staging state where they can be reviewed to avoid uploading unnecessary collections.
-====

--- a/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
@@ -7,10 +7,6 @@ You can edit the *rh-certified* remote repository to synchronize collections fro
 By default, your {PrivateHubName} `rh-certified` repository includes the URL for the entire group of {CertifiedName}.
 To use only those collections specified by your organization, you must include a unique URL.
 
-A {PrivateHubName} administrator can upload manually-created requirements from the `rh-certified` remote.
-
-If you have collections `A`, `B`, and `C` in your requirements file, and you add a new collection `X`, you must add `X` to your requirements file for {PrivateHubName} to synchronize it.
-
 .Prerequisites
 
 * You have valid *Modify Ansible repo content* permissions.

--- a/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-rhcertified-remote.adoc
@@ -7,6 +7,10 @@ You can edit the *rh-certified* remote repository to synchronize collections fro
 By default, your {PrivateHubName} `rh-certified` repository includes the URL for the entire group of {CertifiedName}.
 To use only those collections specified by your organization, you must include a unique URL.
 
+A {PrivateHubName} administrator can upload manually-created requirements from the `rh-certified` remote.
+
+If you have collections `A`, `B`, and `C` in your requirements file, and you add a new collection `X`, you must add `X` to your requirements file for {PrivateHubName} to synchronize it.
+
 .Prerequisites
 
 * You have valid *Modify Ansible repo content* permissions.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Managing Red Hat Certified and Ansible Galaxy collections in automation hub</title>
+<title>Managing Red Hat Certified, validated and Ansible Galaxy content in automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
-<subtitle>Configure automation hub to deliver curated Red Hat Certified and Ansible Galaxy collections to your users.</subtitle>
+<subtitle>Configure automation hub to deliver curated Red Hat Certified, vaidated and Ansible Galaxy content collections to your users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
     <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Managing Red Hat Certified, validated and Ansible Galaxy content in automation hub</title>
+<title>Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
-<subtitle>Configure automation hub to deliver curated Red Hat Certified, vaidated and Ansible Galaxy content collections to your users.</subtitle>
+<subtitle>Configure automation hub to deliver curated Red Hat Certified, validated, and Ansible Galaxy content collections to your users.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>
     <para> If you have a suggestion to improve this documentation, or find an error, please contact technical support at <link xlink:href="https://access.redhat.com"></link> to create an issue on the <emphasis role="strong">Ansible Automation Platform</emphasis> Jira project using the <emphasis role="strong">Docs</emphasis> component.</para>

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,6 +1,6 @@
 
 :imagesdir: images
-= Managing Red Hat Certified, validated and Ansible Galaxy content in automation hub
+= Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub
 :numbered:
 :experimental:
 

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,6 +1,6 @@
 
 :imagesdir: images
-= Managing Red Hat Certified and Ansible Galaxy collections in automation hub
+= Managing Red Hat Certified, validated and Ansible Galaxy content in automation hub
 :numbered:
 :experimental:
 
@@ -13,6 +13,9 @@ You can also synchronize {HubNameMain} to create a custom list of collections fr
 
 At present, Ansible validated collections are only available in your {PrivateHubName} {Valid} as part of the Platform Installer.
 When you download {PlatformName} with the bundled installer, validated content is pre-populated into the {PrivateHubName} by default, but only if you enable the {PrivateHubName} as part of the inventory.
+
+If you are not using the bundle installer, a Red Hat supplied Ansible playbook can be used to install validated content. 
+For further information, see xref:assembly-validated-content[{Valid}]
 
 You can update these collections manually by downloading their packages.
 

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -6,12 +6,10 @@
 
 include::attributes/attributes.adoc[]
 
-{CertifiedColl} is included in your subscription to {PlatformName}. {CertifiedColl} inclues two types of content: {CertifiedName} and {Valid}. 
+{CertifiedColl} is included in your subscription to {PlatformName}. Red Hat Ansible content inclues two types of content: {CertifiedName} and {Valid}. 
 Using {HubNameMain}, you can access and curate a unique set of collections from all forms of Ansible content. 
 
-You can also synchronize {HubNameMain} to create a custom list of collections from {CertifiedCon}, {Valid}, or {Galaxy} community content. 
-
-At present, Ansible validated collections are only available in your {PrivateHubName} {Valid} as part of the Platform Installer.
+Ansible validated collections are available in your {PrivateHubName} through the Platform Installer.
 When you download {PlatformName} with the bundled installer, validated content is pre-populated into the {PrivateHubName} by default, but only if you enable the {PrivateHubName} as part of the inventory.
 
 If you are not using the bundle installer, a Red Hat supplied Ansible playbook can be used to install validated content. 


### PR DESCRIPTION
Instructions for content without bundle installer.

Create documentation for "Seed Validated Content into any deployments of Private Automation Hub when not using bundler installer"
Affects `hub/configuring-private-hub-rh-certified`

https://issues.redhat.com/browse/AAP-10670