### PR TITLE
AAP-960: Updated the minimum requirements for execution nodes

### DIFF
--- a/downstream/modules/platform/ref-controller-system-requirements.adoc
+++ b/downstream/modules/platform/ref-controller-system-requirements.adoc
@@ -9,7 +9,7 @@ Use the following recommendations for node sizing:
 
 [NOTE]
 ====
-On all nodes except hop nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
+On control and hybrid nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
 ====
 
 .Execution nodes
@@ -20,7 +20,7 @@ Runs automation. Increases memory and CPU to increase capacity for running more 
 h| Requirement | Required
 | *RAM* | 16 GB
 | *CPUs* | 4
-| *Local disk* | 40GB minimum with at least 20GB available under /var/lib/awx
+| *Local disk* | 40GB minimum
 |===
 
 .Control nodes


### PR DESCRIPTION
This PR addresses doc update for JIRA: https://issues.redhat.com/browse/AAP-960.

Changes made:

- Updated the minimum requirements for execution nodes to remove 'at least 20GB available under /var/lib/awx' req. for execution nodes.

Once this PR is merged, I'll create backport PRs to reflect the changes in v2.4 and v2.3. 