### PR TITLE
AAP-12313: adds an underscore to an automation controller variable 

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -6,7 +6,7 @@
 |====
 | *Variable* | *Description* 
 | *`admin_password`* | The password for an administration user to access the UI upon install completion.
-| *`automationcontroller_main_url`* | For an alternative front end URL needed for SSO configuration with {CatalogName}, provide the URL.
+| *`automation_controller_main_url`* | For an alternative front end URL needed for SSO configuration with {CatalogName}, provide the URL.
 
 {CatalogNameStart} requires either Controller to be installed with {ControllerName}, or a URL to an active and routable Controller server must be provided with this variable
 | *`automationcontroller_password`* | Password for your {ControllerName} instance.


### PR DESCRIPTION
Fixes issue in [AAP-12313](https://issues.redhat.com/browse/AAP-12313). For more context, see this [Slack thread](https://redhat-internal.slack.com/archives/C035VBWU98D/p1684429969208019). 

This change will add an underscore to an automation controller variable. 