### PR TITLE
AAP-14005: Restructured the AAP 2.1 release notes

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -4,157 +4,26 @@ include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 
-include::topics/upgrading.adoc[leveloffset=+1]
-
-[[anchor-december-2022-release]]
-== December 2022 release
+[[anchor-aap_2.1-release]]
+== Red Hat Ansible Automation Platform 2.1
 This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
-
-include::topics/aap-214.adoc[leveloffset=+2]
-
-include::topics/hub-443.adoc[leveloffset=+2]
-
-include::topics/controller-414.adoc[leveloffset=+2]
-
-[[anchor-august-2022-release]]
-== August 2022 release
- 
-include::topics/aap-213.adoc[leveloffset=+2]
-
-[[anchor-april-2022-release]]
-== April 2022 release
- 
-include::topics/aap-212.adoc[leveloffset=+2]
-
-[[anchor-february-2022-release]]
-== February 2022 release
-
-include::topics/aap-211.adoc[leveloffset=+2]
-
-include::topics/hub-441.adoc[leveloffset=+2]
-
-include::topics/controller-411.adoc[leveloffset=+2]
-
-[[anchor-january-2022-release]]
-== January 2022 release
-
-include::topics/aap-126.adoc[leveloffset=+2]
-
-[[anchor-december-2021-release]]
-== December 2021 release
 
 include::topics/aap-21.adoc[leveloffset=+2]
 
+include::topics/aap-211.adoc[leveloffset=+2]
+
+include::topics/aap-212.adoc[leveloffset=+2]
+
+include::topics/aap-213.adoc[leveloffset=+2]
+
+include::topics/aap-214.adoc[leveloffset=+2]
+
+include::topics/hub-441.adoc[leveloffset=+2]
+
+include::topics/hub-443.adoc[leveloffset=+3]
+
 include::topics/controller-41.adoc[leveloffset=+2]
 
-[[anchor-october-2021-release]]
-== October 2021 release
+include::topics/controller-411.adoc[leveloffset=+3]
 
-include::topics/insights-102021.adoc[leveloffset=+2]
-
-[[anchor-september-2021-release]]
-== September 2021 release
-
-include::topics/platform-intro-125.adoc[leveloffset=+2]
-
-include::topics/tower-intro-384.adoc[leveloffset=+2]
-
-include::topics/hub-426.adoc[leveloffset=+2]
-
-[[anchor-july-2021-release]]
-== July 2021 release
-
-include::topics/platform-intro-124.adoc[leveloffset=+2]
-
-include::topics/hub-424.adoc[leveloffset=+2]
-
-[[anchor-june-2021-release]]
-== June 2021 release
-
-=== Red Hat Insights for Red Hat Ansible Automation Platform
-
-include::topics/insights-062021.adoc[leveloffset=+2]
-
-[[anchor-may-2021-release]]
-== May 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.3
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-383.adoc[leveloffset=+3]
-
-include::topics/hub-423.adoc[leveloffset=+3]
-
-[[anchor-mar-2021-release]]
-== March 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.2
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-382.adoc[leveloffset=+3]
-
-include::topics/hub-422.adoc[leveloffset=+3]
-
-[[anchor-jan-2021-release]]
-== January 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.1
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/platform-installer-121.adoc[leveloffset=+3]
-
-include::topics/tower-intro-381.adoc[leveloffset=+3]
-
-include::topics/hub-421.adoc[leveloffset=+3]
-
-
-[[anchor-nov-2020-release]]
-== November 2020 release
-
-=== Red Hat Ansible Automation Platform 1.2.0
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-38.adoc[leveloffset=+3]
-
-include::topics/hub-42.adoc[leveloffset=+3]
-
-include::topics/catalog-11-2020.adoc[leveloffset=+3]
-
-
-[[anchor-oct-2020-release]]
-== October 2020 release
-
-include::topics/introduction.adoc[leveloffset=+2]
-
-// include::topics/changelog-022020.adoc[leveloffset=+1]
-
-include::topics/new-features-oct-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements-102020.adoc[leveloffset=+2]
-
-include::topics/bugfixes-102020.adoc[leveloffset=+2]
-
-////
-[[anchor-may-2020-release]]
-== May 2020 release
-
-include::topics/new-features-may-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements-052020.adoc[leveloffset=+2]
-
-include::topics/bugfixes-052020.adoc[leveloffset=+2]
-
-
-[[anchor-february-2020-release]]
-== February 2020 release
-
-include::topics/new-features-feb-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements.adoc[leveloffset=+2]
-
-include::topics/bugfixes-022020.adoc[leveloffset=+2]
-////
+include::topics/controller-414.adoc[leveloffset=+3]

--- a/release-notes/topics/aap-21.adoc
+++ b/release-notes/topics/aap-21.adoc
@@ -3,7 +3,7 @@
 
 Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
-.Enhancements
+== Enhancements
 
 * Automation Mesh introduces separate execution capacity and update your cluster without downtime with Automation Mesh that connects the cluster with a flexible communication method using receptor
 * The platform installer can deploy a Highly Available (HA) Automation Hub cluster

--- a/release-notes/topics/aap-211.adoc
+++ b/release-notes/topics/aap-211.adoc
@@ -1,14 +1,14 @@
 [[aap-2.1.1-intro]]
 = Ansible Automation Platform 2.1.1
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
-.Enhancements and bug fixes
+.Enhancements
 
 * Added OCP 4.10 compatibility
 * Added support for HTTP proxy when pushing execution environment images
 * Added ability to configure nginx headers on Controller
 * Changed the setup.log file to no longer be world readable
