### PR TITLE
Backport-2.4-1050 AAP-10975C New chapter on EDA installation w/ AAP operator on OCP

### DIFF
--- a/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
@@ -1,0 +1,20 @@
+ifdef::context[:parent: {context}]
+
+
+[id="deploy-eda-controller-on-aap-operator-ocp"]
+
+= Deploying {EDAcontroller} with {OperatorPlatform} on {OCPShort}
+
+:context: deploying
+
+[role="_abstract"]
+{EDAcontroller} is the interface for event-driven automation and introduces automated resolution of IT requests. This component helps you connect to sources of events and acts on those events using rulebooks. When you deploy {EDAcontroller}, you can automate decision making, leverage numerous event sources, implement event-driven automation within and across multiple IT use cases, and achieve more efficient service delivery. 
+
+Use the following instructions to install {EDAName} with your {OperatorPlatform} on {OCPShort}.
+
+
+include::platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-deploy-eda-controller-with-aap-operator-ocp[:context: {parent-context-of-deploy-eda-controller-with-aap-operator-ocp}]
+ifndef::parent-context-of-deploy-eda-controller-with-aap-operator-ocp[:!context:]
+

--- a/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
+++ b/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
@@ -1,0 +1,53 @@
+
+[id="proc-deploy-eda-controller-with-aap-operator-ocp_{context}"]
+
+
+
+.Prerequisites
+
+* You have installed {OperatorPlatform} on {OCPShort}.
+* You have installed and configured {ControllerName}.
+
+.Procedure
+
+. Select menu:Operators[Installed Operators].
+
+. Locate and select your installation of {PlatformNameShort}.
+
+. Under *Provided APIs*, locate the {EDAName} modal and click *Create instance*. 
++
+This takes you to the Form View to customize your installation.
+
+. Specify your controller URL. 
++
+If you deployed {ControllerName} in Openshift as well, you can find the URL on the Routes page.
++
+[NOTE]
+====
+This is the only required customization, but you can customize other options using the UI form or directly in the YAML configuration tab, if desired.
+====
+
+. Click btn:[Create].
+This deploys {EDAcontroller} in the namespace you specified. 
++
+After a couple minutes when the installation is marked as *Successful*, you can find the URL for the {EDAName} UI on the *Routes* page in the Openshift UI. 
+
+. From the navigation panel, select menu:Networking[Routes] to find the new Route URL that has been created for you. 
++
+Routes are listed according to the name of your custom resource.
+
+. Click the new URL to navigate to {EDAName} in the browser.
+
+. From the navigation panel, select menu:Workloads[Secrets] and locate the Admin Password k8s secret that was created for you, unless you specified a custom one.
++
+Secrets are listed according to the name of your custom resource and appended with `-admin-password.`
++
+[NOTE]
+====
+You can use the password value in the secret to log in to the {EDAcontroller} UI. The default user is `admin`.
+====
+
+
+
+
+

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -32,6 +32,8 @@ include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
 
+include::platform/assembly-deploy-eda-controller-on-aap-operator.adoc[leveloffset=+1]
+
 include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[leveloffset=+1]
 
 include::platform/assembly-aap-migration.adoc[leveloffset=+1]


### PR DESCRIPTION
Based on [PR #1050](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1050):

Created new assembly and module for instructions on installing EDA on AAP operator on OpenShift Container Platform. Also added new assembly to master. adoc.