### PR TITLE
AAP-14004: Restructured the AAP 2.2 release notes

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -4,13 +4,13 @@ include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 
-include::topics/upgrading.adoc[leveloffset=+1]
-
-[[anchor-may-2022-release]]
-== May 2022 release
+[[anchor-aap_2.2-release]]
+== Red Hat Ansible Automation Platform 2.2
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
 include::topics/aap-22.adoc[leveloffset=+2]
+
+include::topics/aap-221.adoc[leveloffset=+2]
 
 include::topics/hub-450.adoc[leveloffset=+2]
 
@@ -19,139 +19,3 @@ include::topics/catalog-05-2022.adoc[leveloffset=+2]
 include::topics/controller-420.adoc[leveloffset=+2]
 
 include::topics/operator-220.adoc[leveloffset=+2]
-
-
-[[anchor-february-2022-release]]
-== February 2022 release
-
-include::topics/aap-211.adoc[leveloffset=+2]
-
-include::topics/hub-441.adoc[leveloffset=+2]
-
-include::topics/controller-411.adoc[leveloffset=+2]
-
-[[anchor-january-2022-release]]
-== January 2022 release
-
-include::topics/aap-126.adoc[leveloffset=+2]
-
-[[anchor-december-2021-release]]
-== December 2021 release
-
-include::topics/aap-21.adoc[leveloffset=+2]
-
-include::topics/controller-41.adoc[leveloffset=+2]
-
-[[anchor-october-2021-release]]
-== October 2021 release
-
-include::topics/insights-102021.adoc[leveloffset=+2]
-
-[[anchor-september-2021-release]]
-== September 2021 release
-
-include::topics/platform-intro-125.adoc[leveloffset=+2]
-
-include::topics/tower-intro-384.adoc[leveloffset=+2]
-
-include::topics/hub-426.adoc[leveloffset=+2]
-
-[[anchor-july-2021-release]]
-== July 2021 release
-
-include::topics/platform-intro-124.adoc[leveloffset=+2]
-
-include::topics/hub-424.adoc[leveloffset=+2]
-
-[[anchor-june-2021-release]]
-== June 2021 release
-
-=== Red Hat Insights for Red Hat Ansible Automation Platform
-
-include::topics/insights-062021.adoc[leveloffset=+2]
-
-[[anchor-may-2021-release]]
-== May 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.3
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-383.adoc[leveloffset=+3]
-
-include::topics/hub-423.adoc[leveloffset=+3]
-
-[[anchor-mar-2021-release]]
-== March 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.2
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-382.adoc[leveloffset=+3]
-
-include::topics/hub-422.adoc[leveloffset=+3]
-
-[[anchor-jan-2021-release]]
-== January 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.1
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/platform-installer-121.adoc[leveloffset=+3]
-
-include::topics/tower-intro-381.adoc[leveloffset=+3]
-
-include::topics/hub-421.adoc[leveloffset=+3]
-
-
-[[anchor-nov-2020-release]]
-== November 2020 release
-
-=== Red Hat Ansible Automation Platform 1.2.0
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-38.adoc[leveloffset=+3]
-
-include::topics/hub-42.adoc[leveloffset=+3]
-
-include::topics/catalog-11-2020.adoc[leveloffset=+3]
-
-
-
-
-[[anchor-oct-2020-release]]
-== October 2020 release
-
-include::topics/introduction.adoc[leveloffset=+2]
-
-// include::topics/changelog-022020.adoc[leveloffset=+1]
-
-include::topics/new-features-oct-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements-102020.adoc[leveloffset=+2]
-
-include::topics/bugfixes-102020.adoc[leveloffset=+2]
-
-////
-[[anchor-may-2020-release]]
-== May 2020 release
-
-include::topics/new-features-may-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements-052020.adoc[leveloffset=+2]
-
-include::topics/bugfixes-052020.adoc[leveloffset=+2]
-
-
-[[anchor-february-2020-release]]
-== February 2020 release
-
-include::topics/new-features-feb-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements.adoc[leveloffset=+2]
-
-include::topics/bugfixes-022020.adoc[leveloffset=+2]
-////

