### PR TITLE
AAP-12257: Created and restructured AAP 2.4 release notes

### DIFF
--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -7,8 +7,6 @@ include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 
-include::topics/upgrading.adoc[leveloffset=+1]
-
 [[anchor-aap_2.4-release]]
 == Red Hat Ansible Automation Platform 2.4
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
@@ -86,8 +84,6 @@ This release includes a number of enhancements, additions, and fixes that have b
 include::topics/platform-installer-121.adoc[leveloffset=+2]
 
 include::topics/platform-intro-124.adoc[leveloffset=+2]
-
-include::topics/platform-intro-125.adoc[leveloffset=+2]
 
 include::topics/aap-126.adoc[leveloffset=+2]
 

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -15,6 +15,16 @@ This release includes a number of enhancements, additions, and fixes that have b
 
 include::topics/aap-24.adoc[leveloffset=+2]
 
+include::topics/hub-464.adoc[leveloffset=+2]
+
+include::topics/controller-440.adoc[leveloffset=+2]
+
+include::topics/eda-24.adoc[leveloffset=+2]
+
+include::topics/operator-240.adoc[leveloffset=+2]
+
+include::topics/docs-24.adoc[leveloffset=+2]
+
 [[anchor-aap_2.3-release]]
 == Red Hat Ansible Automation Platform 2.3
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
@@ -73,11 +83,11 @@ include::topics/controller-414.adoc[leveloffset=+3]
 == Red Hat Ansible Automation Platform 1.2
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
-include::topics/platform-installer-121.adoc[leveloffset=+3]
+include::topics/platform-installer-121.adoc[leveloffset=+2]
 
-include::topics/platform-intro-124.adoc[leveloffset=+3]
+include::topics/platform-intro-124.adoc[leveloffset=+2]
 
-include::topics/platform-intro-125.adoc[leveloffset=+3]
+include::topics/platform-intro-125.adoc[leveloffset=+2]
 
 include::topics/aap-126.adoc[leveloffset=+2]
 

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -9,18 +9,14 @@ include::topics/platform-intro.adoc[leveloffset=+1]
 
 include::topics/upgrading.adoc[leveloffset=+1]
 
-[[anchor-december-2022-release]]
-== December 2022 release
+[[anchor-aap_2.4-release]]
+== Red Hat Ansible Automation Platform 2.4
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
-include::topics/aap-214.adoc[leveloffset=+2]
+include::topics/aap-24.adoc[leveloffset=+2]
 
-include::topics/hub-443.adoc[leveloffset=+2]
-
-include::topics/controller-414.adoc[leveloffset=+2]
-
-[[anchor-november-2022-release]]
-== November 2022 release
+[[anchor-aap_2.3-release]]
+== Red Hat Ansible Automation Platform 2.3
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
 include::topics/aap-23.adoc[leveloffset=+2]
@@ -33,21 +29,13 @@ include::topics/operator-230.adoc[leveloffset=+2]
 
 include::topics/docs-23.adoc[leveloffset=+2]
 
-[[anchor-september-2022-release]]
-== September 2022 release
-
-include::topics/aap-221.adoc[leveloffset=+2]
-
-[[anchor-august-2022-release]]
-== August 2022 release
-
-include::topics/aap-213.adoc[leveloffset=+2]
-
-[[anchor-may-2022-release]]
-== May 2022 release
+[[anchor-aap_2.2-release]]
+== Red Hat Ansible Automation Platform 2.2
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
 include::topics/aap-22.adoc[leveloffset=+2]
+
+include::topics/aap-221.adoc[leveloffset=+2]
 
 include::topics/hub-450.adoc[leveloffset=+2]
 
@@ -57,116 +45,75 @@ include::topics/controller-420.adoc[leveloffset=+2]
 
 include::topics/operator-220.adoc[leveloffset=+2]
 
-
-[[anchor-april-2022-release]]
-== April 2022 release
-
-include::topics/aap-212.adoc[leveloffset=+2]
-
-
-[[anchor-february-2022-release]]
-== February 2022 release
-
-include::topics/aap-211.adoc[leveloffset=+2]
-
-include::topics/hub-441.adoc[leveloffset=+2]
-
-include::topics/controller-411.adoc[leveloffset=+2]
-
-[[anchor-january-2022-release]]
-== January 2022 release
-
-include::topics/aap-126.adoc[leveloffset=+2]
-
-[[anchor-december-2021-release]]
-== December 2021 release
+[[anchor-aap_2.1-release]]
+== Red Hat Ansible Automation Platform 2.1
+This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
 include::topics/aap-21.adoc[leveloffset=+2]
 
+include::topics/aap-211.adoc[leveloffset=+2]
+
+include::topics/aap-212.adoc[leveloffset=+2]
+
+include::topics/aap-213.adoc[leveloffset=+2]
+
+include::topics/aap-214.adoc[leveloffset=+2]
+
+include::topics/hub-441.adoc[leveloffset=+2]
+
+include::topics/hub-443.adoc[leveloffset=+3]
+
 include::topics/controller-41.adoc[leveloffset=+2]
 
-[[anchor-october-2021-release]]
-== October 2021 release
+include::topics/controller-411.adoc[leveloffset=+3]
 
-include::topics/insights-102021.adoc[leveloffset=+2]
+include::topics/controller-414.adoc[leveloffset=+3]
 
-[[anchor-september-2021-release]]
-== September 2021 release
-
-include::topics/platform-intro-125.adoc[leveloffset=+2]
-
-include::topics/tower-intro-384.adoc[leveloffset=+2]
-
-include::topics/hub-426.adoc[leveloffset=+2]
-
-[[anchor-july-2021-release]]
-== July 2021 release
-
-include::topics/platform-intro-124.adoc[leveloffset=+2]
-
-include::topics/hub-424.adoc[leveloffset=+2]
-
-[[anchor-june-2021-release]]
-== June 2021 release
-
-=== Red Hat Insights for Red Hat Ansible Automation Platform
-
-include::topics/insights-062021.adoc[leveloffset=+2]
-
-[[anchor-may-2021-release]]
-== May 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.3
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-383.adoc[leveloffset=+3]
-
-include::topics/hub-423.adoc[leveloffset=+3]
-
-[[anchor-mar-2021-release]]
-== March 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.2
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-382.adoc[leveloffset=+3]
-
-include::topics/hub-422.adoc[leveloffset=+3]
-
-[[anchor-jan-2021-release]]
-== January 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.1
-
-The latest version of Red Hat Automation Platform includes the following:
+[[anchor-aap_1.2-release]]
+== Red Hat Ansible Automation Platform 1.2
+This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
 include::topics/platform-installer-121.adoc[leveloffset=+3]
 
+include::topics/platform-intro-124.adoc[leveloffset=+3]
+
+include::topics/platform-intro-125.adoc[leveloffset=+3]
+
+include::topics/aap-126.adoc[leveloffset=+2]
+
+include::topics/tower-intro-38.adoc[leveloffset=+2]
+
 include::topics/tower-intro-381.adoc[leveloffset=+3]
 
