### PR TITLE
Backport -2.4 -1150 AAP-13585 Correction to EDA variables appendix link in GS w/ EDA guide

### DIFF
--- a/downstream/modules/eda/ref-installing-eda-controller-on-aap.adoc
+++ b/downstream/modules/eda/ref-installing-eda-controller-on-aap.adoc
@@ -14,6 +14,6 @@ To further assist you in getting started with {EDAName}, review the following ex
 Lastly, refer to the following {EDAcontroller}-specific code example and appendix section that have been added to the Red Hat Ansible Automation Platform Installation Guide:
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-eda-controller-with-internal-db_platform-install-scenario[Single Event-Driven Ansible controller node with internal database]
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-eda-controller-variables[Appendix A. 5. Event-Driven Ansible controller variables]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#event-driven-ansible-controller_platform-install-scenario[Appendix A. 5. Event-Driven Ansible controller variables]
 
 

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -1,7 +1,7 @@
 
 [id="event-driven-ansible-controller_{context}"]
 = {EDAcontroller} variables
-
+ 
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description* 


### PR DESCRIPTION
Last link to EDA variables appendix in Chap 3 of the "Getting Started with EDA Guide" was landing at the top of the Appendix section of the Installation Guide. Updated to land in Appendix 5 in the Installation Guide where the EDA variables are.