### PR TITLE
Updated Getting Started guide and corrected errors on previous branch…

### DIFF
--- a/downstream/modules/automation-hub/con-create-api-token.adoc
+++ b/downstream/modules/automation-hub/con-create-api-token.adoc
@@ -1,0 +1,10 @@
+[id="con-create-api-token"]
+= Creating the Red Hat automation hub API token
+
+Before you can interact with automation hub by uploading or downloading collections, you must create an API token. The automation hub API token authenticates your `ansible-galaxy` client to the Red Hat automation hub server.
+
+You can create an API token using automation hub *Token management* in automation hub or *API Token Management* in private automation hub (PAH).
+
+include::proc-create-api-token.adoc[leveloffset=+1]
+
+include::proc-create-api-token-pah.adoc[leveloffset=+1]

--- a/downstream/modules/automation-hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/automation-hub/proc-create-api-token-pah.adoc
@@ -1,11 +1,9 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
-[id="proc-create-api-token"]
-= Creating the Red Hat {HubName} API token
+[id="proc-create-api-token-pah"]
+= Creating the API token in private automation hub
 
-Before you can interact with {HubName} by uploading or downloading collections, you need to create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.
-
-You can create an API token using {HubName} *Token management*.
+You can create an API token using *API Token Management* in PAH.
 
 .Prerequisites
 
@@ -13,9 +11,10 @@ You can create an API token using {HubName} *Token management*.
 
 .Procedure
 
-. Navigate to link:https://cloud.redhat.com/ansible/automation-hub/token/[https://cloud.redhat.com/ansible/automation-hub/token/].
+. Navigate to your PAH.
+. From the sidebar, navigate to menu:Collections[API Token Management].
 . Click btn:[Load Token].
-. Click btn:[copy] icon to copy the API token to the clipboard.
+. Click the *copy* icon to copy the API token to the clipboard.
 . Paste the API token into a file and store in a secure location.
 
 [IMPORTANT]

--- a/downstream/titles/hub/getting-started/master.adoc
+++ b/downstream/titles/hub/getting-started/master.adoc
@@ -19,9 +19,7 @@ This guide walks you through the steps required to configure your `ansible.cfg` 
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
-include::automation-hub/proc-create-api-token.adoc[leveloffset=+1]
-
-The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
+include::automation-hub/con-create-api-token.adoc[leveloffset=+1]
 
 include::automation-hub/con-offline-token-active.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Previous branch AAP-11480 (commit https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/commit/15d554e0dd5acd62dab835cce4498c82497b5243) (PR https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1036) contained errors. Changes tracked in PR 1036 were merged to main but not backported.

New [PR 1084](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1084) created to fix errors.

Backporting [PR 1084](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1084) to 2.3.