-include::topics/hub-421.adoc[leveloffset=+3]
+include::topics/tower-intro-382.adoc[leveloffset=+3]
 
+include::topics/tower-intro-383.adoc[leveloffset=+3]
 
-[[anchor-nov-2020-release]]
-== November 2020 release
-
-=== Red Hat Ansible Automation Platform 1.2.0
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-38.adoc[leveloffset=+3]
+include::topics/tower-intro-384.adoc[leveloffset=+2]
 
 include::topics/hub-42.adoc[leveloffset=+3]
 
+include::topics/hub-421.adoc[leveloffset=+3]
+
+include::topics/hub-422.adoc[leveloffset=+3]
+
+include::topics/hub-423.adoc[leveloffset=+3]
+
+include::topics/hub-424.adoc[leveloffset=+3]
+
+include::topics/hub-426.adoc[leveloffset=+3]
+
 include::topics/catalog-11-2020.adoc[leveloffset=+3]
 
+[[anchor-aap_insights-release]]
+== Red Hat Insights for Red Hat Ansible Automation Platform
 
+include::topics/insights-062021.adoc[leveloffset=+2]
 
+include::topics/insights-102021.adoc[leveloffset=+2]
 
-[[anchor-oct-2020-release]]
-== October 2020 release
+[[anchor-aap-automation-analytics-10-2020-release]]
+== Red Hat Automation Analytics October 2020 release
 
 include::topics/introduction.adoc[leveloffset=+2]
 
@@ -177,6 +124,8 @@ include::topics/new-features-oct-2020.adoc[leveloffset=+2]
 include::topics/enhancements-102020.adoc[leveloffset=+2]
 
 include::topics/bugfixes-102020.adoc[leveloffset=+2]
+
+
 
 ////
 [[anchor-may-2020-release]]

--- a/downstream/titles/release-notes/topics/aap-126.adoc
+++ b/downstream/titles/release-notes/topics/aap-126.adoc
@@ -1,8 +1,6 @@
 [[aap-1.2.6-intro]]
 = Ansible Automation Platform 1.2.6
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements and bug fixes
 
 * Updated openshift-clients package that ships with Ansible Tower 3.7 and 3.8

--- a/downstream/titles/release-notes/topics/aap-211.adoc
+++ b/downstream/titles/release-notes/topics/aap-211.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.1-intro]]
 = Ansible Automation Platform 2.1.1
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements and bug fixes
 
 * Added OCP 4.10 compatibility

--- a/downstream/titles/release-notes/topics/aap-212.adoc
+++ b/downstream/titles/release-notes/topics/aap-212.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.2-intro]]
 = Ansible Automation Platform 2.1.2
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements
 * Added architecture support labels for the Ansible Automation Platform operator
 * Updated to Receptor 1.2.1 on all supported versions of the Ansible Automation Platform

--- a/downstream/titles/release-notes/topics/aap-213.adoc
+++ b/downstream/titles/release-notes/topics/aap-213.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.3-intro]]
 = Ansible Automation Platform 2.1.3
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements
 * Updated the version to `Openshift-clients` 4.10.x
 * Updated the version to `pulpcore-selinux` 1.3.2

--- a/downstream/titles/release-notes/topics/aap-214.adoc
+++ b/downstream/titles/release-notes/topics/aap-214.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.4-intro]]
 = Ansible Automation Platform 2.1.4
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements
 * Rebuilt the bundle installer to pick up the latest python-pulp-container rpm and container images.
 * Updated RSA key strength for Ansible Automation Platform certificates.

--- a/downstream/titles/release-notes/topics/aap-22.adoc
+++ b/downstream/titles/release-notes/topics/aap-22.adoc
@@ -1,11 +1,13 @@
+// This is the release notes for AAP 2.2, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[aap-2.2-intro]]
 = Ansible Automation Platform 2.2
 
 Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
-.Enhancements
+.Enhancements 
 
-* Added the Automation Services Catalog as an on-prem component for the Ansible Automation Platform. Automation Services Catalog is is a Technology Preview supported feature in Ansible Automation Platform 2.2.
+* Added the Automation Services Catalog as an on-prem component for the Ansible Automation Platform. Automation Services Catalog is a Technology Preview supported feature in Ansible Automation Platform 2.2.
 * Added support for RHEL 9 for automation controller, private automation hub, and private services catalog.
 * Components of the Ansible Automation Platform now run with python 3.9 runtime.
 * Ansible Automation Platform now deploys with PostgreSQL 13, Nginx 1.20 and Redis 6.

--- a/downstream/titles/release-notes/topics/aap-221.adoc
+++ b/downstream/titles/release-notes/topics/aap-221.adoc
@@ -1,7 +1,6 @@
+
 [[aap-2.2.1-intro]]
 = Ansible Automation Platform 2.2.1
-
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
 .Enhancements
 * Modified installer to include the *ansible-builder* image

--- a/downstream/titles/release-notes/topics/aap-23.adoc
+++ b/downstream/titles/release-notes/topics/aap-23.adoc
@@ -21,6 +21,9 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 .Technology preview features
 
+Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Please note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
+
+Following are the technology preview features:
 * Added the ability to use external execution nodes when running AAP as a managed service in Azure.
 * Added the ability to use external execution nodes when running the AAP Operator in Openshift.
 //[DCD removed following per PG see AAP-7858]
@@ -37,5 +40,4 @@ Other noteworthy developer tooling updates include the following:
 [role="_additional-resources"]
 .Additional resources
 
-* xref:technology-preview[What is a Technology Preview feature]
 * For information regarding execution node enhancements on Openshift deployments, see link:https://docs.ansible.com/automation-controller/latest/html/administration/instances.html[Managing Capacity With Instances].

--- a/downstream/titles/release-notes/topics/aap-23.adoc
+++ b/downstream/titles/release-notes/topics/aap-23.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for AAP 2.3, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[aap-2.3-intro]]
-= Ansible Automation Platform 2.3
+= Ansible Automation Platform
 
 Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -19,7 +19,17 @@ The Execution Environment includes the following container images:
 ** ee-minimal
 ** ee-supported
 
