### PR TITLE
AAP-5182 - add content for RHSSO on controller for RH OCP

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
+++ b/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
@@ -5,7 +5,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: aap-authentication
 
-= Setting up single sign-on
+= {RHSSO} integration with {ControllerName}
 
 [role="_abstract"]
 

--- a/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
+++ b/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
@@ -5,17 +5,17 @@ ifdef::context[:parent-context: {context}]
 
 :context: aap-authentication
 
-= Setting up authentication
+= Setting up single sign-on
 
 [role="_abstract"]
 
-Red Hat Single Sign-On (RH-SSO) is based on the Keycloak project and enables you to secure Ansible Automation Platform by providing single sign-on (SSO) capabilities based on popular standards such as SAML 2.0 and OpenID Connect.
+{RHSSO} ({RHSSOshort}) is based on the Keycloak project and enables you to secure {PlatformNameShort} by providing single sign-on (SSO) capabilities based on popular standards such as SAML 2.0 and OpenID Connect.
 
-Red Hat Ansible Automation Platform supports SAML authentication by default. Beginning with Ansible Automation Platform 2.x, you can enhance security by delegating authentication to Red Hat Single Sign-on.
+{PlatformName} supports SAML authentication by default. Beginning with {PlatformNameShort} 2.x, you can enhance security by delegating authentication to Red Hat Single Sign-on.
 
 .Prerequisites
-- A running instance of Red Hat Single Sign-On (RH-SSO)
-- A running installation of automation controller from Ansible Automation Platform 2.x
+- A running instance of {RHSSOshort}
+- A running installation of automation controller from {PlatformNameShort} 2.x
 - Administrator rights to the two systems
 - A valid host name
 
@@ -36,7 +36,7 @@ Log out of both systems before attempting authorization.
 
 .Verification
 
-* Go to the login page for Ansible Automation Platform and verify that *Sign in With S* is displayed indicating it as an alternative method of authentication.
+* Go to the login page for {PlatformNameShort} and verify that *Sign in With S* is displayed indicating it as an alternative method of authentication.
 
 
 

--- a/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
+++ b/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
@@ -29,12 +29,13 @@ include::platform/proc-configure-client-settings.adoc[leveloffset=+2]
 include::platform/proc-create-mappers.adoc[leveloffset=+2]
 include::platform/proc-create-sso-user.adoc[leveloffset=+2]
 
-.Verification
-
 [IMPORTANT]
 ====
 Log out of both systems before attempting authorization.
 ====
+
+.Verification
+
 * Go to the login page for Ansible Automation Platform and verify that *Sign in With S* is displayed indicating it as an alternative method of authentication.
 
 

--- a/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
+++ b/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
@@ -1,0 +1,43 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="aap-os-rhsso"]
+
+:context: aap-authentication
+
+= Setting up authentication
+
+[role="_abstract"]
+
+Red Hat Single Sign-On (RH-SSO) is based on the Keycloak project and enables you to secure Ansible Automation Platform by providing single sign-on (SSO) capabilities based on popular standards such as SAML 2.0 and OpenID Connect.
+
+Red Hat Ansible Automation Platform supports SAML authentication by default. Beginning with Ansible Automation Platform 2.x, you can enhance security by delegating authentication to Red Hat Single Sign-on.
+
+.Prerequisites
+- A running instance of Red Hat Single Sign-On (RH-SSO)
+- A running installation of automation controller from Ansible Automation Platform 2.x
+- Administrator rights to the two systems
+- A valid host name
+
+include::platform/con-saml-configuration.adoc[leveloffset=+1]
+include::platform/proc-creating-ssl-certificate.adoc[leveloffset=+2]
+include::platform/proc-create-realm.adoc[leveloffset=+2]
+include::platform/proc-configure-saml-controller.adoc[leveloffset=+2]
+include::platform/con-configure-rhsso-client.adoc[leveloffset=+1]
+include::platform/proc-create-client.adoc[leveloffset=+2]
+include::platform/proc-configure-client-settings.adoc[leveloffset=+2]
+include::platform/proc-create-mappers.adoc[leveloffset=+2]
+include::platform/proc-create-user.adoc[leveloffset=+2]
+
+.Verification
+
+[IMPORTANT]
+====
+Log out of both systems before attempting authorization.
+====
+* Go to the login page for Ansible Automation Platform and verify that *Sign in With S* is displayed indicating it as an alternative method of authentication.
+
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
+++ b/downstream/assemblies/platform/assembly-aap-os-rhsso.adoc
@@ -27,7 +27,7 @@ include::platform/con-configure-rhsso-client.adoc[leveloffset=+1]
 include::platform/proc-create-client.adoc[leveloffset=+2]
 include::platform/proc-configure-client-settings.adoc[leveloffset=+2]
 include::platform/proc-create-mappers.adoc[leveloffset=+2]
