### PR TITLE
Fixed missing doc title in master file and lower case title in docinfo

### DIFF
--- a/downstream/titles/hub/install/docinfo.xml
+++ b/downstream/titles/hub/install/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Installing and upgrading Private Automation Hub</title>
+<title>Installing and upgrading private automation hub</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Installing an instance of Private Automation Hub or upgrading to a new version on online or offline Red Hat Enterprise Linux 8.4 and 9 physical or virtual machines.</subtitle>

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -4,6 +4,8 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
+= Installing and upgrading {PrivateHubName}
+
 You can install Private Automation Hub or upgrade to a new version on a Red Hat Enterprise Linux (RHEL) 8.4 or later, or RHEL 9 or later virtual or physical machine with a valid Red Hat Ansible Automation Platform subscription.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR corrects the doc title mistakenly removed in PR813. 