-* Support for Ansible Builder V3.
+* The ansible-builder project recently released Ansible Builder version 3, a much-improved approach to creating execution environments. 
+You can use the following configuration YAML keys with Ansible Builder version 3:
+** additional_build_files
+** additional_build_steps
+** build_arg_defaults
+** dependencies
+** images
+** options
+** version
+For more information about using Ansible Builder version 3, see 
+https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Documentation] and https://docs.ansible.com/automation-controller/latest/html/userguide/ee_reference.html[Execution Environment Setup Reference].
 
 * Ansible Automation Platform 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
 

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -1,0 +1,101 @@
+// For each release of AAP, make a copy of this file and rename it to aap-rn-xx.adoc where xx is the release number; for example, 24 for the 2.4 release.
+// Save the renamed copy of this file to the release-notes/topics directory topic files for the release notes reside.
+//Only include release note types that have updates for a given release. For example, if there are no Technology previews for the release, remove that section from this file.
+
+
+= Ansible Automation Platform 2.4
+
+Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+
+== New features and enhancements
+
+This release of Ansible Automation Platform features the following enhancements:
+
+* Previously, the Execution Environment container images were based on RHEL 8 only. With Ansible Automation Platform 2.4 onwards, the Execution Environment container images are now available on RHEL 9 too. 
+The Execution Environment includes the following container images:
+** ansible-python-base
+** ansible-python-toolkit
+** ansible-builder
+** ee-minimal
+** ee-supported
+
+* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
+** Inventories
+** Projects
+** Instance Groups
+** Credentials
+** Schedules
+** Workflow Job Templates
+** Launch Workflows
+
+One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+
+* Support for Ansible Builder V3.
+
+* Ansible Automation Platform 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
+
+* Added an option to configure SSO logout URL for Automation Hub.
+
+* Updated the ansible-lint RPM package to version 6.14.3.
+
+* Updated django for potential denial-of-service vulnerability in file uploads (CVE-2023-24580).
+
+* Updated sqlparse for ReDOS vulnerability (CVE-2023-30608).
+
+* Updated django for potential denial-of-service via Accept-Language headers (CVE-2023-23969).
+
+
+
+
+
+
+
+
+
+
+
+
+
+== Technology Preview
+
+Some features in this release are currently classified as Technology Preview. These experimental features are not intended for production use. For more information about technology preview features, see xref:technology-preview[What is a Technology Preview feature].
+
+<ABC> is available as a Technology Preview::
+ABC, which Red Hat provides as an unsupported Technology Preview, is <description of feature>
+
+<XYZ> is available as a Technology Preview::
+XYZ, which Red Hat provides as an unsupported Technology Preview, is <description of feature>
+
+== Bug fixes
+
+These bugs were fixed in this release of Ansible Automation Platform:
+
+* Installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
+
+*  Fixed issue restoring backups when installed automation controller version is different from backup.
+
+
+
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in Ansible Automation Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. The following is a list of major functionality deprecated and removed within Ansible Automation Platform 2.4:
+
+* On-premise component Automation Services Catalog is now removed from Ansible Automation Platform 2.4 onwards.
+
+* With the Ansible Automation Platform 2.4 release, the Execution Environment container image for Ansible 2.9 (ee-29-rhel-8) is no longer loaded into the Automation Controller configuration by default.
+
+* Although you can still synchronize content, the use of synclists is deprecated and will be removed in a later release. Instead, private automation hub administrators can upload manually-created requirements files from the `rh-certified` remote.
+
+* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
+** Inventories
+** Projects
+** Instance Groups
+** Credentials
+** Schedules
+** Workflow Job Templates
+** Launch Workflows
+
+[.indent]
+One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -36,9 +36,9 @@ The Execution Environment includes the following container images:
 
 == Deprecated and removed features
 
-Some features available in previous releases have been deprecated or removed.
+Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in Ansible Automation Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. 
 
-Deprecated functionality is still included in Ansible Automation Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. The following is a list of major functionality deprecated and removed within Ansible Automation Platform 2.4:
+The following is a list of major functionality deprecated and removed within Ansible Automation Platform 2.4:
 
 * On-premise component Automation Services Catalog is now removed from Ansible Automation Platform 2.4 onwards.
 
@@ -84,7 +84,7 @@ The following bugs were fixed in this release of Ansible Automation Platform:
 
 == Technology Preview
 
-Some features in this release are currently classified as Technology Preview.Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. These features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 
+Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Please note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
 
 Following are the technology preview features: 
 

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -11,7 +11,7 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 This release of Ansible Automation Platform features the following enhancements:
 
-* Previously, the Execution Environment container images were based on RHEL 8 only. With Ansible Automation Platform 2.4 onwards, the Execution Environment container images are now available on RHEL 9 too. 
+* Previously, the Execution Environment container images were based on RHEL 8 only. With Ansible Automation Platform 2.4 onwards, the Execution Environment container images are now also available on RHEL 9. 
 The Execution Environment includes the following container images:
 ** ansible-python-base
 ** ansible-python-toolkit
@@ -19,7 +19,7 @@ The Execution Environment includes the following container images:
 ** ee-minimal
 ** ee-supported
 
-* The ansible-builder project recently released Ansible Builder version 3, a much-improved approach to creating execution environments. 
+* The ansible-builder project recently released Ansible Builder version 3, a much-improved and simplified approach to creating execution environments. 
 You can use the following configuration YAML keys with Ansible Builder version 3:
 ** additional_build_files
 ** additional_build_steps
@@ -28,6 +28,7 @@ You can use the following configuration YAML keys with Ansible Builder version 3
 ** images
 ** options
 ** version
+
 For more information about using Ansible Builder version 3, see 
 https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Documentation] and https://docs.ansible.com/automation-controller/latest/html/userguide/ee_reference.html[Execution Environment Setup Reference].
 
@@ -41,7 +42,7 @@ https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Docum
 
 * Updated sqlparse for ReDOS vulnerability (CVE-2023-30608).
 
-* Updated django for potential denial-of-service via Accept-Language headers (CVE-2023-23969).
+* Updated django for potential denial-of-service in Accept-Language headers (CVE-2023-23969).
 
 
 == Deprecated and removed features
@@ -66,7 +67,7 @@ The following bugs were fixed in this release of Ansible Automation Platform:
 
 * Installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
 
-*  Fixed an issue with restoring backups when the installed automation controller version is different from the backup version.
+* Fixed an issue with restoring backups when the installed automation controller version is different from the backup version.
 
 * Fixed an issue with not adding user defined galaxy-importer settings to `galaxy-importer.cfg` file.
 
@@ -84,7 +85,7 @@ The following bugs were fixed in this release of Ansible Automation Platform:
 
 * Added a FQDN check for the automation hub hostname required to run the Skopeo commands.
 
-*  Fixed an issue such that the front end URL for Red Hat Single Sign On (SSO) is now properly configured after you specify the `sso_redirect_host` variable.
+* Fixed an issue such that the front end URL for Red Hat Single Sign On (SSO) is now properly configured after you specify the `sso_redirect_host` variable.
 
 * Fixed the variable precedence for all component `nginx_tls_files_remote` variables.
 
@@ -98,14 +99,14 @@ Some features in this release are currently classified as Technology Preview. Te
 
 Following are the technology preview features: 
 
