### PR TITLE
Backport 2.3: AAP-13402 update automation hub variables (#1092)

### DIFF
--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -85,10 +85,14 @@ Default = `false`.
 To enable pulp analytics, set `automationhub_enable_analytics = true`.
 
 Default = `false`.
-| *`automationhub_enable_unathenticated_collection_access`* | Enables unauthorized users to view collections
+| *`automationhub_enable_unauthenticated_collection_access`* | Enables unauthorized users to view collections.
+
+To enable unauthorized users to view collections, set `automationhub_enable_unauthenticated_collection_access = true`.
 
 Default = `false`.
 | *`automation_hub_enable_unauthenticated_collection_download`* | Enables unauthorized users to download collections.
+
+To enable unauthorized users to download collections, set `automationhub_enable_unauthenticated_collection_download = true`.
 
 Default = `false`.
 | *`automationhub_importer_settings`* | _Optional_


### PR DESCRIPTION
Updates automation hub variables to correct spelling in automationhub_enable_unauthenticated_collection_access and to add info about setting the parameter to "true." This change affects the Installation Guide.

This PR backports the changes to the 2.3 release.

See [AAP-13402](https://issues.redhat.com/browse/AAP-13402) for more info.