### PR TITLE
Delete hidden characters (#1156)

### DIFF
--- a/downstream/archive/archived-modules/platform/ref-copyright.adoc
+++ b/downstream/archive/archived-modules/platform/ref-copyright.adoc
@@ -1,9 +1,8 @@
 = Copyright © Red Hat, Inc.
 
-
 Ansible, Ansible Tower, Red Hat, and {RHEL} are trademarks of Red Hat, Inc., registered in the United States and other countries.
 
-If you distribute this document, or a modified version of it, you must provide attribution to Red Hat, Inc. and provide a link to the original version. 
+If you distribute this document, or a modified version of it, you must provide attribution to Red Hat, Inc. and provide a link to the original version.
 
 **Third Party Rights**
 
@@ -15,7 +14,7 @@ Microsoft, Windows, Windows Azure, and Internet Explore are trademarks of Micros
 
 VMware is a registered trademark or trademark of VMware, Inc.
 
-Rackspace trademarks, service marks, logos and domain names are either common-law trademarks/service marks or registered trademarks/service marks of Rackspace US, Inc., or its subsidiaries, and are protected by trademark and other laws in the United States and other countries. 
+Rackspace trademarks, service marks, logos and domain names are either common-law trademarks/service marks or registered trademarks/service marks of Rackspace US, Inc., or its subsidiaries, and are protected by trademark and other laws in the United States and other countries.
 
 Amazon Web Services", "AWS", "Amazon EC2", and "EC2”, are trademarks of Amazon Web Services, Inc. or its affiliates.
 
@@ -28,3 +27,4 @@ Safari® is a registered trademark of Apple, Inc.
 Firefox® is a registered trademark of the Mozilla Foundation.
 
 All other trademarks are the property of their respective owners.
+

--- a/downstream/modules/builder/con-about-ee.adoc
+++ b/downstream/modules/builder/con-about-ee.adoc
@@ -1,17 +1,11 @@
-////
-Base the file name and the ID on the module title. For example:
-* file name: con-my-concept-module-a.adoc
-* ID: [id="con-my-concept-module-a_{context}"]
-* Title: = My concept module A
-////
-
 [id="con-about-ee"]
 
 = About {ExecEnvName}
 
 [role="_abstract"]
 
-{ExecEnvNameStart} are container images on which all automation in {PlatformName} is run. {ExecEnvNameStart} create a common language for communicating automation dependencies, and provide a standard way to build and distribute the automation environment.
+{ExecEnvNameStart} are container images on which all automation in {PlatformName} is run.
+{ExecEnvNameStart} create a common language for communicating automation dependencies, and provide a standard way to build and distribute the automation environment.
 
 An {ExecEnvNameSing} is expected to contain the following:
 

--- a/downstream/modules/builder/con-why-ee.adoc
+++ b/downstream/modules/builder/con-why-ee.adoc
@@ -2,12 +2,15 @@
 
 = Why use {ExecEnvName}?
 
-With {ExecEnvName}, {PlatformName} has transitioned to a distributed architecture by separating the control plane from the execution plane. Keeping automation execution independent of the control plane results in faster development cycles and improves scalability, reliability, and portability across environments. {PlatformName} also includes access to Ansible content tools, making it easy to build and manage {ExecEnvName}.
+With {ExecEnvName}, {PlatformName} has transitioned to a distributed architecture by separating the control plane from the execution plane.
+Keeping automation execution independent of the control plane results in faster development cycles and improves scalability, reliability, and portability across environments.
+{PlatformName} also includes access to Ansible content tools, making it easy to build and manage {ExecEnvName}.
 
 In addition to speed, portability, and flexibility, {ExecEnvName} provide the following benefits:
 
 * They ensure that automation runs consistently across multiple platforms and make it possible to incorporate system-level dependencies and collection-based content.
 * They give {PlatformName} administrators the ability to provide and manage automation environments to meet the needs of different teams.
 * They allow automation to be easily scaled and shared between teams by providing a standard way of building and distributing the automation environment.
-* They enable automation teams to define, build, and update their automation environments themselves. 
+* They enable automation teams to define, build, and update their automation environments themselves.
 * {ExecEnvNameStart} provide a common language to communicate automation dependencies.
+

--- a/downstream/modules/dev-guide/proc-create-role.adoc
+++ b/downstream/modules/dev-guide/proc-create-role.adoc
@@ -17,15 +17,14 @@ Standalone roles outside of Collections are still supported, but new roles shoul
 
 . In your terminal, navigate to the `roles` directory inside a collection.
 . Create a role called `role_name` inside the collection created previously:
-
 +
 -----
 $ ansible-galaxy role init my_role
 -----
 +
-
 The collection now contains a role named `my_role` inside the `roles` directory:
-
++
+-----
     ~/.ansible/collections/ansible_collections/<my_namespace>/<my_collection_name>
     ...
     └── roles/
@@ -33,21 +32,22 @@ The collection now contains a role named `my_role` inside the `roles` directory:
             ├── .travis.yml
             ├── README.md
             ├── defaults/
-            │   └── main.yml
+            │   └── main.yml
             ├── files/
             ├── handlers/
-            │   └── main.yml
+            │   └── main.yml
             ├── meta/
-            │   └── main.yml
+            │   └── main.yml
             ├── tasks/
-            │   └── main.yml
+            │   └── main.yml
             ├── templates/
             ├── tests/
-            │   ├── inventory
-            │   └── test.yml
+            │   ├── inventory
+            │   └── test.yml
             └── vars/
                 └── main.yml
-
+-----
++
 . A custom role skeleton directory can be supplied using the `--role-skeleton` argument. This allows organizations to create standardized templates for new roles to suit their needs.
 
     ansible-galaxy role init my_role --role-skeleton ~/role_skeleton

--- a/downstream/modules/platform/con-about-operator.adoc
+++ b/downstream/modules/platform/con-about-operator.adoc
@@ -4,8 +4,10 @@
 
 [role="_abstract"]
 The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
-The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub. It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments. 
+The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub.
+It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments.
 
 Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments.
 
 You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
+

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -43,7 +43,7 @@ metadata:
   name: ansible-automation-platform
   namespace: ansible-automation-platform
 spec:
-  channel: 'stable-2.3'
+  channel: 'stable-2.4'
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators
@@ -59,7 +59,7 @@ spec:
 
 -----
 +
-This file creates a `Subscription` object called `_ansible-automation-platform_` that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` operator.
+This file creates a `Subscription` object called `_ansible-automation-platform_` that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` operator.
 +
 It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace.
 +
@@ -86,3 +86,4 @@ $ oc get subs -n ansible-automation-platform
 -----
 
 For further information about subscribing namespaces to operators, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.
+


### PR DESCRIPTION
Backports #1156 to 2.4: Delete hidden characters.

To locate hidden characters in the repo, run the following command from the `downstream` directory:
```
find  . -name "*.adoc" -exec pcregrep --color='auto' -n '[\xa0]'  {} + ;
```
The above command works on a Mac.

The hidden character is an NBSP character. It's usually introduced when you copy text from a Google doc into an editor.