### PR TITLE
JIRA-AAP-4359: Added the scenario to import or generate API tokens in AAP installer

### DIFF
--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -49,6 +49,8 @@ include::ini/clustered-nodes.ini[]
 
 .Importing and generating API tokens
 
+When upgrading from {PlatformName} 2.0 or earlier to {PlatformName} 2.1 or later, you can use your existing automation hub API token or generate a new token. In the inventory file, edit one of the following fields before running the {PlatformName} installer setup script `setup.sh`:
+
 * Import an existing API token with the `automationhub_api_token` flag as follows:
 +
 [options="nowrap",subs="+quotes"]
@@ -60,7 +62,7 @@ automationhub_api_token=__<api_token>__
 +
 [options="nowrap",subs="+quotes"]
 ----
-generate_automationhub_token=
+generate_automationhub_token=True
 ----
 
 [role="_additional-resources"]


### PR DESCRIPTION
Jira link: [AAP-4359](https://issues.redhat.com/browse/AAP-4359)

Following are the minor changes:

- Added the info. 'when migrating from AAP 2.0 or earlier to AAP 2.1 or later, users now have the option to add their existing automationhub api token or generate a new one.'
- Corrected the flag for 'generate_automationhub_token='