### PR TITLE
2.3 Remove empty Additional Resources sections (#1203)

### DIFF
--- a/downstream/assemblies/aap-on-azure/assembly-aap-azure-install.adoc
+++ b/downstream/assemblies/aap-on-azure/assembly-aap-azure-install.adoc
@@ -5,9 +5,6 @@ ifdef::context[:parent-context: {context}]
 
 :context: aap-azure-install
 
-// [role="_abstract"]
-// You can use these instructions to install 
-
 == Prerequisites
 
 .Azure requirements
@@ -35,16 +32,6 @@ include::aap-on-azure/proc-azure-accessing-aap.adoc[leveloffset=+1]
 include::aap-on-azure/proc-azure-license-association.adoc[leveloffset=+2]
 include::aap-on-azure/proc-azure-configure-ad-sso.adoc[leveloffset=+2]
 // include::aap-on-azure/[leveloffset=+2]
-
-////
-[role="_additional-resources"]
-.Additional resources
-
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-////
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/builder/assembly-intro-to-builder.adoc
+++ b/downstream/assemblies/builder/assembly-intro-to-builder.adoc
@@ -8,16 +8,4 @@ Using Ansible content that depends on non-default dependencies can be complicate
 
 include::builder/con-about-ee.adoc[leveloffset=+1]
 include::builder/con-why-ee.adoc[leveloffset=+2]
-//include::builder/con-about-builder.adoc[leveloffset=+1]
-//include::builder/con-why-builder.adoc[leveloffset=+2]
 
-////
-Consider adding a link to future Builder docs here
-[role="_additional-resources"]
-.Additional resources
-
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-////

--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -16,16 +16,5 @@ include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]
 include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]
 
-
-////
-[role="_additional-resources"]
-== Additional resources (or Next steps)
-Optional. Delete if not used.
-* A bulleted list of links to other material closely related to the contents of the assembly, including xref links to other assemblies in your collection.
-* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-////
-
-
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-configuring-proxy-support-controller.adoc
+++ b/downstream/modules/platform/proc-configuring-proxy-support-controller.adoc
@@ -30,11 +30,3 @@ $ vi /etc/tower/conf.d/remote_host_headers.py`
 
 {ControllerNameStart} determines the remote host's IP address by searching through the list of headers in `REMOTE_HOST_HEADERS` until the FIRST IP address is located.
 
-
-[role="_additional-resources"]
-.Additional resources
-
-* A bulleted list of links to other material closely related to the contents of the procedure module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/downstream/modules/platform/ref-controller-system-requirements.adoc
+++ b/downstream/modules/platform/ref-controller-system-requirements.adoc
@@ -74,8 +74,6 @@ All of these are great approaches to managing larger environments. For further q
 
 [role="_additional-resources"]
 .Additional resources
-////
-Optional. Delete if not used.
 
-////
 * link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html?extIdCarryOver=true&sc_cid=7013a00000388B5AAI[Import a subscription].
+

--- a/downstream/modules/security/con-about-firewall-policy-management.adoc
+++ b/downstream/modules/security/con-about-firewall-policy-management.adoc
@@ -1,9 +1,3 @@
-////
-Base the file name and the ID on the module title. For example:
-* file name: con-my-concept-module-a.adoc
-* ID: [id="con-my-concept-module-a_{context}"]
-* Title: = My concept module A
-////
 [id="con-about-firewall-policy-management_{context}"]
 
 = About firewall policy management
@@ -18,7 +12,3 @@ Managing multiple firewall rules across various products and vendors can be both
 
 Ansible security automation interacts with a wide variety of security technologies from a range of vendors. Ansible enables security teams to manage different products, interfaces, and workflows in a unified way to produce a successful deployment. For example, your security team can automate tasks such as blocking and unblocking IP and URLs on supported technologies such as enterprise firewalls.
 
-////
-[role="_additional-resources"]
-.Additional resources
-////

--- a/downstream/modules/security/con-automate-idps-rules.adoc
+++ b/downstream/modules/security/con-automate-idps-rules.adoc
@@ -1,18 +1,6 @@
-////
-Base the file name and the ID on the module title. For example:
-* file name: con-my-concept-module-a.adoc
-* ID: [id="con-my-concept-module-a_{context}"]
-* Title: = My concept module A
-////
-
 [id="con-automate-ids-rules_{context}"]
 
 = Automating your IDPS rules with Ansible
-
-////
-[role="_abstract"]
-Write a short introductory paragraph that provides an overview of the module. The text that immediately follows the `[role="_abstract"]` tag is used for search metadata.
-////
 
 To automate your IDPS, use the `ids_rule` role to create and change Snort rules. Snort uses rule-based language that analyzes your network traffic and compares it against the given rule set.
 
@@ -22,8 +10,3 @@ Keep in mind that a real world setup will feature other vendors and technologies
 
 image::security-ids-sample-demo.png[Sample Ansible security automation integration]
 
-[role="_additional-resources"]
-.Additional resources
-////
-Optional. Delete if not used.
-////

--- a/downstream/modules/security/proc-creating-idps-rule.adoc
+++ b/downstream/modules/security/proc-creating-idps-rule.adoc
@@ -1,12 +1,3 @@
-////
-Base the file name and the ID on the module title. For example:
-* file name: proc-doing-procedure-a.adoc
-* ID: [id="doing-procedure-a_{context}"]
-* Title: = Doing procedure A
-
-The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-////
-
 [id="proc-creating-ids-rule_{context}"]
 
 = Creating a new IDPS rule
@@ -92,7 +83,3 @@ Once you run the playbook, all of your tasks will be executed in addition to you
 
 To verify that your IDPS rules were successfully created, SSH to the Snort server and view the content of the `/etc/snort/rules/local.rules` file.
 
-////
-[role="_additional-resources"]
-.Additional resources
-////


### PR DESCRIPTION
Empty additional resources sections are causing the assemblies or modules that follow them to be enclosed in a box.
Delete empty sections.