### PR TITLE
Backport 2.4 1192 AAP-13734 Updates to code samples in Chapter 2

### DIFF
--- a/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-customer-provided.adoc
@@ -43,7 +43,8 @@ execution1.example.com node_type=execution
 
 [automationhub]
 automationhub.example.com
-
+[automationedacontroller]
+eda.example.com
 [database]
 
 [all:vars]
@@ -144,4 +145,5 @@ automationedacontroller_pg_password='<password>'
 # The default install will deploy SSO with sso_use_https=True
 # Keystore password is required for https enabled SSO
 sso_keystore_password=''
+
 -----

--- a/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
+++ b/downstream/modules/platform/ref-example-platform-ext-database-inventory.adoc
@@ -40,7 +40,8 @@ execution2.example.com node_type=execution
 
 [automationhub]
 automationhub.exaample.com
-
+[automationedacontroller]
+eda.example.com
 [database]
 data.example.com
 

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -29,39 +29,13 @@ automationedacontroller_pg_password='<password>'
 #
 automation_controller_main_url = 'https://controller.example.com/'
  
-
 # Boolean flag used to verify Automation Controller's
 # web certificates when making calls from Automation EDA Controller.
 #
 automationedacontroller_controller_verify_ssl = true
 
-# SSL-related variables
-
-# If set, this will install a custom CA certificate to the system trust store.
-# custom_ca_cert=/path/to/ca.crt
-
-# Certificate and key to install in nginx for the web UI and API
-# web_server_ssl_cert=/path/to/tower.cert
-# web_server_ssl_key=/path/to/tower.key
-
-# Certificate and key to install in Automation Hub node
-# automationhub_ssl_cert=/path/to/automationhub.cert
-# automationhub_ssl_key=/path/to/automationhub.key
-
-# Server-side SSL settings for PostgreSQL (when we are installing it).
-# postgres_use_ssl=False
-# postgres_ssl_cert=/path/to/pgsql.crt
-# postgres_ssl_key=/path/to/pgsql.key
-
-# Keystore file to install in SSO node
-# sso_custom_keystore_file='/path/to/sso.jks'
-
-# The default install will deploy SSO with sso_use_https=True
-# Keystore password is required for https enabled SSO
-sso_keystore_password=''
-
-
 -----
+
 [role="_additional-resources"]
 .Additional resources
 * For more details on {EDAName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event-driven_ansible_guide/index[Getting Started with Event-Driven Ansible Guide].


### PR DESCRIPTION
Updates to code samples in the Red Hat Ansible Automation Platform Installation Guide, specifically adding the following lines

[automationedacontroller]
eda.example.com

to the following sections:

[2.1.1.4](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-standlone-platform-ext-database-inventory_platform-install-scenario) - Lines 46-47
[2.1.1.5](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-example-platform-ext-database-customer-provided_platform-install-scenario) - Lines 43-44
Also, removed the SSL-related variables from the EDA controller code sample:

[2.1.1.6](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#ref-single-eda-controller-with-internal-db_platform-install-scenario) - after line 36