### PR TITLE
Backport PR #1218 to AAP v2.2

### DIFF
--- a/downstream/modules/dev-guide/proc-downloading-base-ees.adoc
+++ b/downstream/modules/dev-guide/proc-downloading-base-ees.adoc
@@ -18,7 +18,7 @@ Base images that ship with AAP 2.0 are hosted on the Red Hat Ecosystem Catalog (
 . Log in to registry.redhat.io
 +
 -----
-$ podman login registry.redhat.com
+$ podman login registry.redhat.io
 -----
 +
 . Pull the base images from the registry


### PR DESCRIPTION
This PR backports PR https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1218 from main to AAP v2.3.