### PR TITLE
Making edits to the description lists of user guide

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -24,7 +24,7 @@ of the {ControllerNameStart} documentation.
 . From the navigation panel, select menu:Decision Environments[Create decision environment].
 . Insert the following: 
 +
-Name::
+Name:: Insert the name.
 Description:: This field is optional.
 Image:: This is the full image location, including the container registry, image name, and version tag.
 Credential:: This field is optional. This is the token needed to utilize the decision environment image. 

--- a/downstream/modules/eda/proc-eda-set-up-new-project.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-project.adoc
@@ -11,8 +11,8 @@ Projects are a logical collection of rulebooks.
 * You are logged in to the {EDAcontroller} Dashboard as a Content Consumer.
 * You have set up a credential, if necessary. 
 For more information, refer to the link:https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html[Credentials]
-section of the {ControllerNameStart} documentation.
-* You have an existing repository containing rulebooks that are integrated with playbooks contained in a repository to be used by Automation Controller.
+section of the {ControllerName} documentation.
+* You have an existing repository containing rulebooks that are integrated with playbooks contained in a repository to be used by {ControllerName}.
 
 == Procedure
 
@@ -20,7 +20,7 @@ section of the {ControllerNameStart} documentation.
 . From the navigation panel, select menu:Projects[Create project].
 . Insert the following:
 +
-Name::
+Name:: Enter project name.
 Description:: This field is optional.
 SCM type:: Git is the only SCM type available for use.
 SCM URL:: HTTP[S] protocol address of a repository, such as GitHub or GitLab. 

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -19,7 +19,7 @@ Rulebook activations are rulebooks that have been activated to run.
 . From the navigation panel, select menu:Rulebook Activations[Create rulebook activation].
 . Insert the following: 
 +
-Name::
+Name:: Insert the name.
 Description:: This field is optional.
 Project:: Projects are a logical collection of rulebooks.
 Rulebook:: Rulebooks will be shown according to the project selected.

--- a/downstream/modules/eda/proc-eda-set-up-token.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-token.adoc
@@ -19,7 +19,7 @@
 . Select menu:Controller Tokens[Create controller token].
 . Insert the following: 
 +
-Name::
+Name:: Insert the name.
 Description:: This field is optional.
 Token::
 . Select btn:[Create controller token].


### PR DESCRIPTION
Edits made to descriptions lists that didn't render in Pantheon

Correcting "Description" lists in EDA controller user guide

https://issues.redhat.com/browse/AAP-13542

Affects `titles/eda-user-guide