### PR TITLE
Add internal database host installation note (#1000)

### DIFF
--- a/downstream/modules/platform/con-install-scenario-examples.adoc
+++ b/downstream/modules/platform/con-install-scenario-examples.adoc
@@ -8,7 +8,9 @@ Red Hat supports a number of installation scenarios for {PlatformNameShort}. Rev
 
 [IMPORTANT]
 ====
-* For Red Hat Ansible Automation Platform or automation hub: Add an automation hub host in the [automationhub] group.
+* For {PlatformName} or {HubName}: Add an {HubName} host in the [automationhub] group.
+* For internal databases: [database] cannot be used to point to another host in the {PlatformNameShort} cluster. 
+The database host set to be installed by the installer needs to be a unique host.
 * Do not install {ControllerName} and {HubName} on the same node for versions of {PlatformNameShort} in a production or customer environment.
 This can cause contention issues and heavy resource use.
 * Provide a reachable IP address or fully qualified domain name (FDQN) for the [automationhub] and [automationcontroller] hosts to ensure users can sync and install content from automation hub from a different node. 


### PR DESCRIPTION
Adding mention in the inventory examples that clearly states [database] cannot be used to point to another host in the AAP cluster.

Document internal vs external postgres supported installations

https://issues.redhat.com/browse/AAP-11781

Affects `titles/aap-installation-guide`