### PR TITLE
Fix broken links that use PlatformVers attribute in 2.4 docs

### DIFF
--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -27,7 +27,7 @@ If missing both content sets will be uploaded.
 If you are not using the bundle installer, a standalone tarball, `ansible-validated-content-bundle-1.tar.gz` can be used instead.
 The standalone tarball can also be used later to update validated contents later in any environment, when a newer tarball becomes available, and without having to re-run the bundle installer.
 
-To obtain the tarball, navigate to link:https://access.redhat.com/downloads/content/480[{PlatformNameShort} Downloads] and select *Ansible Validated Content*.
+To obtain the tarball, navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page and select *Ansible Validated Content*.
 
 You require the following variables to run the playbook. 
 

--- a/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
@@ -19,7 +19,7 @@ include::platform/proc-import-mesh-ca.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/index#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
@@ -19,7 +19,7 @@ include::platform/proc-import-mesh-ca.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/index#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements[{PlatformName} System Requirements]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -14,5 +14,5 @@ As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {B
 [role="_additional-resources"]
 .Additional resources
 
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
+* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Ansible Navigator Creator Guide] for more on using {Navigator}.
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is no Red Hat subscription attached to the node, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#proc-attaching-subscriptions_planning[attaching your {PlatformNameShort} subscription] for more information.
+If there is no Red Hat subscription attached to the node, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index[Attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
+++ b/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
@@ -19,7 +19,7 @@ Choose the {PlatformName} (AAP) installer if your Red Hat Enterprise Linux envir
 
 *Tarball install*
 
-. Navigate to the https://access.redhat.com/downloads/content/480[Red Hat Ansible Automation Platform download] page.
+. Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup*.
 . Extract the files:
 +
@@ -52,7 +52,7 @@ When you use the RPM installer, the files are placed under the `/opt/ansible-aut
 
 Use the {PlatformName} (AAP) *Bundle* installer if you are unable to access the internet, or would prefer not to install separate components and dependencies from online repositories. Access to Red Hat Enterprise Linux repositories is still needed. All other dependencies are included in the tar archive.
 
-. Navigate to the https://access.redhat.com/downloads/content/480[Red Hat Ansible Automation Platform download] page.
+. Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup Bundle*.
 . Extract the files:
 +

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -65,5 +65,5 @@ generate_automationhub_token=
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#supported_installation_scenarios[{PlatformName} Installation Guide]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario[Installing {PlatformName}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/assembly-deprovisioning-mesh[Deprovisioning individual nodes or instance groups]

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -9,7 +9,7 @@ The “bundle” version is strongly recommended for disconnected installations 
 
 == Downloading the Setup Bundle
 
-. Download the AAP setup bundle package by navigating to the https://access.redhat.com/downloads/content/480[Red Hat Ansible Automation Platform download] page and clicking btn:[Download Now] for the Ansible Automation Platform {PlatformVers} Setup Bundle.
+. Download the AAP setup bundle package by navigating to the link:{PlatformDownloadUrl}[{PlatformName} download] page and clicking btn:[Download Now] for the Ansible Automation Platform {PlatformVers} Setup Bundle.
 
 === Installing the Setup Bundle
 

--- a/downstream/modules/platform/proc-installing-with-internet.adoc
+++ b/downstream/modules/platform/proc-installing-with-internet.adoc
@@ -10,7 +10,7 @@ Choose the {PlatformName} (AAP) installer if your Red Hat Enterprise Linux envir
 
 .Tarball install
 
-. Navigate to the https://access.redhat.com/downloads/content/480[Red Hat Ansible Automation Platform download] page.
+. Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup*.
 . Extract the files:
 +

--- a/downstream/modules/platform/proc-installing-without-internet.adoc
+++ b/downstream/modules/platform/proc-installing-without-internet.adoc
@@ -7,7 +7,7 @@
 Use the {PlatformName} (AAP) *Bundle* installer if you are unable to access the internet, or would prefer not to install separate components and dependencies from online repositories. Access to Red Hat Enterprise Linux repositories is still needed. All other dependencies are included in the tar archive.
 
 .Procedure
-. Navigate to https://access.redhat.com/downloads/content/480
+. Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup Bundle*.
 . Extract the files:
 +

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -4,7 +4,7 @@
 
 To upgrade your instance of Ansible Tower to {PlatformNameShort} {PlatformVers}, copy the `inventory` file from your original Tower instance to your new Tower instance and run the installer. The {PlatformName} installer detects a pre-{PlatformVers} and offers an upgraded inventory file to continue with the upgrade process:
 
-. Download the latest installer for {PlatformName} from the link:https://access.redhat.com/downloads/content/480[Red Hat Customer Portal].
+. Download the latest installer for {PlatformName} from the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Extract the files:
 +
 [subs="+quotes"]

--- a/downstream/modules/platform/ref-hub-configs.adoc
+++ b/downstream/modules/platform/ref-hub-configs.adoc
@@ -9,6 +9,6 @@ See the following resources to explore additional {HubName} configurations.
 |====
 |Resource link|Description
 |link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}]|Configure user access for {HubName}
-|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in {HubName}]|Add content to your {HubName}
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_validated_and_ansible_galaxy_content_in_automation_hub/index[Managing Red Hat Certified, validated, and Ansible Galaxy content in {HubName}]|Add content to your {HubName}
 |link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}
 |====

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -63,7 +63,7 @@ You must have a valid Red Hat customer account to access {PlatformNameShort} ins
 Install {PrivateHubName} using the {PlatformNameShort} installer if your Red Hat Enterprise Linux environment is connected to the internet.
 Installing with internet access will retrieve the latest required repositories, packages, and dependencies.
 
-. Navigate to link:https://access.redhat.com/downloads/content/480[Download Red Hat Ansible Automation Platform].
+. Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *{PlatformNameShort} <latest-version> Setup*.
 . Extract the files:
 +


### PR DESCRIPTION
Fix the links in 2.4 that use the `{PlayformVers}` attribute