### PR TITLE
AAP-13734 Updates to code samples for sections 2.1.1.4 - 2.1.1.6 in the Installation Guide

### DIFF
--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -43,7 +43,8 @@ execution1.example.com node_type=execution
 
 [automationhub]
 automationhub.example.com
-
+[automationedacontroller]
+eda.example.com
 [database]
 
 [all:vars]
@@ -99,13 +100,6 @@ automationhub_pg_sslmode='prefer'
 
 # Automation EDA Controller Configuration
 #
-
-[automationedacontroller]
-eda.example.com
-
-[database]
-
-[all:vars]
 
 automationedacontroller_admin_password='<eda-password>'
 

--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -127,4 +127,29 @@ automationedacontroller_pg_password='<password>'
 #
 # automationedacontroller_controller_verify_ssl = true
 
+# SSL-related variables
+
+# If set, this will install a custom CA certificate to the system trust store.
+# custom_ca_cert=/path/to/ca.crt
+
+# Certificate and key to install in nginx for the web UI and API
+# web_server_ssl_cert=/path/to/tower.cert
+# web_server_ssl_key=/path/to/tower.key
+
+# Certificate and key to install in Automation Hub node
+# automationhub_ssl_cert=/path/to/automationhub.cert
+# automationhub_ssl_key=/path/to/automationhub.key
+
+# Server-side SSL settings for PostgreSQL (when we are installing it).
+# postgres_use_ssl=False
+# postgres_ssl_cert=/path/to/pgsql.crt
+# postgres_ssl_key=/path/to/pgsql.key
+
+# Keystore file to install in SSO node
+# sso_custom_keystore_file='/path/to/sso.jks'
+
+# The default install will deploy SSO with sso_use_https=True
+# Keystore password is required for https enabled SSO
+sso_keystore_password=''
+
 -----

--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -100,6 +100,13 @@ automationhub_pg_sslmode='prefer'
 # Automation EDA Controller Configuration
 #
 
+[automationedacontroller]
+eda.example.com
+
+[database]
+
+[all:vars]
+
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host='data.example.com'
@@ -120,28 +127,4 @@ automationedacontroller_pg_password='<password>'
 #
 # automationedacontroller_controller_verify_ssl = true
 
-# SSL-related variables
-
-# If set, this will install a custom CA certificate to the system trust store.
-# custom_ca_cert=/path/to/ca.crt
-
-# Certificate and key to install in nginx for the web UI and API
-# web_server_ssl_cert=/path/to/tower.cert
-# web_server_ssl_key=/path/to/tower.key
-
-# Certificate and key to install in Automation Hub node
-# automationhub_ssl_cert=/path/to/automationhub.cert
-# automationhub_ssl_key=/path/to/automationhub.key
-
-# Server-side SSL settings for PostgreSQL (when we are installing it).
-# postgres_use_ssl=False
-# postgres_ssl_cert=/path/to/pgsql.crt
-# postgres_ssl_key=/path/to/pgsql.key
-
-# Keystore file to install in SSO node
-# sso_custom_keystore_file='/path/to/sso.jks'
-
-# The default install will deploy SSO with sso_use_https=True
-# Keystore password is required for https enabled SSO
-sso_keystore_password=''
 -----

--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -98,6 +98,13 @@ automationhub_pg_sslmode='prefer'
 # Automation EDA Controller Configuration
 #
 
+[automationedacontroller]
+eda.example.com
+
+[database]
+
+[all:vars]
+
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host='data.example.com'
@@ -117,30 +124,5 @@ automationedacontroller_pg_password='<password>'
 # web certificates when making calls from Automation EDA Controller.
 #
 # automationedacontroller_controller_verify_ssl = true
-
-# SSL-related variables
-
-# If set, this will install a custom CA certificate to the system trust store.
-# custom_ca_cert=/path/to/ca.crt
-
-# Certificate and key to install in nginx for the web UI and API
-# web_server_ssl_cert=/path/to/tower.cert
-# web_server_ssl_key=/path/to/tower.key
-
-# Certificate and key to install in Automation Hub node
-# automationhub_ssl_cert=/path/to/automationhub.cert
-# automationhub_ssl_key=/path/to/automationhub.key
-
-# Server-side SSL settings for PostgreSQL (when we are installing it).
-# postgres_use_ssl=False
-# postgres_ssl_cert=/path/to/pgsql.crt
-# postgres_ssl_key=/path/to/pgsql.key
-
-# Keystore file to install in SSO node
-# sso_custom_keystore_file='/path/to/sso.jks'
-
-# The default install will deploy SSO with sso_use_https=True
-# Keystore password is required for https enabled SSO
-sso_keystore_password=''
 
 -----

