### PR TITLE
2.4 AAP-13660 Fix formatting issues in 2.4 Upgrade guide (#1175)

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -12,7 +12,7 @@ ifdef::context[:parent-context: {context}]
 
 
 
-[role="_abstract"]
+// [role="_abstract"]
 
 include::platform/con-why-ee.adoc[leveloffset=+1]
 
@@ -30,7 +30,7 @@ The below workflow describes how to migrate from legacy venvs to {ExecEnvName} u
 
 include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+// [role="_additional-resources"]
 // Remove comments once 2.2 version of the docs are published.
 //== Additional resources
 


### PR DESCRIPTION
Backports #1175 to 2.4

Affects `/titles/upgrade/`

Fix a formatting issue in Chapter 4. Migrating isolated nodes to execution nodes on the customer portal.
The chapter is surrounded by a box:
![image](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/assets/44700011/9164a3a6-b49c-41cd-8bfc-2428f78b6c90)