--- a/release-notes/topics/aap-22.adoc
+++ b/release-notes/topics/aap-22.adoc
@@ -23,7 +23,7 @@ Other noteworthy developer tooling updates include the following:
 
 == Technology Preview
 
-Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Please note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
+Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
 
 Following are the technology preview features: 
 * Added functionality for collection signing and verification in Ansible Builder.

--- a/release-notes/topics/aap-22.adoc
+++ b/release-notes/topics/aap-22.adoc
@@ -3,7 +3,7 @@
 
 Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
-.Enhancements
+== Enhancements
 
 * Added the Automation Services Catalog as an on-prem component for the Ansible Automation Platform. Automation Services Catalog is is a Technology Preview supported feature in Ansible Automation Platform 2.2.
 * Added support for RHEL 9 for automation controller, private automation hub, and private services catalog.
@@ -18,6 +18,23 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 Other noteworthy developer tooling updates include the following:
 
-* `ansible-lint` is available as a technology preview. It is a command-line tool that further enhances the content creation experience by proven practices, patterns, and behaviors. See link:https://github.com/ansible/ansible-navigator/releases/tag/v2.0.0[New features and changes for ansible-navigator] for more information.
 * Automation content navigator v2.0 now includes more features to create content more easily. See link:https://github.com/ansible/ansible-lint/releases/tag/v6.0.0[New features and changes for ansible-lint] for more information.
 * An updated VS Code extension provide language support for creating Ansible content, including smart auto-completion of related playbook content, syntax highlighting, jinja helpers, and direct integrations with supported tooling. See link:https://github.com/ansible/vscode-ansible/blob/main/CHANGELOG.md[New features and enhancements for vscode-ansible] for more information.
+
+== Technology Preview
+
+Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Please note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
+
+Following are the technology preview features: 
+* Added functionality for collection signing and verification in Ansible Builder.
+
+* Added `ansible-lint`, a command-line tool that further enhances the content creation experience by proven practices, patterns, and behaviors. See link:https://github.com/ansible/ansible-navigator/releases/tag/v2.0.0[New features and changes for ansible-navigator] for more information.
+
+* Added Automation Services Catalog, which provides an easy way to extend automation in your Ansible controller to a broader user base. See xref:catalog-05-2022[Automation Services Catalog] for more information.
+
+[role="_additional-resources"]
+.Additional resources
+
+* For the most recent list of technology preview features, see link:https://access.redhat.com/articles/ansible-automation-platform-preview-features[Ansible Automation Platform - Preview Features].
+
+* For more information about support for technology preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].

--- a/release-notes/topics/aap-221.adoc
+++ b/release-notes/topics/aap-221.adoc
@@ -1,0 +1,41 @@
+// This is the release notes for Ansible Automation Platform 2.2.1 release and was added on here as part of AAP release notes restructuring efforts.
+
+[[aap-2.2.1-intro]]
+= Ansible Automation Platform 2.2.1
+
+.Enhancements
+* Modified installer to include the *ansible-builder* image
+* Updated the `openshift-clients` to 4.10.x
+* Enabled users to use certificates located on destination nodes
+* Updated the version to `pulpcore-selinux` 1.3.2
+* Updated the version to `pulp_installer` 3.18
+* Enhanced the copy process of execution environments so that they require less space in the `/tmp` directory
+* Updated RSA key strength for Ansible Automation Platform certificates
+* Removed `redhat.rhv` collection from supported execution environments due to Python dependencies
+* Modified the base images of execution environments so that controller backups are executed in the container
+* Added the capability to configure LDAP with private automation hub
+
+.Bug fixes
+* Fixed an issue where package dependencies were missing on execution nodes
+* The setup log now gets updated when it is run as `non-root` on bastion host
+* The pulp resource manager now gets removed when the Ansible Automation Platform is upgraded from 2.1 to 2.2
+* The `receptor.service` now restarts as expected when you run the `automation-controller-service` commands
+* The installer no longer fails with permission errors in the ``/home/pulp` directory
+* The receptor no longer fails in FIPS mode
+* Installer no longer fails with error in installing the `semanage` dependency
+* Updated the default configuration of `GALAXY_COLLECTION_SIGNING_SERVICE` to `ansible-default` instead of `TRUE`
+* Installation no longer fails due to conflicting `ansible-builder` Python packages
+* Upgrade from Ansible Tower to Ansible Automation Platform 2.1 no longer fails due to non-root user error
+* Controller database no longer gets unpacked on all nodes and cause disk space issues
+* Installation of high availability automation hub no longer fails on a shared Netapp storage
+* Ansible Automation Platform 1.2 to 2.1 upgrade no longer fails with 502 error due to wrong SELinux content set on nginx
+* Installer no longer fails to generate SSO key pair for IPV6
+* The group permissions editor can now be used to set permissions for the group when external authorization is enabled
+* While using automation hub 4.5.0 with central authentication, the hub user interface no longer turns unresponsive when the group permissions are modified
+* Added localization support for *Modules*, *Roles*, *Plugins*, and *Dependencies* counter in container list for both card and list view
+* The *Deprecated* label now appears immediately after an action click or after the page reload on automation hub UI
+* Upon clicking the *Undeprecate* button for a collection on automation hub UI, an alert is displayed stating that the task has started with a link of the task
+* After syncing the Red Hat certified collections and their versions in private automation hub, the UI now correctly displays the release date of the collection and not the synchronization date
+* Updated the default namespace logo to make it appear similar to the Ansible product logo
+* Automation hub UI now displays the selected collection similar to the rest of the selections
+* Reenabled the *Deprecate* button for collections in Insights mode on automation hub UI

--- a/release-notes/topics/aap-221.adoc
+++ b/release-notes/topics/aap-221.adoc
@@ -20,7 +20,7 @@
 * The setup log now gets updated when it is run as `non-root` on bastion host
 * The pulp resource manager now gets removed when the Ansible Automation Platform is upgraded from 2.1 to 2.2
 * The `receptor.service` now restarts as expected when you run the `automation-controller-service` commands
-* The installer no longer fails with permission errors in the ``/home/pulp` directory
+* The installer no longer fails with permission errors in the `/home/pulp` directory
 * The receptor no longer fails in FIPS mode
 * Installer no longer fails with error in installing the `semanage` dependency
 * Updated the default configuration of `GALAXY_COLLECTION_SIGNING_SERVICE` to `ansible-default` instead of `TRUE`

--- a/release-notes/topics/controller-420.adoc
+++ b/release-notes/topics/controller-420.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Controller 4.2, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-420-intro]]
-= Automation Controller 4.2
+= Automation Controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.

--- a/release-notes/topics/hub-450.adoc
+++ b/release-notes/topics/hub-450.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Hub 4.5, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[hub-450-intro]]
-= Automation Hub 4.5
+= Automation Hub
 
 Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 

--- a/release-notes/topics/operator-220.adoc
+++ b/release-notes/topics/operator-220.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation Platform Operator 2.2, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[operator-220-intro]]
-= Automation Platform Operator 2.2
+= Automation Platform Operator
 
 The Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
 

--- a/release-notes/topics/platform-intro.adoc
+++ b/release-notes/topics/platform-intro.adoc
@@ -24,3 +24,18 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
 See link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle] for additional information.
 
+== Upgrading Ansible Automation platform
+
+Use installer to perform upgrades to maintenance versions of Ansible Automation Platform. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+
+[IMPORTANT]
+====
+Do not use `yum update` to run upgrades. Use installer instead.
+====
+
+.Additional resources
+* Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+
+* For more information on upgrading your Ansible Automation Platform, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
+
+* For procedures related to using the Ansible Automation Platform installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].


### PR DESCRIPTION
This PR is to make similar release notes restructuring changes (done in AAP 2.4) in AAP 2.2 release notes.

JIRA: https://issues.redhat.com/browse/AAP-14004

Changes:
As per the release notes restructuring efforts, following changes are made:

- Restructured AAP 2.2 release notes based on AAP versions instead of release date.
- Added section for Technology Preview and combined the Tech. Preview features into a list under that section.
- Removed release numbers of components like controller, hub, and so on.
- Added source file for AAP 2.2.1 release notes (z-stream release).
- Retained only 2.2 specific updates, and removed updates for 2.1 and all earlier versions.