-* Ansible Automation Platform 2.4 adds the ability to install the automation controller for IBM Power (ppc64le), IBM Z (s390x), and IBM(R) LinuxONE (s390x) architectures as a Technology Preview feature.
+* Ansible Automation Platform 2.4 adds the ability to install the automation controller for IBM Power (ppc64le), IBM Z (s390x), and IBM(R) LinuxONE (s390x) architectures.
 
 [role="_additional-resources"]
 .Additional resources
 
 * For the most recent list of technology preview features, see link:https://access.redhat.com/articles/ansible-automation-platform-preview-features[Ansible Automation Platform - Preview Features].
 
-* For more information about technology preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].
+* For more information about support for technology preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].
 
 * For information regarding execution node enhancements on Openshift deployments, see link:https://docs.ansible.com/automation-controller/latest/html/administration/instances.html[Managing Capacity With Instances].
 

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -19,22 +19,11 @@ The Execution Environment includes the following container images:
 ** ee-minimal
 ** ee-supported
 
-* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
-** Inventories
-** Projects
-** Instance Groups
-** Credentials
-** Schedules
-** Workflow Job Templates
-** Launch Workflows
-
-One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
-
 * Support for Ansible Builder V3.
 
 * Ansible Automation Platform 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
 
-* Added an option to configure SSO logout URL for Automation Hub.
+* Added an option to configure SSO logout URL for automation hub.
 
 * Updated the ansible-lint RPM package to version 6.14.3.
 
@@ -45,37 +34,6 @@ One notable change is that you can now configure the Controller Access Token for
 * Updated django for potential denial-of-service via Accept-Language headers (CVE-2023-23969).
 
 
-
-
-
-
-
-
-
-
-
-
-
-== Technology Preview
-
-Some features in this release are currently classified as Technology Preview. These experimental features are not intended for production use. For more information about technology preview features, see xref:technology-preview[What is a Technology Preview feature].
-
-<ABC> is available as a Technology Preview::
-ABC, which Red Hat provides as an unsupported Technology Preview, is <description of feature>
-
-<XYZ> is available as a Technology Preview::
-XYZ, which Red Hat provides as an unsupported Technology Preview, is <description of feature>
-
-== Bug fixes
-
-These bugs were fixed in this release of Ansible Automation Platform:
-
-* Installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
-
-*  Fixed issue restoring backups when installed automation controller version is different from backup.
-
-
-
 == Deprecated and removed features
 
 Some features available in previous releases have been deprecated or removed.
@@ -84,18 +42,60 @@ Deprecated functionality is still included in Ansible Automation Platform and co
 
 * On-premise component Automation Services Catalog is now removed from Ansible Automation Platform 2.4 onwards.
 
-* With the Ansible Automation Platform 2.4 release, the Execution Environment container image for Ansible 2.9 (ee-29-rhel-8) is no longer loaded into the Automation Controller configuration by default.
+* With the Ansible Automation Platform 2.4 release, the Execution Environment container image for Ansible 2.9 (*ee-29-rhel-8*) is no longer loaded into the Automation Controller configuration by default.
 
 * Although you can still synchronize content, the use of synclists is deprecated and will be removed in a later release. Instead, private automation hub administrators can upload manually-created requirements files from the `rh-certified` remote.
 
-* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
-** Inventories
-** Projects
-** Instance Groups
-** Credentials
-** Schedules
-** Workflow Job Templates
-** Launch Workflows
+* You can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
 
-[.indent]
-One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+* Smart inventories have been deprecated in favor of constructed inventories and will be removed in a future release.
+
+== Bug fixes
+
+The following bugs were fixed in this release of Ansible Automation Platform:
+
+* Installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
+
+*  Fixed an issue with restoring backups when the installed automation controller version is different from the backup version.
+
+* Fixed an issue with not adding user defined galaxy-importer settings to `galaxy-importer.cfg` file.
+
+* Added missing `X-Forwarded-For` header information to nginx logs.
+
+* Removed unnecessary receptor peer name validation when IP address is used as the name.
+
+* Updated the `outdated base_packages.txt` file that is included in the bundle installer.
+
+* Fixed an issue where upgrading the Ansible Automation Platform did not update the nginx package by default.
+
+* Fixed an issue where an *awx* user was created without creating an *awx* group on execution nodes.
+
+* Fixed the assignment of package version variable to work with flat file inventories. 
+
+* Added a FQDN check for the automation hub hostname required to run the Skopeo commands.
+
+*  Fixed an issue such that the front end URL for Red Hat Single Sign On (SSO) is now properly configured after you specify the `sso_redirect_host` variable.
+
+* Fixed the variable precedence for all component `nginx_tls_files_remote` variables.
+
+* Fixed the *setup.sh* script to escalate privileges if necessary for installing Ansible Automation Platform. 
+
+* Fixed an issue when restoring a backup to an automation hub with a different hostname.
+
+== Technology Preview
+
+Some features in this release are currently classified as Technology Preview.Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. These features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 
+
+Following are the technology preview features: 
+
+* Ansible Automation Platform 2.4 adds the ability to install the automation controller for IBM Power (ppc64le), IBM Z (s390x), and IBM(R) LinuxONE (s390x) architectures as a Technology Preview feature.
+
+[role="_additional-resources"]
+.Additional resources
+
+* For the most recent list of technology preview features, see link:https://access.redhat.com/articles/ansible-automation-platform-preview-features[Ansible Automation Platform - Preview Features].
+
+* For more information about technology preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].
+
+* For information regarding execution node enhancements on Openshift deployments, see link:https://docs.ansible.com/automation-controller/latest/html/administration/instances.html[Managing Capacity With Instances].
+

--- a/downstream/titles/release-notes/topics/bugfixes-102020.adoc
+++ b/downstream/titles/release-notes/topics/bugfixes-102020.adoc
@@ -1,6 +1,6 @@
 [[bugfixes-102020]]
-= Bug Fixes
+= Bug fixes
 
-This release of Red Hat Automation Analytics includes the following bug fixes:
+This release of Red Hat Automation Analytics includes the following bug fix:
 
 * Scaling on the Automation Calculator is corrected. 

--- a/downstream/titles/release-notes/topics/controller-41.adoc
+++ b/downstream/titles/release-notes/topics/controller-41.adoc
@@ -10,14 +10,14 @@ The name change reflects these enhancements and the overall position within the 
 Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
 
 
-.Automation controller 4.1 new features
+.Automation controller 4.1 new features and enhancements
 
 * Separate control and execution layers.
 * Automation execution environments are container images that provide a standardized way to build and distribute environments where automation runs.
 * Automation mesh allows distributed execution across on-premises environments, the hybrid cloud, and the edge. It replaces Ansible Tower and isolated nodes.
 
 
-.Automation controller 4.1 removed features
+.Automation controller 4.1 deprecated and removed features
 
 * Support for custom Python virtual environments for execution.
 

--- a/downstream/titles/release-notes/topics/controller-41.adoc
+++ b/downstream/titles/release-notes/topics/controller-41.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation controller 4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-41-intro]]
-= Automation controller 4.1
+= Automation controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
@@ -8,14 +10,14 @@ The name change reflects these enhancements and the overall position within the 
 Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
 
 
