### PR TITLE
AAP-14410: Restructured the AAP 1.2 release notes

### DIFF
--- a/release-notes/master.adoc
+++ b/release-notes/master.adoc
@@ -2,85 +2,49 @@
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 
-include::topics/upgrading.adoc[leveloffset=+1]
+[[anchor-aap_1.2-release]]
+== Red Hat Ansible Automation Platform 1.2
+This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
 
-[[anchor-october-2021-release]]
-== October 2021 release
-
-include::topics/insights-102021.adoc[leveloffset=+2]
-
-[[anchor-september-2021-release]]
-== September 2021 release
-
-include::topics/platform-intro-125.adoc[leveloffset=+2]
-
-include::topics/tower-intro-384.adoc[leveloffset=+2]
-
-include::topics/hub-426.adoc[leveloffset=+2]
-
-[[anchor-july-2021-release]]
-== July 2021 release
+include::topics/platform-installer-121.adoc[leveloffset=+2]
 
 include::topics/platform-intro-124.adoc[leveloffset=+2]
 
-include::topics/hub-424.adoc[leveloffset=+2]
+include::topics/aap-126.adoc[leveloffset=+2]
 
-include::topics/insights-062021.adoc[leveloffset=+2]
-
-[[anchor-may-2021-release]]
-== May 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.3
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-383.adoc[leveloffset=+3]
-
-include::topics/hub-423.adoc[leveloffset=+3]
-
-[[anchor-mar-2021-release]]
-== March 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.2
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-382.adoc[leveloffset=+3]
-
-include::topics/hub-422.adoc[leveloffset=+3]
-
-[[anchor-jan-2021-release]]
-== January 2021 release
-
-=== Red Hat Ansible Automation Platform 1.2.1
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/platform-installer-121.adoc[leveloffset=+3]
+include::topics/tower-intro-38.adoc[leveloffset=+2]
 
 include::topics/tower-intro-381.adoc[leveloffset=+3]
 
-include::topics/hub-421.adoc[leveloffset=+3]
+include::topics/tower-intro-382.adoc[leveloffset=+3]
 
+include::topics/tower-intro-383.adoc[leveloffset=+3]
 
-[[anchor-nov-2020-release]]
-== November 2020 release
-
-=== Red Hat Ansible Automation Platform 1.2.0
-
-The latest version of Red Hat Automation Platform includes the following:
-
-include::topics/tower-intro-38.adoc[leveloffset=+3]
+include::topics/tower-intro-384.adoc[leveloffset=+2]
 
 include::topics/hub-42.adoc[leveloffset=+3]
 
+include::topics/hub-421.adoc[leveloffset=+3]
+
+include::topics/hub-422.adoc[leveloffset=+3]
+
+include::topics/hub-423.adoc[leveloffset=+3]
+
+include::topics/hub-424.adoc[leveloffset=+3]
+
+include::topics/hub-426.adoc[leveloffset=+3]
+
 include::topics/catalog-11-2020.adoc[leveloffset=+3]
 
+[[anchor-aap_insights-release]]
+== Red Hat Insights for Red Hat Ansible Automation Platform
 
+include::topics/insights-062021.adoc[leveloffset=+2]
 
+include::topics/insights-102021.adoc[leveloffset=+2]
 
-[[anchor-oct-2020-release]]
-== October 2020 release
+[[anchor-aap-automation-analytics-10-2020-release]]
+== Red Hat Automation Analytics October 2020 release
 
 include::topics/introduction.adoc[leveloffset=+2]
 
@@ -91,24 +55,3 @@ include::topics/new-features-oct-2020.adoc[leveloffset=+2]
 include::topics/enhancements-102020.adoc[leveloffset=+2]
 
 include::topics/bugfixes-102020.adoc[leveloffset=+2]
