### PR TITLE
Backport pull request #1163 from main to 2.4

### DIFF
--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -30,7 +30,7 @@ You can use the following configuration YAML keys with Ansible Builder version 3
 ** version
 
 For more information about using Ansible Builder version 3, see 
-https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Documentation] and https://docs.ansible.com/automation-controller/latest/html/userguide/ee_reference.html[Execution Environment Setup Reference].
+link:https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Documentation] and link:https://docs.ansible.com/automation-controller/latest/html/userguide/ee_reference.html[Execution Environment Setup Reference].
 
 * Ansible Automation Platform 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
 

--- a/downstream/titles/release-notes/topics/controller-440.adoc
+++ b/downstream/titles/release-notes/topics/controller-440.adoc
@@ -9,4 +9,4 @@ The name change reflects these enhancements and the overall position within the 
 
 Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
 
-See link:https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#release-notes-for-4-x[automation controller Release Notes for 4.x] for a full list of new features and enhancements.
+See link:https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#release-notes-for-4-x[Automation Controller Release Notes for 4.x] for a full list of new features and enhancements.

--- a/downstream/titles/release-notes/topics/docs-24.adoc
+++ b/downstream/titles/release-notes/topics/docs-24.adoc
@@ -11,15 +11,15 @@ The documentation set for Red Hat Ansible Automation Platform 2.4 has had signif
 
 * The following documents are created to help you install and use Event-Driven Ansible, the newest capability of Ansible Automation Platform:
 
-** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event_driven_ansible/index[Getting Started with Event-Driven Ansible]
+** link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event-driven_ansible_guide/index[Getting Started with Event-Driven Ansible]
 
-** https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event_driven_ansible_controller_user_guide/index[Event-Driven Ansible User Guide ]
+** link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event Driven Ansible User Guide]
 
-In addition, sections of the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide] 
-and the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] are updated to include instructions for planning and installing Event-Driven Ansible. 
+In addition, sections of the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide] 
+and the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] are updated to include instructions for planning and installing Event-Driven Ansible. 
 
 * The name of the _Managing Red Hat Certified and Ansible Galaxy collections in automation hub Guide_ has changed to include validated content and is now _Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub_.
 
 * The Ansible Automation Platform 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the Ansible Automation Platform versions, instead of their release timeline. 
 
-* The document https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in automation hub. 
+* The document link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in automation hub. 

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -35,6 +35,6 @@ Do not use `yum update` to run upgrades. Use installer instead.
 .Additional resources
 * Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
 
-* For more information on upgrading your Ansible Automation Platform, see the  https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade Guide].
+* For more information on upgrading your Ansible Automation Platform, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
 
-* For procedures related to using the Ansible Automation Platform installer, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].
+* For procedures related to using the Ansible Automation Platform installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].


### PR DESCRIPTION
This PR backports the broken link fixes in AAP 2.4 release notes.
See PR [#1163](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1163) 