-include::platform/proc-create-user.adoc[leveloffset=+2]
+include::platform/proc-create-sso-user.adoc[leveloffset=+2]
 
 .Verification
 

--- a/downstream/modules/platform/con-configure-rhsso-client.adoc
+++ b/downstream/modules/platform/con-configure-rhsso-client.adoc
@@ -1,0 +1,6 @@
+[id="configure-rhsso-client"]
+
+= Red Hat Single Sign-On client configuration
+
+[role="_abstract"]
+After you configure SAML authentication, you can enable simplified login authentication for users by configuring the Red Hat Single Sign-On client. 

--- a/downstream/modules/platform/con-configure-rhsso-client.adoc
+++ b/downstream/modules/platform/con-configure-rhsso-client.adoc
@@ -1,6 +1,6 @@
 [id="configure-rhsso-client"]
 
-= Red Hat Single Sign-On client configuration
+= {RHSSO} client configuration
 
 [role="_abstract"]
-After you configure SAML authentication, you can enable simplified login authentication for users by configuring the {RHSSO} client. 
+After you configure SAML authentication, you can enable simplified login authentication for users by configuring the {RHSSO} client.

--- a/downstream/modules/platform/con-configure-rhsso-client.adoc
+++ b/downstream/modules/platform/con-configure-rhsso-client.adoc
@@ -3,4 +3,4 @@
 = Red Hat Single Sign-On client configuration
 
 [role="_abstract"]
-After you configure SAML authentication, you can enable simplified login authentication for users by configuring the Red Hat Single Sign-On client. 
+After you configure SAML authentication, you can enable simplified login authentication for users by configuring the {RHSSO} client. 

--- a/downstream/modules/platform/con-saml-configuration.adoc
+++ b/downstream/modules/platform/con-saml-configuration.adoc
@@ -3,4 +3,4 @@
 = SAML configuration
 
 [role="_abstract"]
-The first step to integrating Red Hat Single Sign-On on Ansible Automation Platform is to create a certificate, a realm and configure SAML settings.
+The first step to integrating {RHSSO} on {PlatformNameShort} is to create a certificate, a realm and configure SAML settings.

--- a/downstream/modules/platform/con-saml-configuration.adoc
+++ b/downstream/modules/platform/con-saml-configuration.adoc
@@ -1,0 +1,6 @@
+[id="saml-configuration"]
+
+= SAML configuration
+
+[role="_abstract"]
+The first step to integrating Red Hat Single Sign-On on Ansible Automation Platform is to create a certificate, a realm and configure SAML settings.

--- a/downstream/modules/platform/proc-configure-client-settings.adoc
+++ b/downstream/modules/platform/proc-configure-client-settings.adoc
@@ -1,0 +1,22 @@
+[id="configure-client-settings"]
+
+= Configure client settings
+
+[role=_abstract]
+.Procedure
+. Enter a Name.
+. Ensure that the following are set to On:
+** Enabled
+** Include AuthStatement
+** Sign Documents
+** Sign Assertions
+** Encrypt Assertions
+** Force POST Binding
+** Force Channel Logout
+. Enter SAML for Client Protocol.
+. Enter a Signature Algorithm.
+. Enter a SAML Signature Key Name.
+. Enter a Canonicalization Method.
+. Enter a Name ID Format.
+. Enter a Root URL.
+. Click Save.

--- a/downstream/modules/platform/proc-configure-client-settings.adoc
+++ b/downstream/modules/platform/proc-configure-client-settings.adoc
@@ -3,20 +3,28 @@
 = Configure client settings
 
 [role=_abstract]
+After a SAML client is created, you can define the client settings on the client *Settings* tab.
+
 .Procedure