-.New features
+.Automation controller 4.1 new features
 
 * Separate control and execution layers.
 * Automation execution environments are container images that provide a standardized way to build and distribute environments where automation runs.
 * Automation mesh allows distributed execution across on-premises environments, the hybrid cloud, and the edge. It replaces Ansible Tower and isolated nodes.
 
 
-.Removed
+.Automation controller 4.1 removed features
 
 * Support for custom Python virtual environments for execution.
 

--- a/downstream/titles/release-notes/topics/controller-411.adoc
+++ b/downstream/titles/release-notes/topics/controller-411.adoc
@@ -1,13 +1,9 @@
+// This is the release notes for Automation controller 4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-411-intro]]
-= Automation controller 4.1.1
+= Automation controller
 
-Automation controller replaces Ansible Tower.
-Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
-The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
-
-Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
-
-.Enhancements and Bug fixes
+.Automation controller 4.1.1 enhancements and bug fixes
 
 * Added the ability to specify additional nginx headers
 * Fixed analytics gathering to collect all the data the controller needed to collect

--- a/downstream/titles/release-notes/topics/controller-414.adoc
+++ b/downstream/titles/release-notes/topics/controller-414.adoc
@@ -1,12 +1,8 @@
+// This is the release notes for Automation controller 4.1.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-414-intro]]
-= Automation Controller 4.1.4
+= Automation controller 
 
-Automation controller replaces Ansible Tower.
-Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
-The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
-
-Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
-
-.Bug fixes
+.Automation controller 4.1.4 bug fixes
 
 * Fixed an issue where the installer failed at "Push execution environment images locally on Automation Controller and Execution Nodes" and was unable to make rootless runtime.

--- a/downstream/titles/release-notes/topics/controller-420.adoc
+++ b/downstream/titles/release-notes/topics/controller-420.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Controller 4.2, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-420-intro]]
-= Automation Controller 4.2
+= Automation Controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.

--- a/downstream/titles/release-notes/topics/controller-430.adoc
+++ b/downstream/titles/release-notes/topics/controller-430.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Controller 4.3, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-430-intro]]
-= Automation Controller 4.3
+= Automation Controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.

--- a/downstream/titles/release-notes/topics/controller-440.adoc
+++ b/downstream/titles/release-notes/topics/controller-440.adoc
@@ -1,7 +1,7 @@
 // This is the release notes for Automation Controller 4.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[controller-440-intro]]
-= Automation controller
+= Automation Controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.

--- a/downstream/titles/release-notes/topics/controller-440.adoc
+++ b/downstream/titles/release-notes/topics/controller-440.adoc
@@ -1,0 +1,12 @@
+// This is the release notes for Automation Controller 4.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+[[controller-440-intro]]
+= Automation controller
+
+Automation controller replaces Ansible Tower.
+Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
+The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
+
+Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
+
+See link:https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#release-notes-for-4-x[automation controller Release Notes for 4.x] for a full list of new features and enhancements.

--- a/downstream/titles/release-notes/topics/docs-23.adoc
+++ b/downstream/titles/release-notes/topics/docs-23.adoc
@@ -1,11 +1,13 @@
+// This is the release notes for AAP 2.3 documentation, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[docs-2.3-intro]]
-= Ansible Automation Platform 2.3 Documentation
+= Ansible Automation Platform Documentation
 
 The documentation set for Red Hat Ansible Automation Platform 2.3 has been refactored to improve the experience for our customers and the Ansible community. These changes will make it easier for you to install, migrate, backup, recover and implement new features.
 
 .Enhancements
 
-* The _Red Hat Ansible Automation Platform Instllation Guide_ has been restructured into three separate documents to include the following:
+* The _Red Hat Ansible Automation Platform Installation Guide_ has been restructured into three separate documents to include the following:
 
 _Red Hat Ansible Automation Platform Planning Guide_::
 Use this guide to understand requirements, options, and recommendations for installing Ansible Automation Platform.

--- a/downstream/titles/release-notes/topics/docs-24.adoc
+++ b/downstream/titles/release-notes/topics/docs-24.adoc
@@ -14,7 +14,7 @@ The documentation set for Red Hat Ansible Automation Platform 2.4 has had signif
 
 ** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event_driven_ansible/index[Getting Started with Event-Driven Ansible]
 
-** Event-Driven Ansible User's Guide <insert hyperlink>
+** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event_driven_ansible_controller_user_guide/index[Event-Driven Ansible User Guide ]
 
 In addition, sections of the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide]  
 and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide]  are updated to include instructions for planning and installing Event-Driven Ansible. 

--- a/downstream/titles/release-notes/topics/docs-24.adoc
+++ b/downstream/titles/release-notes/topics/docs-24.adoc
@@ -5,10 +5,9 @@
 
 The documentation set for Red Hat Ansible Automation Platform 2.4 has had significant updates to improve the experience for our customers and the Ansible community. 
 
-
 .Enhancements
 
-* With the removal of the on-premise component Automation Services Catalog from Ansible Automation Platform 2.4 onwards, the Automation Services Catalog documentation too is removed from the Ansible Automation Platform 2.4 documentation.
+* With the removal of the on-premise component Automation Services Catalog from Ansible Automation Platform 2.4 onwards, all Automation Services Catalog documentation is removed from the Ansible Automation Platform 2.4 documentation.
 
 * The following documents are created to help you install and use Event-Driven Ansible, the newest capability of Ansible Automation Platform:
 
@@ -16,11 +15,11 @@ The documentation set for Red Hat Ansible Automation Platform 2.4 has had signif
 
 ** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event_driven_ansible_controller_user_guide/index[Event-Driven Ansible User Guide ]
 
-In addition, sections of the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide]  
-and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide]  are updated to include instructions for planning and installing Event-Driven Ansible. 
+In addition, sections of the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide] 
+and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] are updated to include instructions for planning and installing Event-Driven Ansible. 
 
 * The name of the _Managing Red Hat Certified and Ansible Galaxy collections in automation hub Guide_ has changed to include validated content and is now _Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub_.
 
-* The Ansible Automation Platform 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the Ansible Automation Platform versions, instead of their release timeline.  
+* The Ansible Automation Platform 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the Ansible Automation Platform versions, instead of their release timeline. 
 
 * The document https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in automation hub. 

