### PR TITLE
Backport-2.3-980 New content on LDAP configuration for private automation hub

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -27,6 +27,8 @@ There are a number of supported installation scenarios for {PlatformName}. To in
 * xref:ref-standlone-hub-inventory_platform-install-scenario[Standalone {HubName} with internal database]
 * xref:ref-standlone-hub-ext-database-inventory_platform-install-scenario[Single {ControllerName} with external (installer managed) database]
 * xref:ref-standalone-hub-ext-database-customer-provided_platform-install-scenario[Single {ControllerName} with external (customer provided) database]
+* xref:ref-ldap-config-on-pah_platform-install-scenario[LDAP configuration on {PrivateHubName}]
+
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
 include::platform/con-install-scenario-examples.adoc[leveloffset=+2]
@@ -38,6 +40,7 @@ include::platform/ref-example-platform-ext-database-customer-provided.adoc[level
 include::platform/ref-standalone-hub-inventory.adoc[leveloffset=+3]
 include::platform/ref-standalone-hub-ext-database-inventory.adoc[leveloffset=+3]
 include::platform/ref-standalone-hub-ext-database-customer-provided.adoc[leveloffset=+3]
+include::platform/ref-ldap-config-on-pah.adoc[leveloffset=+3]
 include::platform/proc-running-setup-script.adoc[leveloffset=+1]
 include::platform/proc-verify-controller-installation.adoc[leveloffset=+1]
 include::platform/ref-controller-configs.adoc[leveloffset=+2]

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -12,7 +12,7 @@ You must set the following six variables in your {PlatformName} installer invent
 * `automationhub_ldap_user_search_base_dn`
 * `automationhub_ldap_group_search_base_dn`
 
-If any of these variables are missing, the Ansible Automation installer will  not complete the installation. 
+If any of these variables are missing, the Ansible Automation installer will not complete the installation. 
 
 
 == Setting up your inventory file variables
@@ -26,7 +26,7 @@ When you configure your {PrivateHubName} with LDAP authentication, you must set 
 
 .Procedure
 
-. Access your inventory file according to the procedure in link:hhttps://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-editing-installer-inventory-file_platform-install-scenario[Editing the {PlatformName} installer inventory file].
+. Access your inventory file according to the procedure in link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-editing-installer-inventory-file_platform-install-scenario[Editing the {PlatformName} installer inventory file].
 
 . Use the following example as a guide to set up your {PlatformNameShort} inventory file:
 +
@@ -54,16 +54,16 @@ auth_ldap_group_type_class= 'django_auth_ldap.config:GroupOfNamesType'
 
 ====
 
-. If you plan to set up extra parameters in  your {PrivateHubName} (such as user groups, super user access, mirroring, or others), proceed to the next section.
+. If you plan to set up extra parameters in  your {PrivateHubName} (such as user groups, superuser access, mirroring, or others), proceed to the next section.
 
 
 == Configuring extra LDAP parameters
 
-If you plan to set up super user access, user groups, mirroring or other extra parameters, you can create a yaml file that comprises them in your `ldap_extra_settings` dictionary.
+If you plan to set up superuser access, user groups, mirroring or other extra parameters, you can create a YAML file that comprises them in your `ldap_extra_settings` dictionary.
 
 .Procedure
 
-. Create a yaml file that will contain `ldap_extra_settings`, such as the following:
+. Create a YAML file that will contain `ldap_extra_settings`, such as the following:
 +
 ----
 #ldapextras.yml   

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -1,0 +1,177 @@
+:_content-type: REFERENCE
+
+[id="ref-ldap-config-on-pah_{context}"]
+= LDAP configuration on {PrivateHubName}
+
+You must set the following six variables in your {PlatformName} installer inventory file to configure your {PrivateHubName} for LDAP authentication:
+
+* `automationhub_authentication_backend`
+* `automationhub_ldap_server_uri`
+* `automationhub_ldap_bind_dn`
+* `automationhub_ldap_bind_password`
+* `automationhub_ldap_user_search_base_dn`
+* `automationhub_ldap_group_search_base_dn`
+
+If any of these variables are missing, the Ansible Automation installer will  not complete the installation. 
+
+
+== Setting up your inventory file variables
+
+When you configure your {PrivateHubName} with LDAP authentication, you must set the proper variables in your inventory files during the installation process.
+
+//.Prerequisites (Add Prereqs to 2.2 only)
+
+//* Ensure that your system is running {PlatformName} 2.2.1 or later.
+//* Ensure that you are using {PrivateHubName} 4.5.2 or later.
+
+.Procedure
+
+. Access your inventory file according to the procedure in link:hhttps://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/red_hat_ansible_automation_platform_installation_guide/index#proc-editing-installer-inventory-file_platform-install-scenario[Editing the {PlatformName} installer inventory file].
+
+. Use the following example as a guide to set up your {PlatformNameShort} inventory file:
++
+-----
+automationhub_authentication_backend = "ldap"
+
+automationhub_ldap_server_uri = "ldap://ldap:389"   (for LDAPs use  automationhub_ldap_server_uri = "ldaps://ldap-server-fqdn")
+automationhub_ldap_bind_dn = "cn=admin,dc=ansible,dc=com"
+automationhub_ldap_bind_password = "GoodNewsEveryone"
+automationhub_ldap_user_search_base_dn = "ou=people,dc=ansible,dc=com"
+automationhub_ldap_group_search_base_dn = "ou=people,dc=ansible,dc=com"
+-----
++
+[Note] 
+====
+The following variables will be set with default values, unless you set them with other options.
+
+-----
+auth_ldap_user_search_scope= `SUBTREE'
+auth_ldap_user_search_filter= `(uid=%(user)s)`
+auth_ldap_group_search_scope= 'SUBTREE'
+auth_ldap_group_search_filter= '(objectClass=Group)`
+auth_ldap_group_type_class= 'django_auth_ldap.config:GroupOfNamesType'
+-----
+
+====
+
+. If you plan to set up extra parameters in  your {PrivateHubName} (such as user groups, super user access, mirroring, or others), proceed to the next section.
+
+
+== Configuring extra LDAP parameters
+
+If you plan to set up super user access, user groups, mirroring or other extra parameters, you can create a yaml file that comprises them in your `ldap_extra_settings` dictionary.
+
+.Procedure
+
+. Create a yaml file that will contain `ldap_extra_settings`, such as the following:
++
+----
+#ldapextras.yml   
+---
+ldap_extra_settings:
+  AUTH_LDAP_USER_ATTR_MAP: '{"first_name": "givenName", "last_name": "sn", "email": "mail"}'
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use this example to set up a superuser flag based on membership in an LDAP group.
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_USER_FLAGS_BY_GROUP: {"is_superuser": "cn=pah-admins,ou=groups,dc=example,dc=com",}
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use this example to set up superuser access.
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_USER_FLAGS_BY_GROUP: {"is_superuser": "cn=pah-admins,ou=groups,dc=example,dc=com",}
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use this example to mirror all LDAP groups you belong to.
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_MIRROR_GROUPS: True
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use this example to map LDAP user attributes (such as first name, last name, and email address of the user).
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_USER_ATTR_MAP: {"first_name": "givenName", "last_name": "sn", "email": "mail",}
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use the following examples to grant or deny access based on LDAP group membership.
+.. To grant {PrivateHubName} access (for example, members of the `cn=pah-nosoupforyou,ou=groups,dc=example,dc=com` group): 
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_DENY_GROUP: 'cn=pah-nosoupforyou,ou=groups,dc=example,dc=com'
+...
+----
+.. To deny {PrivateHubName} access (for example, members of the `cn=pah-nosoupforyou,ou=groups,dc=example,dc=com` group):
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_DENY_GROUP: 'cn=pah-nosoupforyou,ou=groups,dc=example,dc=com'
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+. Use this example to enable LDAP debug logging.
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  GALAXY_LDAP_LOGGING: True
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
++
+[NOTE]
+====
+If it is not practical to re-run `setup.sh` or if debug logging is enabled for a short time, you can add a line containing `GALAXY_LDAP_LOGGING: True` manually to the `/etc/pulp/settings.py` file on {PrivateHubName}. Restart both `pulpcore-api.service` and `nginx.service` for the changes to take effect. To avoid failures due to human error, use this method only when necessary.
+====
++
+. Use this example to configure LDAP caching by setting the variable `AUTH_LDAP_CACHE_TIMEOUT`.
++
+----
+#ldapextras.yml
+---
+ldap_extra_settings:
+  AUTH_LDAP_CACHE_TIMEOUT: 3600
+...
+----
++
+Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
+
+You can view all of your settings in the `/etc/pulp/settings.py` file on your {PrivateHubName}.

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -130,7 +130,7 @@ Then run `setup.sh -e @ldapextras.yml` during {PrivateHubName} installation.
 #ldapextras.yml
 ---
 ldap_extra_settings:
-  AUTH_LDAP_DENY_GROUP: 'cn=pah-nosoupforyou,ou=groups,dc=example,dc=com'
+  AUTH_LDAP_REQUIRE_GROUP: 'cn=pah-users,ou=groups,dc=example,dc=com'
 ...
 ----
 .. To deny {PrivateHubName} access (for example, members of the `cn=pah-nosoupforyou,ou=groups,dc=example,dc=com` group):


### PR DESCRIPTION
Added new reference module w/ two sets of instructions (discrete headings) to the [Red Hat Ansible Automation Platform Installation Guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/index):

- LDAP configuration on private automation hub (`ref-ldap-config-on-pah.adoc`)

     - Setting up your inventory file variables

     - Configuring extra LDAP parameters

- Updated` assembly-platform-install-scenario.adoc` to include the xref for this new topic `ref-ldap-config-on-pah.adoc`.