-. Enter a Name.
-. Ensure that the following are set to On:
-** Enabled
-** Include AuthStatement
-** Sign Documents
-** Sign Assertions
-** Encrypt Assertions
-** Force POST Binding
-** Force Channel Logout
-. Enter SAML for Client Protocol.
-. Enter a Signature Algorithm.
-. Enter a SAML Signature Key Name.
-. Enter a Canonicalization Method.
-. Enter a Name ID Format.
-. Enter a Root URL.
-. Click Save.
+. Enter a *Name*. This is the display name for the client whenever it is displayed in a {RHSSO} UI screen.
+. Ensure that the following toggles are set to On:
+** *Enabled* to ensure the client can request authentication.
+** *Include AuthStatement* to ensure the client can determine the maximum session length.
+** *Sign Documents* to ensure {RHSSO} signs the document using the realm’s private key.
+** *Sign Assertions* to ensure assertion is signed and embedded within the SAML XML Auth response
+** *Encrypt Assertions* to ensure assertions in SAML documents are encrypted with the realm’s private key
+** *Force POST Binding* to ensure {RHSSO} is forced to respond using the SAML POST Binding.
+** *Force Channel Logout* to ensure browser redirects are able to perform a logout.
+. Select *SAML* for the *Client Protocol*.
+. Select a *Signature Algorithm* for signing SAML documents.
+. Enter a *SAML Signature Key Name*.
++
+[NOTE]
+====
+The {RHSSO} key ID is the default key name. However, your organization might expect a different key name or no key name at all
+====
++
+. Select a *Canonicalization Method* for xml signatures.
+. Enter a *Name ID Format* for the subject. If no name ID policy is specified in the request or if the Force Name ID Format attribute is true, this value is used.
+. Enter a *Root URL*. If {RHSSO} uses any configured relative URLs, this value is prepended to them.
+. Click btn:[Save].

--- a/downstream/modules/platform/proc-configure-client-settings.adoc
+++ b/downstream/modules/platform/proc-configure-client-settings.adoc
@@ -7,7 +7,7 @@ After a SAML client is created, you can define the client settings on the client
 
 .Procedure
 . Enter a *Name*. This is the display name for the client whenever it is displayed in a {RHSSO} UI screen.
-. Ensure that the following toggles are set to On:
+. Ensure that the following toggles are set *On*:
 ** *Enabled* to ensure the client can request authentication.
 ** *Include AuthStatement* to ensure the client can determine the maximum session length.
 ** *Sign Documents* to ensure {RHSSO} signs the document using the realm’s private key.

