### PR TITLE
Update Python attribute to 3.9 for 2.4 release

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -80,7 +80,7 @@
 :ExecEnvShort: execution environment
 :RHEL8: RHEL 8 UBI
 :RHEL9: RHEL 9 UBI
-:Python: Python 3.8
+:Python: Python 3.9
 :Runner: Ansible Runner
 :Role: Role ARG Spec
 


### PR DESCRIPTION
Update Python attribute to 3.9 for the AAP 2.4 release