### PR TITLE
Corrected ansible version (#1184)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -16,7 +16,7 @@ h| Subscription | Valid Red Hat Ansible Automation Platform |
 
 h| OS | Red Hat Enterprise Linux 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version {AnsibleCoreVers} required | If Ansible is not already present on the system, the setup playbook will install `ansible-core` 2.14.
+h| Ansible | version 2.14 (to install) | {PlatformNameShort} ships with execution environments that contain ansible-core {AnsibleCoreVers}.
 
 h| Python | 3.8 or later |
 


### PR DESCRIPTION
Updated table entries

[DDF] If Ansible version 2.15 is *required*, I would expect the setup playbook to install that, and not 2.14?

https://issues.redhat.com/browse/AAP-13633