--- a/downstream/modules/platform/proc-configure-saml-controller.adoc
+++ b/downstream/modules/platform/proc-configure-saml-controller.adoc
@@ -75,10 +75,10 @@ This must match the settings on the {RHSSO} client_id name.
    },
    "Systems Engineering": {
       "admins": [
-         "acheron@redhat.com",
-         "jparrill@redhat.com",
-         "covenant@redhat.com",
-         "olympia@redhat.com"
+         "<admin-email>",
+         "<admin-email>",
+         "<admin-email>",
+         "<admin-email>"
       ],
       "remove_admins": false,
       "remove_users": false,

--- a/downstream/modules/platform/proc-configure-saml-controller.adoc
+++ b/downstream/modules/platform/proc-configure-saml-controller.adoc
@@ -3,21 +3,21 @@
 = Configure SAML on {ControllerName}
 
 [role=_abstract]
-Use this procedure to enable simplified login authentication for users through Red Hat Single Sign-On.
+Use this procedure to enable simplified login authentication for users through {RHSSO}.
 
 .Procedure
-. Log in to Ansible Automation Platform as the admin user.
-. Select Settings to configure AAP settings.
-. Select SAML settings in the Authentication pane.
-. Click Edit.
-. Enter the SAML Service Provider Entity ID. This is usually the URL for the service with the entry point hostname for the controller instance.
+. Log in to {PlatformNameShort} as the admin user.
+. Select *Settings* to configure {PlatformNameShort} settings.
+. Select *SAML settings* from the Authentication pane.
+. Click btn:[Edit].
+. Enter the *SAML Service Provider Entity ID*. This is usually the URL for the service with the entry point hostname for the controller instance.
 +
 [NOTE]
 ====
-This must match the settings on the Red Hat Single Sign-On client_id name.
+This must match the settings on the {RHSSO} client_id name.
 ====
 +
-. Enter the keypair to use as a service provider (SP) and include the certificate content in SAML Service Provider Public Certificate.
+. Enter the keypair to use as a service provider (SP) and include the certificate content in *SAML Service Provider Public Certificate*.
 +
 -----
 -----BEGIN CERTIFICATE——
@@ -25,8 +25,8 @@ This must match the settings on the Red Hat Single Sign-On client_id name.
 -----END CERTIFICATE——
 -----
 +
-. Create a private key for the controller to use as a service provider (SP) and enter it in the SAML Service Provider Private Key field.
-. Provide the URL, display name, and the name of your app in the SAML Service Provider Organization Info field. Refer to the documentation for example syntax.
+. Create a private key for the controller to use as a service provider (SP) and enter it in the *SAML Service Provider Private Key* field.
+. Provide the URL, display name, and the name of your app in the *SAML Service Provider Organization Info* field. Refer to the documentation for example syntax.
 +
 -----
 {
@@ -38,7 +38,7 @@ This must match the settings on the Red Hat Single Sign-On client_id name.
 }
 -----
 +
-. Provide the name and email address of the support contact for your service provider in the SAML Service Provider Technical Contact field.
+. Provide the name and email address of the support contact for your service provider in the *SAML Service Provider Technical Contact* field.
 +
 -----
 {
@@ -47,8 +47,8 @@ This must match the settings on the Red Hat Single Sign-On client_id name.
 }
 -----
 +
-. Provide the name and email address of the support contact for your service provider in the SAML Service Provider Support Contact field.
-. Use the SAML Enabled Identity Providers field to configure the Entity ID, SSO URL and certificate for each identity provider (IdP) in use. Multiple SAML IdPs are supported. Some IdPs may provide user data using attribute names that differ from the default OIDs. Attribute names can be overridden for each IdP.
+. Provide the name and email address of the support contact for your service provider in the *SAML Service Provider Support Contact* field.
+. Use the *SAML Enabled Identity Providers* field to configure the Entity ID, SSO URL and certificate for each identity provider (IdP) in use. Multiple SAML IdPs are supported. Some IdPs may provide user data using attribute names that differ from the default OIDs. Attribute names can be overridden for each IdP.
 +
 -----
 {
@@ -66,7 +66,7 @@ This must match the settings on the Red Hat Single Sign-On client_id name.
 }
 -----
 +
-. Use the SAML Organization Map field to configure the users placed into an organization based on their username and email address, for example:
+. Use the *SAML Organization Map* field to configure the users placed into an organization based on their username and email address, for example:
 +
 -----
 {
@@ -87,11 +87,11 @@ This must match the settings on the Red Hat Single Sign-On client_id name.
 }
 -----
 +
-. Use the SAML Team Map field to map team members (users) from social authorization accounts.
-. Use the SAML Team Attribute Mapping field to translate user team membership.
-. SAML Security Config A dict of key value pairs that are passed to the underlying python-saml security setting https://github.com/onelogin/python-saml#settings
-. SAML Service Provider Extra Configuration Data A dict of key value pairs to be passed to the underlying python-saml Service Provider configuration setting.
-. SAML IDP to EXTRA_DATA Attribute Mapping A list of tuples that maps IDP attributes to extra_attributes. Each attribute will be a list of values, even if only 1 value.
-. Use the SAML User Flags Attribute Mapping field to map super users and system auditors from SAML.
-. Click Save.
-. Go to menu:Settings[Miscellaneous] and make sure the Base URL of the system is properly set to your entrypoint.
+. Use the *SAML Team Map* field to map team members (users) from social authorization accounts.
+. Use the *SAML Team Attribute Mapping* field to translate user team membership.
+. Use the *SAML Security Config* field to define key value pairs that are passed to the underlying python-saml security setting.
+. Use the *SAML Service Provider Extra Configuration Data* field to define key value pairs to be passed to the underlying python-saml Service Provider configuration setting.
+. Use the *SAML IDP to EXTRA_DATA Attribute Mapping* to define a list of tuples that maps IDP attributes to extra_attributes. Each attribute will be a list of values, even if only 1 value.
+. Use the *SAML User Flags Attribute Mapping* field to map super users and system auditors from SAML.
+. Click btn:[Save].
+. Go to menu:Settings[Miscellaneous] and make sure the *Base URL* of the system is properly set to your entrypoint.

--- a/downstream/modules/platform/proc-configure-saml-controller.adoc
+++ b/downstream/modules/platform/proc-configure-saml-controller.adoc
@@ -1,0 +1,97 @@
+[id="configure-saml-controller"]
+
+= Configure SAML on {ControllerName}
+
+[role=_abstract]
+Use this procedure to enable simplified login authentication for users through Red Hat Single Sign-On.
+
+.Procedure
+. Log in to Ansible Automation Platform as the admin user.
+. Select Settings to configure AAP settings.
+. Select SAML settings in the Authentication pane.
+. Click Edit.
+. Enter the SAML Service Provider Entity ID. This is usually the URL for the service with the entry point hostname for the controller instance.
++
+[NOTE]
+====
+This must match the settings on the Red Hat Single Sign-On client_id name.
+====
++
+. Enter the keypair to use as a service provider (SP) and include the certificate content in SAML Service Provider Public Certificate.
++
+-----
+-----BEGIN CERTIFICATE——
+... cert text ...
+-----END CERTIFICATE——
+-----
++
+. Create a private key for the controller to use as a service provider (SP) and enter it in the SAML Service Provider Private Key field.
+. Provide the URL, display name, and the name of your app in the SAML Service Provider Organization Info field. Refer to the documentation for example syntax.
++
+-----
+{
+  "en-US": {
+     "url": "https://rhsso.usersys.redhat.com:8443",
+     "displayname": "RH-SSO Solutions Engineering",
+     "name": "RH-SSO"
+    }
+}
+-----
++
+. Provide the name and email address of the support contact for your service provider in the SAML Service Provider Technical Contact field.
++
+-----
+{
+  “givenName”: “<contact-name>”,
+  “emailAddress”: “<contact-email>”
+}
+-----
++
+. Provide the name and email address of the support contact for your service provider in the SAML Service Provider Support Contact field.
+. Use the SAML Enabled Identity Providers field to configure the Entity ID, SSO URL and certificate for each identity provider (IdP) in use. Multiple SAML IdPs are supported. Some IdPs may provide user data using attribute names that differ from the default OIDs. Attribute names can be overridden for each IdP.
++
+-----
+{
+   "RHSSO": {
+      "attr_last_name": "last_name",
+      "attr_username": "username",
+      "entity_id": "https://rhsso.usersys.redhat.com:8443/auth/realms/tower",
+      "attr_user_permanent_id": "name_id",
+      "url": "https://rhsso.usersys.redhat.com:8443/auth/realms/<realm-name>/protocol/saml",
+      "attr_email": "email",
+      "x509cert": "",
+      "attr_first_name": "first_name",
+      "attr_groups": "groups"
+   }
+}
+-----
++
+. Use the SAML Organization Map field to configure the users placed into an organization based on their username and email address, for example:
++
+-----
+{
+   "Default": {
+      "users": true
+   },
+   "Systems Engineering": {
+      "admins": [
+         "acheron@redhat.com",
+         "jparrill@redhat.com",
+         "covenant@redhat.com",
+         "olympia@redhat.com"
+      ],
+      "remove_admins": false,
+      "remove_users": false,
+      "users": true
+   }
+}
+-----
++
+. Use the SAML Team Map field to map team members (users) from social authorization accounts.
+. Use the SAML Team Attribute Mapping field to translate user team membership.
+. SAML Security Config A dict of key value pairs that are passed to the underlying python-saml security setting https://github.com/onelogin/python-saml#settings
+. SAML Service Provider Extra Configuration Data A dict of key value pairs to be passed to the underlying python-saml Service Provider configuration setting.
+. SAML IDP to EXTRA_DATA Attribute Mapping A list of tuples that maps IDP attributes to extra_attributes. Each attribute will be a list of values, even if only 1 value.
+. Use the SAML User Flags Attribute Mapping field to map super users and system auditors from SAML.
+. Click Save.
+. Go to menu:Settings[Miscellaneous] and make sure the Base URL of the system is properly set to your entrypoint.

--- a/downstream/modules/platform/proc-create-client.adoc
+++ b/downstream/modules/platform/proc-create-client.adoc
@@ -3,16 +3,16 @@
 = Create a client
 
 [role=_abstract]
-Use the following procedure to create a RH-SSO client.
+Use the following procedure to create a SAML client.
 .Procedure
-. Log into Red Hat Single Sign-on as the admin user.
-. Go to your Ansible Automation Platform realm.
-. Navigate menu:Clients[Create].
-. Click *select file* to import the data that exists on Ansible Automation Platform. To get the configuration, run the following:
+. Log into {RHSSO} as the admin user.
+. Go to your {PlatformName} realm.
+. Navigate to menu:Clients[Create].
+. Click *select file* to import the data that exists on {PlatformName}. To get the configuration, run the following command:
 +
 -----
 curl -L -k https://tower.usersys.redhat.com/sso/metadata/saml/ > rhsso-metadata.xml
 -----
-. Import the rhsso-metadata.xml file, which will populate the Client ID and Client Protocol fields
-. Set the Client Protocol to SAML.
-. Click btn:[Save].
+. Import the `_rhsso-metadata.xml_` file, which will populate the *Client ID* and *Client Protocol* fields for you.
+. Set the *Client Protocol* to *SAML*.
+. Click btn:[Save]. This will create the client and bring you to the client *Settings* tab.

--- a/downstream/modules/platform/proc-create-client.adoc
+++ b/downstream/modules/platform/proc-create-client.adoc
@@ -1,0 +1,18 @@
+[id="create-realm"]
+
+= Create a client
+
+[role=_abstract]
+Use the following procedure to create a RH-SSO client.
+.Procedure
+. Log into Red Hat Single Sign-on as the admin user.
+. Go to your Ansible Automation Platform realm.
+. Navigate menu:Clients[Create].
+. Click *select file* to import the data that exists on Ansible Automation Platform. To get the configuration, run the following:
++
+-----
+curl -L -k https://tower.usersys.redhat.com/sso/metadata/saml/ > rhsso-metadata.xml
+-----
+. Import the rhsso-metadata.xml file, which will populate the Client ID and Client Protocol fields
+. Set the Client Protocol to SAML.
+. Click btn:[Save].

--- a/downstream/modules/platform/proc-create-client.adoc
+++ b/downstream/modules/platform/proc-create-client.adoc
@@ -1,4 +1,4 @@
-[id="create-realm"]
+[id="create-client"]
 
 = Create a client
 
@@ -9,7 +9,6 @@ Use the following procedure to create a SAML client.
 . Go to your {PlatformName} realm.
 . Navigate to menu:Clients[Create].
 . Click *select file* to import the data that exists on {PlatformName}. To get the configuration, run the following command:
-+
 -----
 curl -L -k https://tower.usersys.redhat.com/sso/metadata/saml/ > rhsso-metadata.xml
 -----

--- a/downstream/modules/platform/proc-create-mappers.adoc
+++ b/downstream/modules/platform/proc-create-mappers.adoc
@@ -1,18 +1,19 @@
-[id="configure-client-settings"]
+[id="configure-mappers"]
 
-= Create mappers on the AAP client
+= Create mappers on the {PlatformNameShort} client
 
 [role=_abstract]
 The final step to take is to create the mappers on the {PlatformNameShort} {RHSSO} client. This defines the information coming from {RHSSO} and maps it to your {PlatformNameShort} users.
 
 New clients do not have built-in mappers and they must be created. Protocol mappers map items, such as an email address, to a specific claim in the identity and access token. The function of a mapper should be self explanatory from its name.
 
-The mappers required for Ansible Automation Platform include the following:
-* User Name
-* User ID
-* First Name
-* Last Name
-* Email
+The mappers required for {PlatformNameShort} include the following:
+
+//* User Name
+//* User ID
+* firstName
+* lastName
+* email
 
 Use the following procedure to create a mapper for each requirement.
 
@@ -26,13 +27,4 @@ Use the following procedure to create a mapper for each requirement.
 . Enter a *Property* and *Friendly Name*.
 . Enter a *SAML Attribute Name* and select *Basic* for the *SAML Attribute Name Format*.
 . Click btn:[Save].
-. Repeat these steps for each mapper required by the Ansible Automation Platform client.
-
-Mapping in RH-SSO should be these:
-email
-firstName
-lastName
-
-Friendly Name == what it’s called in Controller
-SAML Attribute Name == what it’s called in Controller
-Property == what IdP (rhsso) expects
+. Repeat these steps for each mapper required by the {PlatformNameShort} client.

--- a/downstream/modules/platform/proc-create-mappers.adoc
+++ b/downstream/modules/platform/proc-create-mappers.adoc
@@ -3,25 +3,26 @@
 = Create mappers on the AAP client
 
 [role=_abstract]
-The final step to take is to create the mappers on the Ansible Automation Platform Red Hat Single Sign-On client. This defines the information coming from your Red Hat Single Sign-On and maps it to your Ansible Automation Platform users.
+The final step to take is to create the mappers on the {PlatformNameShort} {RHSSO} client. This defines the information coming from {RHSSO} and maps it to your {PlatformNameShort} users.
 
 New clients do not have built-in mappers and they must be created. Protocol mappers map items, such as an email address, to a specific claim in the identity and access token. The function of a mapper should be self explanatory from its name.
 
 The mappers required for Ansible Automation Platform include the following:
-User Name
-User ID
-First Name
-Last Name
-Email
+* User Name
+* User ID
+* First Name
+* Last Name
+* Email
+
+Use the following procedure to create a mapper for each requirement.
+
 .Procedure
-To create a mapper for each requirement, do the following:
-. Login to the Red Hat Single Sign-On admin console.
+. Login to the {RHSSO} admin console.
 . Navigate to menu:Configure[Clients].
 . Select the *Mappers* tab.
 . Click btn:[Create].
-. Enter an *ID*.
-. Enter *Mapper Type* as User Property
-. Enter a *Name*.
+. Enter a mapper *Name*.
+. Select *User Property* as the *Mapper Type*.
 . Enter a *Property* and *Friendly Name*.
 . Enter a *SAML Attribute Name* and select *Basic* for the *SAML Attribute Name Format*.
 . Click btn:[Save].

--- a/downstream/modules/platform/proc-create-mappers.adoc
+++ b/downstream/modules/platform/proc-create-mappers.adoc
@@ -1,0 +1,37 @@
+[id="configure-client-settings"]
+
+= Create mappers on the AAP client
+
+[role=_abstract]
+The final step to take is to create the mappers on the Ansible Automation Platform Red Hat Single Sign-On client. This defines the information coming from your Red Hat Single Sign-On and maps it to your Ansible Automation Platform users.
+
+New clients do not have built-in mappers and they must be created. Protocol mappers map items, such as an email address, to a specific claim in the identity and access token. The function of a mapper should be self explanatory from its name.
+
+The mappers required for Ansible Automation Platform include the following:
+User Name
+User ID
+First Name
+Last Name
+Email
+.Procedure
+To create a mapper for each requirement, do the following:
+. Login to the Red Hat Single Sign-On admin console.
+. Navigate to menu:Configure[Clients].
+. Select the *Mappers* tab.
+. Click btn:[Create].
+. Enter an *ID*.
+. Enter *Mapper Type* as User Property
+. Enter a *Name*.
+. Enter a *Property* and *Friendly Name*.
+. Enter a *SAML Attribute Name* and select *Basic* for the *SAML Attribute Name Format*.
+. Click btn:[Save].
+. Repeat these steps for each mapper required by the Ansible Automation Platform client.
+
+Mapping in RH-SSO should be these:
+email
+firstName
+lastName
+
+Friendly Name == what it’s called in Controller
+SAML Attribute Name == what it’s called in Controller
+Property == what IdP (rhsso) expects

--- a/downstream/modules/platform/proc-create-realm.adoc
+++ b/downstream/modules/platform/proc-create-realm.adoc
@@ -1,0 +1,25 @@
+[id="create-realm"]
+
+= Create a realm
+
+[role=_abstract]
+When you log in to the Red Hat Single Sign-On admin console, you work in a realm, which is a space where you manage objects. This is the first step in delegating authentication to Red Hat Single Sign-On.
+
+.Prerequisites
+* Red Hat Single Sign-On is installed.
+* You have the initial admin account for the admin console.
+
+.Procedure
+. Go to the RH-SSO console and log in to the Red Hat Single Sign-On admin console using the admin account.
+. From the realm menu, click menu:Add Realm[]. When you are logged in to the main realm, this menu lists all other realms.
+. Enter a name for the realm in the *Name* field. 
+
+[NOTE]
+====
+The realm name is case-sensitive, so make note of the case that you use.
+====
+. Click btn:[Create]. The main admin console page opens with the realm set to the specified name.
+. Select the *Keys* tab and delete all certificates, keys, and other information that have been created by default.
+. Select the *Providers* tab.
+. Click btn:[Add Keystore] and select *rsa*.
+. Click btn:[Save] to create your Ansible Automation Platform client information.

--- a/downstream/modules/platform/proc-create-realm.adoc
+++ b/downstream/modules/platform/proc-create-realm.adoc
@@ -3,16 +3,16 @@
 = Create a realm
 
 [role=_abstract]
-When you log in to the Red Hat Single Sign-On admin console, you work in a realm, which is a space where you manage objects. This is the first step in delegating authentication to Red Hat Single Sign-On.
+When you log in to the {RHSSO} admin console, you work in a realm, which is a space where you manage objects. This is the first step in delegating authentication to {RHSSO}.
 
 .Prerequisites
-* Red Hat Single Sign-On is installed.
+* {RHSSO} is installed.
 * You have the initial admin account for the admin console.
 
 .Procedure
-. Go to the RH-SSO console and log in to the Red Hat Single Sign-On admin console using the admin account.
+. Go to the {RHSSOshort} console and log in using the admin account.
 . From the realm menu, click menu:Add Realm[]. When you are logged in to the main realm, this menu lists all other realms.
-. Enter a name for the realm in the *Name* field. 
+. Enter a name for the realm in the *Name* field.
 
 [NOTE]
 ====
@@ -22,4 +22,4 @@ The realm name is case-sensitive, so make note of the case that you use.
 . Select the *Keys* tab and delete all certificates, keys, and other information that have been created by default.
 . Select the *Providers* tab.
 . Click btn:[Add Keystore] and select *rsa*.
-. Click btn:[Save] to create your Ansible Automation Platform client information.
+. Click btn:[Save] to create your {PlatformNameShort} client information.

--- a/downstream/modules/platform/proc-create-sso-user.adoc
+++ b/downstream/modules/platform/proc-create-sso-user.adoc
@@ -1,0 +1,23 @@
+[id="create-sso-user"]
+
+= Create a user
+
+[role=_abstract]
+You create users in the realm where you intend to have applications needed by those users. Avoid creating users in the master realm, which is only intended for creating other realms.
+
+.Prerequisites
+* You are in a realm other than the master realm.
+
+.Procedure
+
+Click menu:Manage[Users] from the navigation panel.
+Click btn:[Add User].
+Enter the details for the new user.
++
+[NOTE]
+====
+Username is the only required field.
+====
+Click btn:[Save].
++
+After saving the details, the Management page for the new user is displayed where you can define credentials, configure attributes, and perform other user management functions. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.6/html-single/server_administration_guide/index#assembly-managing-users_server_administration_guide[Managing users] in the _{RHSSO} Server Administration Guide_.

--- a/downstream/modules/platform/proc-create-sso-user.adoc
+++ b/downstream/modules/platform/proc-create-sso-user.adoc
@@ -10,14 +10,14 @@ You create users in the realm where you intend to have applications needed by th
 
 .Procedure
 
-Click menu:Manage[Users] from the navigation panel.
-Click btn:[Add User].
-Enter the details for the new user.
+. Click menu:Manage[Users] from the navigation panel.
+. Click btn:[Add User].
+. Enter the details for the new user.
 +
 [NOTE]
 ====
 Username is the only required field.
 ====
-Click btn:[Save].
+. Click btn:[Save].
 +
 After saving the details, the Management page for the new user is displayed where you can define credentials, configure attributes, and perform other user management functions. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.6/html-single/server_administration_guide/index#assembly-managing-users_server_administration_guide[Managing users] in the _{RHSSO} Server Administration Guide_.

--- a/downstream/modules/platform/proc-creating-ssl-certificate.adoc
+++ b/downstream/modules/platform/proc-creating-ssl-certificate.adoc
@@ -1,0 +1,9 @@
+[id="creating-ssl-certificate"]
+
+= Create an SSL certificate
+
+[role=_abstract]
+Unless you already have an SSL certificate, you must create one. To create an SSL certificate, run the following command:
+-----
+# openssl req -new -x509 -days 365 -nodes -out saml.crt -keyout saml.key
+-----

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -23,6 +23,8 @@ include::platform/assembly-install-aap-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
 
+include::platform/assembly-aap-os-rhsso.adoc[leveloffset=+1]
+
 include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 // include::platform/assembly-installing-hub-operator-local-db.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds content requested in https://issues.redhat.com/browse/AAP-5182 and includes the following:

- New Setting up authentication chapter with instructions for setting RH-SSO on controller

Preview link (VPN required): http://file.rdu.redhat.com/~ddacosta/AAP5182/master.html