### PR TITLE
AAP-960-v22: Updated the minimum requirements for execution nodes

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -45,7 +45,7 @@ The following table provides recommendations for node sizing:
 
 [NOTE]
 ====
-On all nodes except hop nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
+On control and hybrid nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
 ====
 
 [cols="a,a,a"]
@@ -57,6 +57,7 @@ On all nodes except hop nodes, allocate a minimum of 20 GB to `/var/lib/awx` for
 
 h| RAM | 16 GB  |
 
+* Storage volume IOPS of 1500 or more is recommended.
 
 h| CPUs | 4|
 


### PR DESCRIPTION
This PR addresses doc update for JIRA: https://issues.redhat.com/browse/AAP-960.

Changes made:

- Updated the minimum requirements for execution nodes to remove 'at least 20GB available under /var/lib/awx' req. for execution nodes.
- Added storage volume recommendation for execution nodes. 

Once this PR is merged, I'll create a backport PR to reflect the changes in v2.1. 