### PR TITLE
backport 2.4: Centralauth2.4 Formatting and link text updates for pre-release chec…

### DIFF
--- a/downstream/assemblies/central-auth/assembly-central-auth-group-perms.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-group-perms.adoc
@@ -11,7 +11,7 @@ You can manage user access on the {PlatformNameShort} by grouping specific permi
 You can group permissions into roles with specific user access to features in the system.
 
 .Prerequisites
-You are signed in as a `hubadmin` user.
+* You are signed in as a `hubadmin` user.
 
 .Procedure
 . Log in to your local {HubName}.

--- a/downstream/modules/automation-hub/proc-assigning-roles.adoc
+++ b/downstream/modules/automation-hub/proc-assigning-roles.adoc
@@ -9,7 +9,7 @@ You can assign roles to groups, giving users access to specific features in the 
 
 .Prerequisites
 
-You are signed in as a `hubadmin` user.
+* You are signed in as a `hubadmin` user.
 
 .Procedure
 


### PR DESCRIPTION
…klist (#1116)

* formatting and link text updates for pre-release check

* adds a bullet point to prereq section in central auth guide

This PR pushes changes to the 2.4 release. 