--- a/downstream/titles/release-notes/topics/docs-24.adoc
+++ b/downstream/titles/release-notes/topics/docs-24.adoc
@@ -1,0 +1,26 @@
+// This is the release notes for AAP 2.4 documentation, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+[[docs-2.4-intro]]
+= Ansible Automation Platform Documentation
+
+The documentation set for Red Hat Ansible Automation Platform 2.4 has had significant updates to improve the experience for our customers and the Ansible community. 
+
+
+.Enhancements
+
+* With the removal of the on-premise component Automation Services Catalog from Ansible Automation Platform 2.4 onwards, the Automation Services Catalog documentation too is removed from the Ansible Automation Platform 2.4 documentation.
+
+* The following documents are created to help you install and use Event-Driven Ansible, the newest capability of Ansible Automation Platform:
+
+** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event_driven_ansible/index[Getting Started with Event-Driven Ansible]
+
+** Event-Driven Ansible User's Guide <insert hyperlink>
+
+In addition, sections of the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide]  
+and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide]  are updated to include instructions for planning and installing Event-Driven Ansible. 
+
+* The name of the _Managing Red Hat Certified and Ansible Galaxy collections in automation hub Guide_ has changed to include validated content and is now _Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub_.
+
+* The Ansible Automation Platform 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the Ansible Automation Platform versions, instead of their release timeline.  
+
+* The document https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in automation hub. 

--- a/downstream/titles/release-notes/topics/eda-24.adoc
+++ b/downstream/titles/release-notes/topics/eda-24.adoc
@@ -1,16 +1,15 @@
-// This is the release notes for Event-Driven Ansible for AAP 2.4 release, the version number is removed from the topic title as part of the release notes restructuring efforts.
+// This is the release notes for Event-Driven Ansible 1.0 for AAP 2.4 release, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[eda-24-intro]]
 = Event-Driven Ansible
 
-Event-Driven Ansible is the newest capability of Ansible Automation Platform that is designed to enable automated response with user-defined, rules-based workflows. Event-Driven Ansible works by receiving events from third party tools, deciding on the actions to take and acting automatically.  
+Event-Driven Ansible is the newest capability of Ansible Automation Platform that is designed to enable automated response with user-defined, rules-based workflows. Event-Driven Ansible works by receiving events from third party tools, deciding on the actions to take, and acting automatically.
 
-Event-Driven Ansible is included in Ansible Automation Platform, making the platform even more capable as a single enterprise automation solution.  Using Event-Driven Ansible, domain experts can easily create end-to-end fully automated OpsAsCode scenarios for a  broad array of use cases across the IT landscape.  By eliminating high-volume routine tasks and automatically responding to changing conditions, teams are free to innovate more, sleep more, and act consistently and accurately at scale.
+Event-Driven Ansible is included in Ansible Automation Platform, making the platform even more capable as a single enterprise automation solution. Using Event-Driven Ansible, domain experts can easily create end-to-end fully automated OpsAsCode scenarios for a broad array of use cases across the IT landscape. By eliminating high-volume routine tasks and automatically responding to changing conditions, teams are free to innovate more efficiently, and act consistently and accurately at scale.
 
 .Known issues
 
 * Certain characters, such as hyphen (-), forward slash (/), and period (.), are not supported in the event keys.
-
 
 * Both contributor and editor roles cannot set the AWX token. The AWX token can be set by users with administrator roles only. 
 
@@ -32,7 +31,7 @@ Event-Driven Ansible is included in Ansible Automation Platform, making the plat
 
 * Long running activations with loads of events can cause out of disk space issue.
 
-* Users can add multiple tokens even when only the first AWX token is used.  
+* Users can add multiple tokens even when only the first AWX token is used. 
 
 * A race condition occurs when creating and rapidly deleting an activation causes multiple errors. 
 

--- a/downstream/titles/release-notes/topics/eda-24.adoc
+++ b/downstream/titles/release-notes/topics/eda-24.adoc
@@ -1,0 +1,61 @@
+// This is the release notes for Event-Driven Ansible for AAP 2.4 release, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+[[eda-24-intro]]
+= Event-Driven Ansible
+
+Event-Driven Ansible is the newest capability of Ansible Automation Platform that is designed to enable automated response with user-defined, rules-based workflows. Event-Driven Ansible works by receiving events from third party tools, deciding on the actions to take and acting automatically.  
+
+Event-Driven Ansible is included in Ansible Automation Platform, making the platform even more capable as a single enterprise automation solution.  Using Event-Driven Ansible, domain experts can easily create end-to-end fully automated OpsAsCode scenarios for a  broad array of use cases across the IT landscape.  By eliminating high-volume routine tasks and automatically responding to changing conditions, teams are free to innovate more, sleep more, and act consistently and accurately at scale.
+
+.Known issues
+
+* Certain characters, such as hyphen (-), forward slash (/), and period (.), are not supported in the event keys.
+
+
+* Both contributor and editor roles cannot set the AWX token. The AWX token can be set by users with administrator roles only. 
+
+* Activation-job pods do not have request limits.
+
+* The onboarding wizard does not request a controller token creation.
+
+* Users cannot filter through a list of tokens under the Controller Token tab. 
+
+* Only the users with administrator rights can set or modify their passwords. 
+
+* In the event of a failure, an activation with restart policy set to `Always` is unable to restart the failed activation. 
+
+* Disabling and enabling an activation causes the restart count to increase by one count. This behavior results in an incorrect `restart` count. 
+
+* When all workers are busy with activation processes, other asynchronous tasks are not executed, such as importing projects.
+
+* Podman pods must be executed with memory limits.
+
+* Long running activations with loads of events can cause out of disk space issue.
+
+* Users can add multiple tokens even when only the first AWX token is used.  
+
+* A race condition occurs when creating and rapidly deleting an activation causes multiple errors. 
+
+* When users filter any list, only the items that are on the list get filtered. 
+
+* When ongoing activations start multiple jobs, a few jobs are not recorded in the audit logs. 
+
+* When a job template fails, a few key attributes are missing in the event payload. 
+
+* Restart policy in a Kubernetes deployment does not restart successful activations that are marked as failed.
+
+* An incorrect status is reported for activations that are disabled or enabled. 
+
+* If the *run_job_template* action fails, the rule is not counted as executed. 
+
+* RHEL 9.2 activations cannot connect to the host.
+
+* When there are more activations than available workers, disabling the activations incorrectly shows them in running state. 
+
+* Event-Driven Ansible activation pods are running out of memory on RHEL 9.
+
+* Restarting the Event-Driven Ansible server can cause activation states to become stale.
+
+* Bulk deletion of rulebook activation lists is not consistent, and the deletion can be either successful or unsuccessful.
+
+* When users access the detail screen of a rule audit, the related rulebook activation link is broken. 

--- a/downstream/titles/release-notes/topics/enhancements-102020.adoc
+++ b/downstream/titles/release-notes/topics/enhancements-102020.adoc
@@ -1,8 +1,6 @@
 [[enhancements-102020]]
 = Enhancements
 
-.October 2020
-
 This Red Hat Automation Analytics release includes the following enhancements:
 
 * A date filter on the Automation Calculator;

--- a/downstream/titles/release-notes/topics/hub-421.adoc
+++ b/downstream/titles/release-notes/topics/hub-421.adoc
@@ -1,8 +1,6 @@
 [[hub-421-intro]]
 = Automation Hub 4.2.1
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Private Automation Hub bug fixes and enhancements 
 
 * Fixed NamespaceLink creation and Validation on duplicated name