-
-////
-[[anchor-may-2020-release]]
-== May 2020 release
-
-include::topics/new-features-may-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements-052020.adoc[leveloffset=+2]
-
-include::topics/bugfixes-052020.adoc[leveloffset=+2]
-
-
-[[anchor-february-2020-release]]
-== February 2020 release
-
-include::topics/new-features-feb-2020.adoc[leveloffset=+2]
-
-include::topics/enhancements.adoc[leveloffset=+2]
-
-include::topics/bugfixes-022020.adoc[leveloffset=+2]
-////

--- a/release-notes/topics/aap-126.adoc
+++ b/release-notes/topics/aap-126.adoc
@@ -5,5 +5,5 @@
 
 * Updated openshift-clients package that ships with Ansible Tower 3.7 and 3.8
 * Modified database backup and restore logic to compress dump data
-* Added ability to provide custom secret key when running rekey.yml
+* Added ability to provide custom secret key when running `rekey.yml`
 * Fixed a bug where the selinux-policy was not recognized during installation

--- a/release-notes/topics/aap-126.adoc
+++ b/release-notes/topics/aap-126.adoc
@@ -1,0 +1,9 @@
+[[aap-1.2.6-intro]]
+= Ansible Automation Platform 1.2.6
+
+.Enhancements and bug fixes
+
+* Updated openshift-clients package that ships with Ansible Tower 3.7 and 3.8
+* Modified database backup and restore logic to compress dump data
+* Added ability to provide custom secret key when running rekey.yml
+* Fixed a bug where the selinux-policy was not recognized during installation

--- a/release-notes/topics/hub-421.adoc
+++ b/release-notes/topics/hub-421.adoc
@@ -1,8 +1,6 @@
 [[hub-421-intro]]
 = Automation Hub 4.2.1
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Private Automation Hub bug fixes and enhancements 
 
 * Fixed NamespaceLink creation and Validation on duplicated name

--- a/release-notes/topics/hub-422.adoc
+++ b/release-notes/topics/hub-422.adoc
@@ -1,8 +1,6 @@
 [[hub-422-intro]]
 = Automation Hub 4.2.2
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes and enhancements 
 
 * Fixed the `galaxy-importer` check for max size of docs files 

--- a/release-notes/topics/hub-423.adoc
+++ b/release-notes/topics/hub-423.adoc
@@ -1,10 +1,7 @@
 [[hub-423-intro]]
 = Automation Hub 4.2.3
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
-
 
 * Fix how travis checks for existence of Jira issues
 

--- a/release-notes/topics/hub-424.adoc
+++ b/release-notes/topics/hub-424.adoc
@@ -1,10 +1,7 @@
 [[hub-424-intro]]
 = Automation Hub 4.2.4
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
-
 
 * Fix "CVE-2021-32052 django: header injection" by moving to django 2.2.23
 

--- a/release-notes/topics/hub-426.adoc
+++ b/release-notes/topics/hub-426.adoc
@@ -1,8 +1,6 @@
 [[hub-426-intro]]
 = Automation Hub 4.2.6
 
-Automation Hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible Automation Hub, you can discover and manage Ansible Collections which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
-
 .Automation Hub bug fixes
 
 * Implemented filters for state and keywords on imports API

--- a/release-notes/topics/insights-062021.adoc
+++ b/release-notes/topics/insights-062021.adoc
@@ -1,8 +1,8 @@
 [[insights-062021]]
 
-= Insights for Ansible Automation Platform
-
 Insights for Ansible Automation Platform gives you feedback about your automation deployments through insights and governance which allow you to view information about automation health, usage, and performance across your enterprise.
+
+.June 2021 release
 
 This release introduces the automation savings planner to Insights for Ansible Automation Platform. The automation savings planner is a tool where users can track their automation efforts by creating automation savings plans, each with a defined set of tasks needed to complete their plans. Users can also view a calculation of their cost savings from automating these tasks.
 

--- a/release-notes/topics/insights-102021.adoc
+++ b/release-notes/topics/insights-102021.adoc
@@ -1,10 +1,5 @@
 [[insights-102021]]
 
