### PR TITLE
backport AAP-12313: adds an underscore to an automation controller variable  (…

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -6,7 +6,7 @@
 |====
 | *Variable* | *Description* 
 | *`admin_password`* | The password for an administration user to access the UI upon install completion.
-| *`automationcontroller_main_url`* | For an alternative front end URL needed for SSO configuration with {CatalogName}, provide the URL.
+| *`automation_controller_main_url`* | For an alternative front end URL needed for SSO configuration with {CatalogName}, provide the URL.
 
 {CatalogNameStart} requires either Controller to be installed with {ControllerName}, or a URL to an active and routable Controller server must be provided with this variable
 | *`automationcontroller_password`* | Password for your {ControllerName} instance.


### PR DESCRIPTION
…#1027)

AAP-12313: adds an underscore to an automation controller variable in installation guide

This PR backports the changes in [PR 1027](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1027) to 2.3.