### PR TITLE
ncg2.4 - fix mismatch between title in master and docinfo files

### DIFF
--- a/downstream/titles/navigator-guide/docinfo.xml
+++ b/downstream/titles/navigator-guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Early Access Ansible Navigator Creator Guide</title>
+<title>Ansible Navigator Creator Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Develop content that is compatible with Ansible Automation Platform


### PR DESCRIPTION
This PR fixes the docinfo.xml title to match the master.adoc and Pantheon titles.