### PR TITLE
AAP-14132 updated Chapter 8. Migrating RH AAP to AAP Operator

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -12,9 +12,8 @@ Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to
 
 Use these procedures to migrate any of the following deployments to the {OperatorPlatform}:
 
-* A VM-based installation of {ControllerName} or {HubName},
-* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2), or
-* An AWX instance
+* A VM-based installation of Ansible Tower 3.8.6, {ControllerName}, or {HubName}
+* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-14132](https://issues.redhat.com/browse/AAP-14132)

**Actual Behavior**

+ A VM-based installation of automation controller or automation hub,
+ An Openshift instance of Ansible Tower 3.8.6 (Ansible Automation Platform 1.2), or
+ An AWX instance

**Expected Behavior**

+ A VM-based installation of Ansible Tower 3.8.6, automation controller or automation hub,
+ An Openshift instance of Ansible Tower 3.8.6 (Ansible Automation Platform 1.2)
