### PR TITLE
AAP-12941A updated wording within link title (#1110)

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -23,7 +23,7 @@ There are a number of supported installation scenarios for {PlatformName}. To in
 * xref:ref-single-controller-ext-installer-managed-db_platform-install-scenario[Single {ControllerName} with external (installer managed) database]
 * xref:ref-single-controller-ext-customer-managed-db_platform-install-scenario[Single {ControllerName} with external (customer provided) database]
 * xref:ref-standlone-platform-ext-database-inventory_platform-install-scenario[{PlatformNameShort} with an external (installer managed) database]
-* xref:ref-example-platform-ext-database-customer-provided_platform-install-scenario[{PlatformNameShort} with an external (customer managed) database]
+* xref:ref-example-platform-ext-database-customer-provided_platform-install-scenario[{PlatformNameShort} with an external (customer provided) database]
 * xref:ref-single-eda-controller-with-internal-db_platform-install-scenario[Single {EDAcontroller} node with internal database]
 * xref:ref-standlone-hub-inventory_platform-install-scenario[Standalone {HubName} with internal database]
 * xref:ref-standlone-hub-ext-database-inventory_platform-install-scenario[Single {ControllerName} with external (installer managed) database]


### PR DESCRIPTION
2.4 Backport of [PR 1110](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1110)

[AAP-12941](https://issues.redhat.com/browse/AAP-12941)

Change made in [Ch. 2 Installing Red Hat Automation Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#doc-wrapper)

Original Behavior

Incorrect link title:

[Ansible Automation Platform with an external (customer managed) database](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-example-platform-ext-database-customer-provided_platform-install-scenario)

New Behavior

Link now titled as:

[Ansible Automation Platform with an external (customer provided) database](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-example-platform-ext-database-customer-provided_platform-install-scenario)