+
+.Bug fixes
 * Fixed an issue during controller deployment where the web-container will fail to start up, resulting in a failed installation
 * Fixed a Server Error 500 that occurs after an Operator upgrade on OCP
 * Updated ansible-hub-ui to use a changelog

--- a/release-notes/topics/aap-212.adoc
+++ b/release-notes/topics/aap-212.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.2-intro]]
 = Ansible Automation Platform 2.1.2
  
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
- 
 .Enhancements
 * Added architecture support labels for the Ansible Automation Platform operator
 * Updated to Receptor 1.2.1 on all supported versions of the Ansible Automation Platform

--- a/release-notes/topics/aap-213.adoc
+++ b/release-notes/topics/aap-213.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.3-intro]]
 = Ansible Automation Platform 2.1.3
  
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
- 
 .Enhancements
 * Updated the version to `Openshift-clients` 4.10.x
 * Updated the version to `pulpcore-selinux` 1.3.2

--- a/release-notes/topics/aap-214.adoc
+++ b/release-notes/topics/aap-214.adoc
@@ -1,8 +1,6 @@
 [[aap-2.1.4-intro]]
 = Ansible Automation Platform 2.1.4
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
-
 .Enhancements
 * Rebuilt the bundle installer to pick up the latest python-pulp-container rpm and container images.
 * Updated RSA key strength for Ansible Automation Platform certificates.

--- a/release-notes/topics/controller-41.adoc
+++ b/release-notes/topics/controller-41.adoc
@@ -1,5 +1,7 @@
+// This is the release notes for Automation controller 4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-41-intro]]
-= Automation controller 4.1
+= Automation controller
 
 Automation controller replaces Ansible Tower.
 Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
@@ -7,15 +9,13 @@ The name change reflects these enhancements and the overall position within the 
 
 Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
 
-
-.New features
+.Automation controller 4.1 new features and enhancements
 
 * Separate control and execution layers.
 * Automation execution environments are container images that provide a standardized way to build and distribute environments where automation runs.
 * Automation mesh allows distributed execution across on-premises environments, the hybrid cloud, and the edge. It replaces Ansible Tower and isolated nodes.
 
-
-.Removed
+.Automation controller 4.1 deprecated and removed features
 
 * Support for custom Python virtual environments for execution.
 

--- a/release-notes/topics/controller-411.adoc
+++ b/release-notes/topics/controller-411.adoc
@@ -1,13 +1,8 @@
+// This is the release notes for Automation controller 4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-411-intro]]
-= Automation controller 4.1.1
 
-Automation controller replaces Ansible Tower.
-Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
-The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
-
-Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
-
-.Enhancements and Bug fixes
+.Automation controller 4.1.1 Enhancements and Bug fixes
 
 * Added the ability to specify additional nginx headers
 * Fixed analytics gathering to collect all the data the controller needed to collect

--- a/release-notes/topics/controller-414.adoc
+++ b/release-notes/topics/controller-414.adoc
@@ -1,12 +1,7 @@
+// This is the release notes for Automation controller 4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[controller-414-intro]]
-= Automation Controller 4.1.4
 
-Automation controller replaces Ansible Tower.
-Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
-The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
-
-Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
-
-.Bug fixes
+.Automation Controller 4.1.4 Bug fixes
 
 * Fixed an issue where the installer failed at "Push execution environment images locally on Automation Controller and Execution Nodes" and was unable to make rootless runtime.

--- a/release-notes/topics/hub-441.adoc
+++ b/release-notes/topics/hub-441.adoc
@@ -1,9 +1,11 @@
+// This is the release notes for Automation Hub 4.4.1, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[hub-441-intro]]
-= Automation Hub 4.4.1
+= Automation Hub
 
 Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 
-.Enhancements and bug fixes
+.Automation Hub 4.4.1 enhancements and bug fixes
 
 * Added tasking system permissions so that users with the appropriate permissions can view and manage tasks
 * Added name, namespace name, and registry requirements when add/editing an execution environment

--- a/release-notes/topics/hub-443.adoc
+++ b/release-notes/topics/hub-443.adoc
@@ -1,9 +1,8 @@
+// This is the release notes for Automation Hub 4.4.3, the version number is removed from the topic title as part of the release notes restructuring efforts.
+
 [[hub-443-intro]]
-= Automation Hub 4.4.3
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
-.Bug fixes
+.Automation Hub 4.4.3 Bug fixes
 
 * Fixed an issue where idle connections were growing and not closing in the automation hub database.
 * Fixed an issue where private automation hub was unable to restore with an external database.

--- a/release-notes/topics/platform-intro.adoc
+++ b/release-notes/topics/platform-intro.adoc
@@ -19,3 +19,18 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
 See link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle] for additional information.
 
+== Upgrading Ansible Automation platform
+
+Use installer to perform upgrades to maintenance versions of Ansible Automation Platform. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+
+[IMPORTANT]
+====
+Do not use `yum update` to run upgrades. Use installer instead.
+====
+
+.Additional resources
+* Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+
+* For more information on upgrading your Ansible Automation Platform, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
+
+* For procedures related to using the Ansible Automation Platform installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].


### PR DESCRIPTION
This PR is to make similar release notes restructuring changes (done in AAP 2.4) in AAP 2.1 release notes.

JIRA: https://issues.redhat.com/browse/AAP-14005

Changes:
As per the release notes restructuring efforts, following changes are made:

- Restructured AAP 2.1 release notes based on AAP versions instead of release date.
- Removed release numbers of components like controller, hub, and so on.
- Retained only 2.1 specific updates, and removed updates for 2.2 and other versions.