### PR TITLE
Replace acme.org with example.com

### DIFF
--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -24,8 +24,8 @@ This example does not have a host under the database group. This indicates to th
 # hybrid2.example <- this will default to hybrid
 
 [automationcontroller]
-hybrid1.acme.org node_type=hybrid
-controller1.acme.org node_type=control
+hybrid1.example.com node_type=hybrid
+controller1.example.com node_type=control
 
 # Execution Nodes
 # There are two valid node_types that can be assigned for this group.
@@ -38,17 +38,17 @@ controller1.acme.org node_type=control
 # execution2.example <- this will default to execution
 
 [execution_nodes]
-hop1.acme.org node_type=hop
-execution1.acme.org node_type=execution
+hop1.example.com node_type=hop
+execution1.example.com node_type=execution
 
 [automationhub]
-automationhub.acme.org
+automationhub.example.com
 
 [database]
 
 [all:vars]
 admin_password='<password>'
-pg_host='data.acme.org'
+pg_host='data.example.com'
 pg_port='5432'
 pg_database='awx'
 pg_username='awx'
@@ -66,7 +66,7 @@ receptor_listener_port=27199
 # Automation Hub Configuration
 #
 automationhub_admin_password='<password>'
-automationhub_pg_host='data.acme.org'
+automationhub_pg_host='data.example.com'
 automationhub_pg_port='5432'
 automationhub_pg_database='automationhub'
 automationhub_pg_username='automationhub'
@@ -102,7 +102,7 @@ automationhub_pg_sslmode='prefer'
 
 automationedacontroller_admin_password='<eda-password>'
 
-automationedacontroller_pg_host='data.acme.org'
+automationedacontroller_pg_host='data.example.com'
 automationedacontroller_pg_port=5432
 
 automationedacontroller_pg_database='automationedacontroller'

--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -21,8 +21,8 @@ Use this example to populate the inventory file to install {PlatformNameShort}. 
 # hybrid2.example <- this will default to hybrid
 
 [automationcontroller]
-controller1.acme.org node_type=control
-controller2.acme.org node_type=control
+controller1.example.com node_type=control
+controller2.example.com node_type=control
 
 # Execution Nodes
 # There are two valid node_types that can be assigned for this group.
@@ -35,18 +35,18 @@ controller2.acme.org node_type=control
 # execution2.example <- this will default to execution
 
 [execution_nodes]
-execution1.acme.org node_type=execution
-execution2.acme.org node_type=execution
+execution1.example.com node_type=execution
+execution2.example.com node_type=execution
 
 [automationhub]
-automationhub.acme.org
+automationhub.exaample.com
 
 [database]
-data.acme.org
+data.example.com
 
 [all:vars]
 admin_password='<password>'
-pg_host='data.acme.org'
+pg_host='data.example.com'
 pg_port='5432'
 pg_database='awx'
 pg_username='awx'
@@ -64,7 +64,7 @@ receptor_listener_port=27199
 # Automation Hub Configuration
 #
 automationhub_admin_password='<password>'
-automationhub_pg_host='data.acme.org'
+automationhub_pg_host='data.example.com
 automationhub_pg_port='5432'
 automationhub_pg_database='automationhub'
 automationhub_pg_username='automationhub'
@@ -100,7 +100,7 @@ automationhub_pg_sslmode='prefer'
 
 automationedacontroller_admin_password='<eda-password>'
 
-automationedacontroller_pg_host='data.acme.org'
+automationedacontroller_pg_host='data.example.com'
 automationedacontroller_pg_port=5432
 
 automationedacontroller_pg_database='automationedacontroller'

--- a/downstream/modules/platform/ref-platform-non-inst-database-inventory.adoc
+++ b/downstream/modules/platform/ref-platform-non-inst-database-inventory.adoc
@@ -10,7 +10,7 @@ This installation inventory file includes a single {ControllerName} node with an
 
 -----
 [automationcontroller]
-controller.acme.org
+controller.example.com
 
 [all:vars]
 admin_password='<password>'

--- a/downstream/modules/platform/ref-single-controller-ext-customer-managed-db.adoc
+++ b/downstream/modules/platform/ref-single-controller-ext-customer-managed-db.adoc
@@ -14,14 +14,14 @@ This example does not have a host under the database group. This indicates to th
 
 -----
 [automationcontroller]
-controller.acme.org
+controller.example.com
 
 [database]
 
 [all:vars]
 admin_password='<password>'
 
-pg_host='data.acme.org'
+pg_host='data.example.com'
 pg_port='5432'
 pg_database='awx'
 pg_username='awx'

--- a/downstream/modules/platform/ref-single-controller-ext-installer-managed-db.adoc
+++ b/downstream/modules/platform/ref-single-controller-ext-installer-managed-db.adoc
@@ -9,14 +9,14 @@ Use this example to populate the inventory file to install {PlatformName}. This 
 
 -----
 [automationcontroller]
-controller.acme.org
+controller.example.com
 
 [database]
-data.acme.org
+data.example.com
 
 [all:vars]
 admin_password='<password>'
-pg_host='data.acme.org'
+pg_host='data.example.com'
 pg_port='5432'
 pg_database='awx'
 pg_username='awx'

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -27,7 +27,7 @@ automationedacontroller_pg_password='<password>'
 # This URL is required if there is no Automation Controller configured
 # in inventory.
 #
-automation_controller_main_url = 'https://controller.example.org/'
+automation_controller_main_url = 'https://controller.example.com/'
  
 
 # Boolean flag used to verify Automation Controller's

--- a/downstream/modules/platform/ref-standalone-hub-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-ext-database-customer-provided.adoc
@@ -14,7 +14,7 @@ This example does not have a host under the database group. This indicates to th
 [automationcontroller]
 
 [automationhub]
-automationhub.acme.org
+automationhub.example.com
 
 [database]
 
@@ -25,7 +25,7 @@ registry_password='<registry password>'
 
 automationhub_admin_password= <PASSWORD>
 
-automationhub_pg_host='data.acme.org'
+automationhub_pg_host='data.example.com'
 automationhub_pg_port='5432'
 
 automationhub_pg_database='automationhub'

--- a/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
@@ -12,7 +12,7 @@ Use this example to populate the inventory file to deploy a single instance of {
 automationhub.example.com
 
 [database]
-data.acme.org
+data.example.com
 
 [all:vars]
 registry_url='registry.redhat.io'

--- a/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
@@ -9,7 +9,7 @@ Use this example to populate the inventory file to deploy a single instance of {
 [automationcontroller]
 
 [automationhub]
-automationhub.acme.org
+automationhub.example.com
 
 [database]
 data.acme.org
@@ -21,7 +21,7 @@ registry_password='<registry password>'
 
 automationhub_admin_password= <PASSWORD>
 
-automationhub_pg_host='data.acme.org'
+automationhub_pg_host='data.example.com'
 automationhub_pg_port='5432'
 
 automationhub_pg_database='automationhub'

--- a/downstream/modules/platform/ref-standalone-hub-inventory.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-inventory.adoc
@@ -11,7 +11,7 @@ Use this example to populate the inventory file to deploy a standalone instance 
 
 
 [automationhub]
-automationhub.acme.org ansible_connection=local
+automationhub.example.com ansible_connection=local
 
 [all:vars]
 registry_url='registry.redhat.io'


### PR DESCRIPTION
Mainly in inventory file examples

[DDF] acme.org is not owned by Red Hat, please use example.com or similar, explicitly reserved for documentation, domains

https://issues.redhat.com/browse/AAP-13632