### PR TITLE
AAP-11480 updated Getting Started to include instructions for PAH

### DIFF
--- a/downstream/modules/automation-hub/con-create-api-token.adoc
+++ b/downstream/modules/automation-hub/con-create-api-token.adoc
@@ -1,0 +1,10 @@
+[id="con-create-api-token"]
+= Creating the Red Hat automation hub API token
+
+Before you can interact with automation hub by uploading or downloading collections, you must create an API token. The automation hub API token authenticates your `ansible-galaxy` client to the Red Hat automation hub server.
+
+You can create an API token using automation hub *Token management* in Automation hub or private automation hub (PAH).
+
+include::proc-create-api-token.adoc[leveloffset=+1]
+
+include::proc-create-api-token-pah.adoc[leveloffset=+1]

--- a/downstream/modules/automation-hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/automation-hub/proc-create-api-token-pah.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// obtaining-token/master.adoc
+[id="proc-create-api-token-pah"]
+= Creating the API token in private automation hub
+
+You can create an API token using automation hub *Token management* in PAH.
+
+.Prerequisites
+
+* Valid subscription credentials for {PlatformName}.
+
+.Procedure
+
+. Navigate to your PAH.
+. From the sidebar, navigate to menu:Collections[API Token Management].
+. Click btn:[Load Token].
+. Click the *copy* icon to copy the API token to the clipboard.
+. Paste the API token into a file and store in a secure location.
+
+[IMPORTANT]
+====
+The API token is a secret token used to protect your content. Store your API token in a secure location.
+====

--- a/downstream/modules/automation-hub/proc-create-api-token.adoc
+++ b/downstream/modules/automation-hub/proc-create-api-token.adoc
@@ -1,15 +1,9 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-create-api-token"]
-= Creating the Red Hat {HubName} API token
+= Creating the API token in automation hub
 
-Before you can interact with {HubName} by uploading or downloading collections, you need to create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.
-
-You can create an API token using {HubName} *Token management*.
-
-.Prerequisites
-
-* Valid subscription credentials for {PlatformName}.
+You can create an API token using automation hub *Token management*.
 
 .Procedure
 

--- a/downstream/titles/hub/getting-started/master.adoc
+++ b/downstream/titles/hub/getting-started/master.adoc
@@ -19,7 +19,9 @@ This guide walks you through the steps required to configure your `ansible.cfg` 
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
-include::automation-hub/proc-create-api-token.adoc[leveloffset=+1]
+The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
+
+include::automation-hub/con-create-api-token.adoc[leveloffset=+1]
 
 The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
 


### PR DESCRIPTION
[AAP-11480](https://issues.redhat.com/browse/AAP-11480)

Updated [Chapter 1: Creating the Red Hat automation hub API Token](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/getting_started_with_red_hat_ansible_automation_hub/proc-create-api-token) to include a subsection 1.2 for creating the API token in PAH. Procedure differs slightly in PAH from procedure in automation hub.

