### PR TITLE
AAP-483: Corrected the podman login registry address

### DIFF
--- a/downstream/modules/dev-guide/proc-downloading-base-ees.adoc
+++ b/downstream/modules/dev-guide/proc-downloading-base-ees.adoc
@@ -18,7 +18,7 @@ Base images that ship with AAP 2.0 are hosted on the Red Hat Ecosystem Catalog (
 . Log in to registry.redhat.io
 +
 -----
-$ podman login registry.redhat.com
+$ podman login registry.redhat.io
 -----
 +
 . Pull the base images from the registry


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-483.

Change made:
Corrected the login instructions read podman login registry.redhat**.com** to registry.redhat**.io**.