--- a/downstream/titles/release-notes/topics/hub-422.adoc
+++ b/downstream/titles/release-notes/topics/hub-422.adoc
@@ -1,8 +1,6 @@
 [[hub-422-intro]]
 = Automation Hub 4.2.2
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes and enhancements 
 
 * Fixed the `galaxy-importer` check for max size of docs files 

--- a/downstream/titles/release-notes/topics/hub-423.adoc
+++ b/downstream/titles/release-notes/topics/hub-423.adoc
@@ -1,10 +1,7 @@
 [[hub-423-intro]]
 = Automation Hub 4.2.3
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
-
 
 * Fix how travis checks for existence of Jira issues
 

--- a/downstream/titles/release-notes/topics/hub-424.adoc
+++ b/downstream/titles/release-notes/topics/hub-424.adoc
@@ -1,8 +1,6 @@
 [[hub-424-intro]]
 = Automation Hub 4.2.4
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
 
 

--- a/downstream/titles/release-notes/topics/hub-426.adoc
+++ b/downstream/titles/release-notes/topics/hub-426.adoc
@@ -1,8 +1,6 @@
 [[hub-426-intro]]
 = Automation Hub 4.2.6
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
 
 * Implemented filters for state and keywords on imports API

--- a/downstream/titles/release-notes/topics/hub-441.adoc
+++ b/downstream/titles/release-notes/topics/hub-441.adoc
@@ -1,9 +1,12 @@
+// This is the release notes for Automation Hub 4.4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+
 [[hub-441-intro]]
-= Automation Hub 4.4.1
+= Automation Hub
 
 Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 
-.Enhancements and bug fixes
+.Automation Hub 4.4.1 enhancements and bug fixes
 
 * Added tasking system permissions so that users with the appropriate permissions can view and manage tasks
 * Added name, namespace name, and registry requirements when add/editing an execution environment

--- a/downstream/titles/release-notes/topics/hub-443.adoc
+++ b/downstream/titles/release-notes/topics/hub-443.adoc
@@ -2,7 +2,6 @@
 
 
 [[hub-443-intro]]
-= Automation Hub
 
 .Automation hub 4.4.3 bug fixes
 

--- a/downstream/titles/release-notes/topics/hub-443.adoc
+++ b/downstream/titles/release-notes/topics/hub-443.adoc
@@ -1,9 +1,10 @@
+// This is the release notes for Automation Hub 4.4.3, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+
 [[hub-443-intro]]
-= Automation Hub 4.4.3
+= Automation Hub
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
-.Bug fixes
+.Automation hub 4.4.3 bug fixes
 
 * Fixed an issue where idle connections were growing and not closing in the automation hub database.
 * Fixed an issue where private automation hub was unable to restore with an external database.

--- a/downstream/titles/release-notes/topics/hub-450.adoc
+++ b/downstream/titles/release-notes/topics/hub-450.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Hub 4.5, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[hub-450-intro]]
-= Automation Hub 4.5
+= Automation Hub
 
 Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 

--- a/downstream/titles/release-notes/topics/hub-460.adoc
+++ b/downstream/titles/release-notes/topics/hub-460.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Hub 4.6, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[hub-460-intro]]
-= Automation Hub 4.6
+= Automation Hub
 
 Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 

--- a/downstream/titles/release-notes/topics/hub-464.adoc
+++ b/downstream/titles/release-notes/topics/hub-464.adoc
@@ -1,7 +1,7 @@
 // This is the release notes for Automation Hub 4.6.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[hub-464-intro]]
-= Automation hub
+= Automation Hub
 
 Automation hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible automation hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 

--- a/downstream/titles/release-notes/topics/hub-464.adoc
+++ b/downstream/titles/release-notes/topics/hub-464.adoc
@@ -1,0 +1,22 @@
+// This is the release notes for Automation Hub 4.6.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+[[hub-464-intro]]
+= Automation hub
+
+Automation hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible automation hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
+
+.Enhancement
+
+* This release of automation hub provides repository management functionality. With repository management, you can create, edit, delete, and move content between repositories.
+
+.Bug fixes
+
+* Fixed an issue in the collection keyword search which was returning an incorrect number of results.
+
+* Added the ability to set *OPT_REFERRALS* option for LDAP, so that users can now successfully log in to the automation hub using their LDAP credentials.
+
+* Fixed an error on the UI when *redhat.openshift* collection's core dependency was throwing a `404 Not Found` error.
+
+* Fixed an error such that the deprecated execution environments are now skipped while syncing with *registry.redhat.io*.
+
+

--- a/downstream/titles/release-notes/topics/insights-062021.adoc
+++ b/downstream/titles/release-notes/topics/insights-062021.adoc
@@ -2,6 +2,7 @@
 
 Insights for Ansible Automation Platform gives you feedback about your automation deployments through insights and governance which allow you to view information about automation health, usage, and performance across your enterprise.
 
+.June 2021 release
 This release introduces the automation savings planner to Insights for Ansible Automation Platform. The automation savings planner is a tool where users can track their automation efforts by creating automation savings plans, each with a defined set of tasks needed to complete their plans. Users can also view a calculation of their cost savings from automating these tasks.
 
 * Create an automation savings plan by specifying a list of tasks needed to complete an automation job.

--- a/downstream/titles/release-notes/topics/insights-102021.adoc
+++ b/downstream/titles/release-notes/topics/insights-102021.adoc
@@ -1,10 +1,5 @@
 [[insights-102021]]
 
-= Red Hat Insights for Red Hat Ansible Automation Platform
+.October 2021 release
 
-Insights for Ansible Automation Platform gives you feedback about your automation deployments through insights and governance which allow you to view information about automation health, usage, and performance across your enterprise.
-
-This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.
-
-.Reports feature
-* Added a reports feature that gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics.
+This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. The reports feature that gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.

--- a/downstream/titles/release-notes/topics/new-features-oct-2020.adoc
+++ b/downstream/titles/release-notes/topics/new-features-oct-2020.adoc
@@ -1,8 +1,6 @@
 [[new-features-102020]]
 = New Features
 
-.October 2020
-
 This Red Hat Automation Analytics release includes the following features:
 
 * The *Job Explorer* provides a detailed view of jobs run on Ansible Tower clusters across your organizations. You can access the Job Explorer by directly clicking on the navigation tab or using the drill-down view available across each of the application’s charts. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html-single/evaluating_your_ansible_tower_job_runs_using_the_job_explorer[Evaluating your Ansible Tower jobs runs using the Job Explorer] to learn more.

--- a/downstream/titles/release-notes/topics/operator-220.adoc
+++ b/downstream/titles/release-notes/topics/operator-220.adoc
@@ -1,5 +1,8 @@
+// This is the release notes for Automation Platform Operator 2.2, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+
 [[operator-220-intro]]
