### PR TITLE
2.2 Delete empty additional resources section (#1198)

### DIFF
--- a/downstream/modules/security/con-requirements.adoc
+++ b/downstream/modules/security/con-requirements.adoc
@@ -1,18 +1,6 @@
-////
-Base the file name and the ID on the module title. For example:
-* file name: con-my-concept-module-a.adoc
-* ID: [id="con-my-concept-module-a_{context}"]
-* Title: = My concept module A
-////
-
 [id="con-requirements_{context}"]
 
 = Requirements and prerequisites
-
-////
-[role="_abstract"]
-Write a short introductory paragraph that provides an overview of the module. The text that immediately follows the `[role="_abstract"]` tag is used for search metadata.
-////
 
 Before you begin automating your IDPS with Ansible, ensure that you have the proper installations and configurations necessary to successfully manage your IDPS.
 
@@ -21,8 +9,3 @@ Before you begin automating your IDPS with Ansible, ensure that you have the pro
 * IDPS software (Snort) is installed and configured.
 * You have access to the IDPS server (Snort) to enforce new policies.
 
-[role="_additional-resources"]
-.Additional resources
-////
-Optional. Delete if not used.
-////


### PR DESCRIPTION
Backports #1198 to 2.2

Delete empty additional resources section.
It was causing the module following it to be enclosed in a box.

![image](https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/assets/44700011/973bae33-9567-476d-97a9-7aef5b3b42b7)
