### PR TITLE
Modified title fields to remove attribute and match to fix build

### DIFF
--- a/downstream/titles/eda/eda-user-guide/docinfo.xml
+++ b/downstream/titles/eda/eda-user-guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Red Hat Event-Driven Ansible Controller user guide </title>
+<title>Event-Driven Ansible Controller user guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Instructions on using Red Hat Event-Driven Ansible Controller</subtitle>

--- a/downstream/titles/eda/eda-user-guide/master.adoc
+++ b/downstream/titles/eda/eda-user-guide/master.adoc
@@ -6,14 +6,12 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= {EDAName} Controller user guide
+= Event-Driven Ansible Controller user guide
 
-{EDANameShort} is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience. 
-Developed by Red Hat, this feature is designed for simplicity and flexibility. 
+{EDANameShort} is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience.
+Developed by Red Hat, this feature is designed for simplicity and flexibility.
 This guide helps you configure your Event-Driven Ansible controller to set up new projects, decision environments, tokens to authenticate to Ansible Automation Platform Controller, and rulebook activation.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::eda/assembly-eda-user-guide-overview.adoc[leveloffset=+1]
-
-


### PR DESCRIPTION
This PR modifies the titles in docinfo and master.adoc to be an exact match to fix the failure in the Pantheon build. 