### PR TITLE
AAP-12684 Add direct doc feedback module to repo management doc

### DIFF
--- a/downstream/titles/hub/repo-management/master.adoc
+++ b/downstream/titles/hub/repo-management/master.adoc
@@ -9,6 +9,8 @@ include::attributes/attributes.adoc[]
 Repository management is included with Red Hat {HubName}. It allows you to create, edit, modify and delete repositories.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
+
 include::hub/assembly-repo-management.adoc[leveloffset=+1]
 include::hub/assembly-basic-repo-management.adoc[leveloffset=+2]
 include::hub/assembly-remote-management.adoc[leveloffset=+1]


### PR DESCRIPTION
AAP-12684

Add direct documentation feedback module to the `titles/hub/repo-management/` title.
Backport to 2.4