--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -125,4 +125,29 @@ automationedacontroller_pg_password='<password>'
 #
 # automationedacontroller_controller_verify_ssl = true
 
+# SSL-related variables
+
+# If set, this will install a custom CA certificate to the system trust store.
+# custom_ca_cert=/path/to/ca.crt
+
+# Certificate and key to install in nginx for the web UI and API
+# web_server_ssl_cert=/path/to/tower.cert
+# web_server_ssl_key=/path/to/tower.key
+
+# Certificate and key to install in Automation Hub node
+# automationhub_ssl_cert=/path/to/automationhub.cert
+# automationhub_ssl_key=/path/to/automationhub.key
+
+# Server-side SSL settings for PostgreSQL (when we are installing it).
+# postgres_use_ssl=False
+# postgres_ssl_cert=/path/to/pgsql.crt
+# postgres_ssl_key=/path/to/pgsql.key
+
+# Keystore file to install in SSO node
+# sso_custom_keystore_file='/path/to/sso.jks'
+
+# The default install will deploy SSO with sso_use_https=True
+# Keystore password is required for https enabled SSO
+sso_keystore_password=''
+
 -----

--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -40,7 +40,8 @@ execution2.example.com node_type=execution
 
 [automationhub]
 automationhub.exaample.com
-
+[automationedacontroller]
+eda.example.com
 [database]
 data.example.com
 
@@ -97,13 +98,6 @@ automationhub_pg_sslmode='prefer'
 
 # Automation EDA Controller Configuration
 #
-
-[automationedacontroller]
-eda.example.com
-
-[database]
-
-[all:vars]
 
 automationedacontroller_admin_password='<eda-password>'
 

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -35,32 +35,6 @@ automation_controller_main_url = 'https://controller.example.com/'
 #
 automationedacontroller_controller_verify_ssl = true
 
-# SSL-related variables
-
-# If set, this will install a custom CA certificate to the system trust store.
-# custom_ca_cert=/path/to/ca.crt
-
-# Certificate and key to install in nginx for the web UI and API
-# web_server_ssl_cert=/path/to/tower.cert
-# web_server_ssl_key=/path/to/tower.key
-
-# Certificate and key to install in Automation Hub node
-# automationhub_ssl_cert=/path/to/automationhub.cert
-# automationhub_ssl_key=/path/to/automationhub.key
-
-# Server-side SSL settings for PostgreSQL (when we are installing it).
-# postgres_use_ssl=False
-# postgres_ssl_cert=/path/to/pgsql.crt
-# postgres_ssl_key=/path/to/pgsql.key
-
-# Keystore file to install in SSO node
-# sso_custom_keystore_file='/path/to/sso.jks'
-
-# The default install will deploy SSO with sso_use_https=True
-# Keystore password is required for https enabled SSO
-sso_keystore_password=''
-
-
 -----
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -14,6 +14,13 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 # Automation EDA Controller Configuration
 #
 
+[automationedacontroller]
+eda.example.com
+
+[database]
+
+[all:vars]
+
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host=''

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -14,13 +14,6 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 # Automation EDA Controller Configuration
 #
 
-[automationedacontroller]
-eda.example.com
-
-[database]
-
-[all:vars]
-
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host=''
@@ -36,13 +29,13 @@ automationedacontroller_pg_password='<password>'
 #
 automation_controller_main_url = 'https://controller.example.com/'
  
-
 # Boolean flag used to verify Automation Controller's
 # web certificates when making calls from Automation EDA Controller.
 #
 automationedacontroller_controller_verify_ssl = true
 
 -----
+
 [role="_additional-resources"]
 .Additional resources
 * For more details on {EDAName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event-driven_ansible_guide/index[Getting Started with Event-Driven Ansible Guide].


### PR DESCRIPTION
Updates to code samples in the Red Hat Ansible Automation Platform Installation Guide, specifically adding the following lines 

[automationedacontroller]
eda.example.com

to the following sections:

- [2.1.1.4](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-standlone-platform-ext-database-inventory_platform-install-scenario) - Lines 46-47
- [2.1.1.5](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-example-platform-ext-database-customer-provided_platform-install-scenario) - Lines 43-44

Also, removed the SSL-related variables from the EDA controller code sample:
- [2.1.1.6](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-single-eda-controller-with-internal-db_platform-install-scenario) - after line 36