### PR TITLE
AAP-10975A Add installation-related content to the AAP Planning Guide…

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -16,6 +16,10 @@ include::platform/con-about-pa-hub.adoc[leveloffset=+1]
 
 //[dcd-moved this description to the intro to platform components since it is the only "required" component. include::platform/con-about-automation-controller.adoc[leveloffset=+1]
 
+//include::platform/con-about-services-catalog.adoc[leveloffset=+1]
+
+include::platform/con-about-eda-controller.adoc[leveloffset=+1]
+
 include::platform/con-overview-automation-mesh.adoc[leveloffset=+1]
 
 include::platform/con-about-execution-env.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
+++ b/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
@@ -23,7 +23,7 @@ include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+1]
 
 //See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
 
-include::platform/ref-single-eda-controller-with-internal-db.adoc[leveloffset=+1]
+include::platform/con-single-eda-controller-with-internal-database.adoc[leveloffset=+1]
 
 include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/con-about-eda-controller.adoc
+++ b/downstream/modules/platform/con-about-eda-controller.adoc
@@ -1,0 +1,20 @@
+[id="about-event-driven-ansible-controller_{context}"]
+
+= Event-Driven Ansible controller
+
+[role="_abstract"]
+The Event-Driven Ansible controller is the interface for event-driven automation and introduces automated resolution of IT requests. This component helps you connect to sources of events and act on those events using rulebooks. This technology improves IT speed and agility, and enables consistency and resilience. With Event-Driven Ansible, you can: 
+
+* Automate decision making
+* Leverage numerous event sources
+* Implement event-driven automation within and across multiple IT use cases
+
+[role="_additional-resources"]
+.Additional resources
+
+////
+The following link will not work until published.
+////
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event-driven_ansible_guide/index[Getting Started with Event-Driven Ansible Guide].
+

--- a/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
+++ b/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
@@ -1,0 +1,17 @@
+:_content-type: CONCEPT
+
+[id="single-eda-controller-with-internal-database"]
+
+= Single {EDAcontroller} node with internal database
+
+This scenario includes installation of {EDAcontroller} on a single machine with an internal database. It installs an installer managed PostgreSQL that is similar to the automation controller installation scenario.
+
+[IMPORTANT]
+====
+{ControllerNameStart} must be installed before you populate the inventory file with the appropriate {EDAName} variables.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-eda-controller-with-internal-db_platform-install-scenario[Single Event-Driven Ansible controller node with internal database]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-eda-controller-variables[Appendix A. 5. Event-Driven Ansible controller variables]

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -14,7 +14,7 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid Red Hat Ansible Automation Platform |
 
-h| OS | Red Hat Enterprise Linux 8.4 or later 64-bit (x86) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
+h| OS | Red Hat Enterprise Linux 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
 h| Ansible | version {AnsibleCoreVers} required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.14.
 


### PR DESCRIPTION
This PR backports the changes for PR (#1042) to the 2.4 branch and includes the following: 

* AAP-10975A Resolve conflict w/ assembly-aap-platform-components.adoc

* AAP-10975A Added new concept module and link to EDA controller in planning guide

* AAP-10975A Minor grammatical tweak and addition of link to Install Guide

* AAP-10975 Corrected link to additional resource

* AAP-10975A Added the EDA install scenario to Chapt 8

* AAP-10975A Added the EDA install scenario to Chapt 8

* AAP-10975A Updated RHEL OS info in system requirements