### PR TITLE
AAP-1636-fix: Reorder of titles

### DIFF
--- a/downstream/titles/aap-hardening/master.adoc
+++ b/downstream/titles/aap-hardening/master.adoc
@@ -12,7 +12,8 @@ include::attributes/attributes.adoc[]
 
 This guide provides recommended practices for various processes needed to install, configure, and maintain {PlatformNameShort} on Red Hat Enterprise Linux in a secure manner.
 
+include::aap-hardening/assembly-intro-to-aap-hardening.adoc[leveloffset=+1]
+include::aap-hardening/assembly-hardening-aap.adoc[leveloffset=+1]
 include::aap-hardening/assembly-aap-compliance.adoc[leveloffset=+1]
 include::aap-hardening/assembly-aap-security-enabling.adoc[leveloffset=+1]
-include::aap-hardening/assembly-hardening-aap.adoc[leveloffset=+1]
-include::aap-hardening/assembly-intro-to-aap-hardening.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Jira link [AAP-1636](https://issues.redhat.com/browse/AAP-1636)

Fixed the arrangement of the titles to:

1. Introduction
2. Hardening Ansible Automation Platform
3. Ansible Automation Platform Compliance
4. Ansible Automation Platform as a security enabling tool