### PR TITLE
2.1 AAP-433: Removed loopback address in automation hub inventory example

### DIFF
--- a/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-ext-database-inventory.adoc
@@ -19,7 +19,7 @@ This example describes how you can populate the inventory file to deploy a stand
 
 
 [automationhub]
-127.0.0.1 ansible_connection=local
+<FQDN> ansible_connection=local
 
 [database]
 host2

--- a/downstream/modules/platform/ref-standalone-hub-inventory.adoc
+++ b/downstream/modules/platform/ref-standalone-hub-inventory.adoc
@@ -19,7 +19,7 @@ This example describes how you can populate the inventory file to deploy a stand
 
 
 [automationhub]
-127.0.0.1 ansible_connection=local
+<FQDN> ansible_connection=local
 
 [all:vars]
 registry_url='registry.redhat.io'


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-433.

Changes made:

- Replaced loopback address (127.0.0.1) to placeholder <FQDN> in automation hub inventory example (See examples in sections 2.3.4 and section 2.4.4)

Affects `titles/aap-installation-guide/`