### PR TITLE
[2.2] AAP-8366: Use fully updated nodes to install AAP

### DIFF
--- a/downstream/assemblies/platform/assembly-multi-machine-install.adoc
+++ b/downstream/assemblies/platform/assembly-multi-machine-install.adoc
@@ -14,6 +14,10 @@ You can use these instructions to install {PlatformName} as multiple {Controller
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
+++ b/downstream/assemblies/platform/assembly-platform-ext-database-install.adoc
@@ -14,6 +14,10 @@ You can use these instructions to install {PlatformName} (both {ControllerName} 
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-platform-non-inst-database.adoc
@@ -14,6 +14,10 @@ You can use these instructions to install {PlatformName} (both {ControllerName} 
 
 * You chose and obtained a platform installer from the link:https://access.redhat.com/downloads/content/480/ver=2.2/rhel---9/2.2/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 * A container registry service is required to install {PlatformNameShort}. 
 Access to a container registry enables you to load automation execution environments onto the {PlatformNameShort}, giving you a consistent and containerized environment for executing Ansible playbooks and roles. 

--- a/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-ext-database.adoc
@@ -13,6 +13,10 @@ You can use these instructions to install a standalone {ControllerName} server o
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-controller-non-inst-database-installation.adoc
@@ -17,6 +17,10 @@ This is considered the standard {ControllerName} installation scenario.
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 

--- a/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-ext-database.adoc
@@ -14,6 +14,10 @@ This installs the {HubName} server on a single machine and installs a remote Pos
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 include::platform/proc-editing-inventory-file.adoc[leveloffset=3]

--- a/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
+++ b/downstream/assemblies/platform/assembly-standalone-hub-non-inst-database.adoc
@@ -14,6 +14,10 @@ You can use these instructions to install a standalone instance of {HubName} wit
 
 * You chose and obtained a platform installer from the https://access.redhat.com/downloads/content/480/ver=2.1/rhel---8/2.1/x86_64/product-software[Red Hat Ansible Automation Platform Product Software].
 * You are installing on a machine that meets base system requirements.
+* You have updated all of the packages to the recent version of your RHEL nodes.
+
+WARNING: You may experience errors if you do not fully upgrade your RHEL nodes prior to your {PlatformNameShort} installation.
+
 * You have created a Red Hat Registry Service Account, following the instructions in the https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts guide].
 
 //include::platform/ref-platform-install-settings.adoc[leveloffset=3]


### PR DESCRIPTION
Jira link: [AAP-8366](https://issues.redhat.com/browse/AAP-8366)

Added prerequisite and note stating that users should use fully updated nodes prior to installing AAP.

See [PR#1029](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1029) where the same information was added to 2.3 and 2.4.