### PR TITLE
[Backport] - AAP-1320 Changed Ansible navigator to Automation content navigator

### DIFF
--- a/downstream/assemblies/navigator/assembly-executing-content.adoc
+++ b/downstream/assemblies/navigator/assembly-executing-content.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-Now that you have your {ExecEnvName} built, you can use Ansible content navigator in order to validate that the content will be run in the same manner as the automation controller will run it.
+Now that you have your {ExecEnvName} built, you can use automation content navigator to validate that the content will be run in the same manner as the automation controller will run it.
 
 
 // include::navigator/con-about-ansible-navigator.adoc[leveloffset=+1]

--- a/downstream/modules/dev-guide/con-content-workflows.adoc
+++ b/downstream/modules/dev-guide/con-content-workflows.adoc
@@ -14,5 +14,5 @@ As {ControllerName} shifts to using {ExecEnvName}, tools like {Navigator} and {B
 [role="_additional-resources"]
 .Additional resources
 
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide[Ansible Navigator Creator Guide] for more on using {Navigator}.
+* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Automation Content Navigator Creator Guide] for more on using {Navigator}.
 * For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].

--- a/downstream/modules/navigator/ref-navigator-command-comparison.adoc
+++ b/downstream/modules/navigator/ref-navigator-command-comparison.adoc
@@ -8,7 +8,7 @@ The {Navigator} commands run familiar Ansible CLI commands in `-m stdout` mode. 
 .Comparison of {Navigator} and Ansible CLI commands
 [options="header"]
 |====
-|Ansible navigator command|Ansible CLI command
+|{Navigator} command|Ansible CLI command
 |`ansible-navigator collections`|`ansible-galaxy collection`
 |`ansible-navigator config`|`ansible-config`
 |`ansible-navigator doc`|`ansible-doc`

--- a/downstream/titles/navigator-guide/docinfo.xml
+++ b/downstream/titles/navigator-guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Ansible Navigator Creator Guide</title>
+<title>Automation Content Navigator Creator Guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.3</productnumber>
 <subtitle>Using Ansible Navigator in the Ansible Creator Workflow.</subtitle>

--- a/downstream/titles/navigator-guide/master.adoc
+++ b/downstream/titles/navigator-guide/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Ansible Navigator Creator Guide
+= Automation Content Navigator Creator Guide
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR backports the changes for #1241 to the 2.3 branch and includes the following: 

* AAP-1320 Changed Ansible navigator to Automation content navigator

* AAP-1320 - Changed title of document to Automation Content Navigator Creator Guide