### PR TITLE
2.2 Update doc metadata for Hub Install guide

### DIFF
--- a/downstream/titles/hub/install/docinfo.xml
+++ b/downstream/titles/hub/install/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing and upgrading Private Automation Hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
-<productnumber>1.2</productnumber>
+<productnumber>2.2</productnumber>
 <subtitle>Installing an instance of Private Automation Hub or upgrading to a new version on online or offline Red Hat Enterprise Linux 7 and 8 physical or virtual machines.</subtitle>
 <abstract>
     <para><emphasis role="strong">Providing Feedback:</emphasis></para>


### PR DESCRIPTION
Fix the release number in `docinfo.xml`

Affects `/titles/hub/install`