-= Red Hat Insights for Red Hat Ansible Automation Platform
+.October 2021 release
 
-Insights for Ansible Automation Platform gives you feedback about your automation deployments through insights and governance which allow you to view information about automation health, usage, and performance across your enterprise.
-
-This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.
-
-.Reports feature
-* Added a reports feature that gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics.
+This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. The reports feature that gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.

--- a/release-notes/topics/insights-102021.adoc
+++ b/release-notes/topics/insights-102021.adoc
@@ -2,4 +2,4 @@
 
 .October 2021 release
 
-This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. The reports feature that gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.
+This release introduces reports to Insights for Ansible Automation Platform. The reports feature on the Ansible Automation Platform provides users with a visual overview of their automation efforts across different teams using Ansible. The reports feature gives you a visual overview of how your Ansible automation environment is running, across a variety of metrics. Each report is designed to help users monitor the status of their automation environment, be it the frequency of playbook runs or the status of hosts affected by various job templates.

--- a/release-notes/topics/platform-intro.adoc
+++ b/release-notes/topics/platform-intro.adoc
@@ -13,3 +13,22 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 |1.2.0 | 3.8.0 | 4.2.0 | hosted service | hosted service
 
 |===
+
+== Red Hat Ansible Automation Platform life cycle
+
+Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
+Refer to link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle].
+
+== Upgrading Ansible Automation platform
+
+Perform upgrades to maintenance versions of Ansible Automation Platform using the installer. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+
+[IMPORTANT]
+====
+Do not use `yum update` to run upgrades. Use installer instead.
+====
+
+Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+
+See https://docs.ansible.com/ansible-tower/latest/html/quickinstall/index.html[Ansible Automation Platform Quick Installation Guide] for procedures on using the Ansible Automation Platform installer.
+

--- a/release-notes/topics/tower-intro-381.adoc
+++ b/release-notes/topics/tower-intro-381.adoc
@@ -1,11 +1,6 @@
 [[tower-381-intro]]
 = Ansible Tower 3.8.1
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes and enhancements
 
 * Improved analytics collection to collect the playbook status for all hosts in a playbook run

--- a/release-notes/topics/tower-intro-382.adoc
+++ b/release-notes/topics/tower-intro-382.adoc
@@ -1,11 +1,6 @@
 [[tower-382-intro]]
 = Ansible Tower 3.8.2
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes and enhancements
 
 * Upgraded to the latest oVirt inventory plugin to resolve a number of inventory syncing issues that can occur on RHEL7

--- a/release-notes/topics/tower-intro-383.adoc
+++ b/release-notes/topics/tower-intro-383.adoc
@@ -1,11 +1,6 @@
 [[tower-383-intro]]
 = Ansible Tower 3.8.3
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
 .Bux fixes 
 
 * Analytics collection no longer cause lost job events when Tower is under load

--- a/release-notes/topics/tower-intro-384.adoc
+++ b/release-notes/topics/tower-intro-384.adoc
@@ -1,12 +1,6 @@
 [[tower-384-intro]]
 = Ansible Tower 3.8.4
 
-Ansible Tower helps teams centralize and control your IT infrastructure with
-a visual dashboard, role-based access control, job scheduling, integrated
-notifications and graphical inventory management.  Easily embed Ansible
-Automation into existing tools and processes with REST API and CLI.
-
-
 .Bux fixes
 
 * Running inventories of ~60k hosts no longer takes a very long time for events to show up


### PR DESCRIPTION
This PR is to make similar release notes restructuring changes (done in AAP 2.4) in AAP 1.2 release notes.

JIRA: https://issues.redhat.com/browse/AAP-14410.

Changes:
As per the release notes restructuring efforts, following changes are made:
- Restructured AAP 1.2 release notes based on AAP versions instead of release date.
- Removed release numbers of components like controller, hub, and so on.
- Retained only 1.2 specific updates