-= Automation Platform Operator 2.2
+= Automation Platform Operator
 
 The Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
 

--- a/downstream/titles/release-notes/topics/operator-230.adoc
+++ b/downstream/titles/release-notes/topics/operator-230.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Platform Operator 2.3, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[operator-230-intro]]
-= Automation Platform Operator 2.3
+= Automation Platform Operator
 
 Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
 

--- a/downstream/titles/release-notes/topics/operator-240.adoc
+++ b/downstream/titles/release-notes/topics/operator-240.adoc
@@ -1,0 +1,30 @@
+// This is the release notes for Automation Platform Operator 2.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
+[[operator-240-intro]]
+= Automation Platform Operator
+
+Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
+
+.Enhancements
+
+* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
+** Inventories
+** Projects
+** Instance Groups
+** Credentials
+** Schedules
+** Workflow Job Templates
+** Launch Workflows
+
+One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+
+.Bug fixes
+
+* Enabled configuration of resource requirements for automation controller `init` containers.
+
+* Added *securityContext* for EDA Operator deployments to be Pod Security Admission compliant.
+
+* Resolved error `Controller: Error 413 Entity too large` when doing bulk updates.
+
+* Ansible token is now obfuscated in YAML job details.
+

--- a/downstream/titles/release-notes/topics/operator-240.adoc
+++ b/downstream/titles/release-notes/topics/operator-240.adoc
@@ -7,7 +7,7 @@ Ansible Automation Platform Operator provides cloud-native, push-button deployme
 
 .Enhancements
 
-* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in Controller by applying YAML to your Openshift cluster:
+* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in automation controller by applying YAML to your Openshift cluster:
 ** Inventories
 ** Projects
 ** Instance Groups
@@ -16,7 +16,7 @@ Ansible Automation Platform Operator provides cloud-native, push-button deployme
 ** Workflow Job Templates
 ** Launch Workflows
 
-One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter. This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
 
 .Bug fixes
 

--- a/downstream/titles/release-notes/topics/platform-intro-124.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro-124.adoc
@@ -1,8 +1,6 @@
 [[platform-124-intro]]
 = Red Hat Ansible Automation Platform 1.2.4
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Bug fixes
 
 * Added the ability for Ansible Automation Platform 1.2.x to transition from venvs to execution environments smoothly to platform 2.x This includes three new `awx-manage` commands, check associations, and export venvs for building an execution environment.

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -10,9 +10,9 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 |===
 | Ansible Automation Platform | Automation controller | Automation hub | Automation services catalog | Insights for Ansible Automation Platform
 
-|2.3 | 4.3|
-* 4.6
-* hosted service a|
+|2.4 | 4.4|
+* 4.7
+* hosted service|
 * 1.0 Private (Technology Preview)
 * hosted service (Retired)
 | hosted service

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -11,7 +11,7 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 | Ansible Automation Platform | Automation controller | Automation hub | Automation services catalog | Insights for Ansible Automation Platform
 
 |2.4 | 4.4|
-* 4.7
+* 4.6.4
 * hosted service|
 * 1.0 Private (Technology Preview)
 * hosted service (Retired)
@@ -23,7 +23,3 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
 Refer to link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle].
-
-[[technology-preview]]
-== What is a Technology Preview feature
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -8,12 +8,12 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 [cols="a,a,a,a,a"]
 |===
-| Ansible Automation Platform | Automation controller | Automation hub | Event-Driven Ansible | Insights for Ansible Automation Platform
+| Ansible Automation Platform | Automation controller | Automation hub | Event-Driven Ansible controller | Insights for Ansible Automation Platform
 
 |2.4 | 4.4|
-* 4.6.4
+* 4.7
 * hosted service|
-2.4
+1.0
 | hosted service
 
 |===

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -23,3 +23,19 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
 Refer to link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle].
+
+== Upgrading Ansible Automation platform
+
+Use installer to perform upgrades to maintenance versions of Ansible Automation Platform. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+
+[IMPORTANT]
+====
+Do not use `yum update` to run upgrades. Use installer instead.
+====
+
+.Additional resources
+* Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+
+* For more information on upgrading your Ansible Automation Platform, see the  https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade Guide].
+
+* For procedures related to using the Ansible Automation Platform installer, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -8,13 +8,12 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 [cols="a,a,a,a,a"]
 |===
-| Ansible Automation Platform | Automation controller | Automation hub | Automation services catalog | Insights for Ansible Automation Platform
+| Ansible Automation Platform | Automation controller | Automation hub | Event-Driven Ansible | Insights for Ansible Automation Platform
 
 |2.4 | 4.4|
 * 4.6.4
 * hosted service|
-* 1.0 Private (Technology Preview)
-* hosted service (Retired)
+2.4
 | hosted service
 
 |===

--- a/downstream/titles/release-notes/topics/tower-intro-381.adoc
+++ b/downstream/titles/release-notes/topics/tower-intro-381.adoc
@@ -1,11 +1,6 @@
 [[tower-381-intro]]
 = Ansible Tower 3.8.1
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes and enhancements
 
 * Improved analytics collection to collect the playbook status for all hosts in a playbook run

--- a/downstream/titles/release-notes/topics/tower-intro-382.adoc
+++ b/downstream/titles/release-notes/topics/tower-intro-382.adoc
@@ -1,11 +1,6 @@
 [[tower-382-intro]]
 = Ansible Tower 3.8.2
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes and enhancements
 
 * Upgraded to the latest oVirt inventory plugin to resolve a number of inventory syncing issues that can occur on RHEL7

--- a/downstream/titles/release-notes/topics/tower-intro-383.adoc
+++ b/downstream/titles/release-notes/topics/tower-intro-383.adoc
@@ -1,11 +1,6 @@
 [[tower-383-intro]]
 = Ansible Tower 3.8.3
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes 
 
 * Analytics collection no longer cause lost job events when Tower is under load

--- a/downstream/titles/release-notes/topics/tower-intro-384.adoc
+++ b/downstream/titles/release-notes/topics/tower-intro-384.adoc
@@ -1,12 +1,6 @@
 [[tower-384-intro]]
 = Ansible Tower 3.8.4
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
-
 .Bux fixes
 
 * Running inventories of ~60k hosts no longer takes a very long time for events to show up


### PR DESCRIPTION
JIRA:

- Restructuring release notes: https://issues.redhat.com/browse/AAP-12257
- Creating AAP 2.4 release notes: https://issues.redhat.com/browse/AAP-12511

Following are the changes:

- Restructured AAP 2.4 release notes based on AAP versions instead of release date.
- Created AAP 2.4 release notes

Following are the files that warrant doc peer review:

- aap-24.adoc
- controller-440.adoc
- docs-24.adoc
- eda-24.adoc
- hub-464.adoc
- operator-240.adoc

Note: I'm working with Aine for the restructured files review. 