### PR TITLE
AAP-11409 updated link for Red Hat Ansible Automation Platform Produc…

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
@@ -12,7 +12,7 @@ You can use these instructions to install {PlatformName} (both {ControllerName} 
 
 == Prerequisites
 
-* You chose and obtained a platform installer from the {PlatformDownloadUrl}[Red Hat Ansible Automation Platform Product Software].
+* You chose and obtained a platform installer from the link:https://access.redhat.com/downloads/content/480/ver=2.2/rhel---9/2.2/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 * A container registry service is required to install {PlatformNameShort}.


### PR DESCRIPTION
[AAP-11409](https://issues.redhat.com/browse/AAP-11409)
Updated link for [Red Hat Ansible Automation Platform Product Software](https://access.redhat.com/downloads/content/480/ver=2.2/rhel---9/2.2/x86_64/product-software) within [Red Hat Ansible Automation Platform Installation Guide chapter 2.1.1](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario).