### PR TITLE
2.4 Corrected minimum and required ansible versions (#1055)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -16,7 +16,7 @@ h| Subscription | Valid Red Hat Ansible Automation Platform |
 
 h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version 2.12 required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.13.
+h| Ansible | version {AnsibleCoreVers} required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.14.
 
 h| Python | 3.8 or later |
 
@@ -46,7 +46,7 @@ See link:https://docs.ansible.com/ansible/latest/user_guide/intro_getting_starte
 
 * Although {PlatformName} depends on Ansible Playbooks and requires the installation of the latest stable version of Ansible before installing {ControllerName}, manual installations of Ansible are no longer required.
 
-* For new installations, {ControllerName} installs the latest release package of Ansible 2.2.
+* For new installations, {ControllerName} installs the latest release package of Ansible 2.14.
 
 * If performing a bundled {PlatformNameShort} installation, the installation program attempts to install Ansible (and its dependencies) from the bundle for you.
 
@@ -54,6 +54,6 @@ See link:https://docs.ansible.com/ansible/latest/user_guide/intro_getting_starte
 
 [NOTE]
 ====
-You must install Ansible using a package manager such as `yum`, and the latest stable version of the package manager must be installed for {PlatformName} to work properly.
-Ansible version 2.9 is required for versions 3.8 and later.
+You must install Ansible using a package manager such as `dnf`, and the latest stable version of the package manager must be installed for {PlatformName} to work properly.
+Ansible version 2.14 is required for versions {PlatformVers} and later.
 ====


### PR DESCRIPTION
* Corrected minimum and required ansible versions

Changed values in system requirements table.

Affects planning guide
Backports #1055 

https://issues.redhat.com/browse/AAP-11993
