### PR TITLE
Added automationedacontoller_pg_* variables

### DIFF
--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -5,30 +5,32 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description* 
+| *`automationedacontroller_admin_password`* | The admin password used by the EDA controller
+
 | *`automationedacontroller_admin_username`* | Username used by django to identify and create the admin superuser in {EDAcontroller}.
 
-Default = admin
+Default = `admin`
 | *`automationedacontroller_admin_email`* | Email address used by django for the admin user for {EDAcontroller}. 
 
-Default = admin@example.com
+Default = `admin@example.com`
 | *`automationedacontroller_disable_https`* | Boolean flag to disable HTTPS {EDAcontroller}. 
 
-Default = false
+Default = `false`
 | *`automationedacontroller_disable_hsts`* | Boolean flag to disable HSTS {EDAcontroller}. 
 
-Default = false
+Default = `false`
 | *`automationedacontroller_user_headers`* | List of additional nginx headers to add to {EDAcontroller}'s nginx configuration. 
 
 Default = empty list
 | *`automationedacontroller_nginx_tls_files_remote`* | Boolean flag to specify whether cert sources are on the remote host (true) or local (false). 
 
-Default = false
+Default = `false`
 | *`automationedacontroller_allowed_hostnames`* | List of additional addresses to enable for user access to {EDAcontroller}.
 
 Default = empty list
-| *`automationedacontroller_controller_verify_ssl`* | Boolean flag used to verify Automation Controller's web certificates when making calls from {EDAcontroller}. Verified is true; not verified is false. 
+| *`automationedacontroller_controller_verify_ssl`* | Boolean flag used to verify Automation Controller's web certificates when making calls from {EDAcontroller}. Verified is `true`; not verified is `false`. 
 
-Default = false
+Default = `false`
 //Add this variable back for the next release, as long as approved by development.
 //| *`automationedacontroller_websocket_ssl_verify`* | 
 //SSL verification for the Daphne websocket used by podman to communicate from the pod to the host. Default is false to disable SSL connection as verified
@@ -37,6 +39,12 @@ Default = false
 | *`automationedacontroller_gunicorn_workers`* | Number of workers for the API served through gunicorn.
 
 Default = (# of cores or threads) * 2 + 1
+| *`automationedacontroller_pg_database`* | The postgres database used by {EDAController.}
+| *`automationnedacontroller_pg_host`* | The hostname of the postgres database used by {EDAController}, which can be an externally managed database.
+| *`automationedacontroller_pg_password`* | The password for the postgres database used by {EDAController}.
+| *`automationedacontroller_pg_port`* | The port number of the postgres database used by {EDAController}.
+
+Default = `5432`
 | *`automationedacontroller_rq_workers`* | Number of rq workers used by {EDAcontroller}.
 
 Default =  (# of cores or threads) * 2 + 1

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -5,7 +5,7 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description* 
-| *`automationedacontroller_admin_password`* | The admin password used by the EDA controller
+| *`automationedacontroller_admin_password`* | The admin password used by the {EdaController} instance.
 
 | *`automationedacontroller_admin_username`* | Username used by django to identify and create the admin superuser in {EDAcontroller}.
 
@@ -45,7 +45,7 @@ Default = (# of cores or threads) * 2 + 1
 | *`automationedacontroller_pg_port`* | The port number of the postgres database used by {EDAController}.
 
 Default = `5432`
-| *`automationedacontroller_rq_workers`* | Number of rq workers used by {EDAcontroller}.
+| *`automationedacontroller_rq_workers`* | Number of rq workers (Python processes that run in the background) used by {EDAcontroller}.
 
 Default =  (# of cores or threads) * 2 + 1
 |====

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -39,7 +39,7 @@ Default = `false`
 | *`automationedacontroller_gunicorn_workers`* | Number of workers for the API served through gunicorn.
 
 Default = (# of cores or threads) * 2 + 1
-| *`automationedacontroller_pg_database`* | The postgres database used by {EDAController.}
+| *`automationedacontroller_pg_database`* | The postgres database used by {EDAController}.
 
 Default = `automtionedacontroller`.
 | *`automationnedacontroller_pg_host`* | The hostname of the postgres database used by {EDAController}, which can be an externally managed database.

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -41,7 +41,7 @@ Default = `false`
 Default = (# of cores or threads) * 2 + 1
 | *`automationedacontroller_pg_database`* | The postgres database used by {EDAController.}
 
-Default = `awx`.
+Default = `automtionedacontroller`.
 | *`automationnedacontroller_pg_host`* | The hostname of the postgres database used by {EDAController}, which can be an externally managed database.
 | *`automationedacontroller_pg_password`* | The password for the postgres database used by {EDAController}.
 
@@ -52,7 +52,7 @@ They can cause the password to fail.
 Default = `5432`.
 | *`automationedacontroller_pg_username`* | The username for yout {EDAController} postgres database.
 
-Default = `awx`.
+Default = `automationedacontroller`.
 | *`automationedacontroller_rq_workers`* | Number of rq workers (Python processes that run in the background) used by {EDAcontroller}.
 
 Default =  (# of cores or threads) * 2 + 1

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -40,11 +40,19 @@ Default = `false`
 
 Default = (# of cores or threads) * 2 + 1
 | *`automationedacontroller_pg_database`* | The postgres database used by {EDAController.}
+
+Default = `awx`.
 | *`automationnedacontroller_pg_host`* | The hostname of the postgres database used by {EDAController}, which can be an externally managed database.
 | *`automationedacontroller_pg_password`* | The password for the postgres database used by {EDAController}.
+
+Do not use special characters for `edacontroller_pg_password`. 
+They can cause the password to fail.
 | *`automationedacontroller_pg_port`* | The port number of the postgres database used by {EDAController}.
 
-Default = `5432`
+Default = `5432`.
+| *`automationedacontroller_pg_username`* | The username for yout {EDAController} postgres database.
+
+Default = `awx`.
 | *`automationedacontroller_rq_workers`* | Number of rq workers (Python processes that run in the background) used by {EDAcontroller}.
 
 Default =  (# of cores or threads) * 2 + 1

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -119,6 +119,10 @@ The database name.
 
 Default = `automationhub`
 | *`automationhub_pg_host`* | Required if not using internal database.
+
+The hostname of the remote postgres database used by {HubName}
+
+Default = `127.0.0.1`
 | *`automationhub_pg_password`* | The password for the {HubName} PostgreSQL database.
 
 Do not use special characters for `automationhub_pg_password`. 


### PR DESCRIPTION
Also amended automationhub_pg_host

Event driven ansible inventory variables are missing automationedacontroller_pg_*

https://issues.redhat.com/browse/AAP-14193