### PR TITLE
AAP-14282 - Updated the galaxy URL and removed requirement for subdirectory

### DIFF
--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
@@ -13,7 +13,7 @@ Configure Red Hat automation hub as your primary source of content by using the 
 [IMPORTANT]
 ====
 Creating a new token revokes any previous tokens generated for Private Automation Hub. Ensure that you update any Controller or scripts that you created with the previous token.
-====
+=======
 
 .Procedure
 
@@ -25,7 +25,8 @@ Creating a new token revokes any previous tokens generated for Private Automatio
 [galaxy_server._<server_name>_]
 -----
 
-. Set the `url` option for each server name. You must include the `api/galaxy/` subdirectory in the server URL:
+. Set the `url` option for each server name:
+//You must include the `api/galaxy/` subdirectory in the server URL:
 +
 [subs="+quotes"]
 -----
@@ -42,7 +43,7 @@ The following `ansible.cfg` configuration file example shows how to configure mu
 server_list = automation_hub, my_org_hub
 
 [galaxy_server.automation_hub]
-url=https://cloud.redhat.com/api/automation-hub/api/galaxy/ <1> <2>
+url=https://console.redhat.com/api/automation-hub/api/galaxy/ <1> <2>
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 
 token=my_ah_token

--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
@@ -13,7 +13,7 @@ Configure Red Hat automation hub as your primary source of content by using the 
 [IMPORTANT]
 ====
 Creating a new token revokes any previous tokens generated for Private Automation Hub. Ensure that you update any Controller or scripts that you created with the previous token.
-=======
+====
 
 .Procedure
 


### PR DESCRIPTION
This PR addresses the changes for https://issues.redhat.com/browse/AAP-14282 and includes the following changes:

Changed URL to https://console.redhat.com/api/automation-hub/content/published/
Removed statement:  You must include the api/galaxy/ subdirectory in the server URL: