### PR TITLE
[Backport] rmeda - changed EDA to use the attribute in sys req prereqs (#1288)

### DIFF
--- a/downstream/assemblies/platform/assembly-system-requirements.adoc
+++ b/downstream/assemblies/platform/assembly-system-requirements.adoc
@@ -10,7 +10,7 @@ Use this information when planning your {PlatformName} installations and designi
 .Prerequisites
 
 * You must be able to obtain root access either through the `sudo` command, or through privilege escalation. For more on privilege escalation see link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html[Understanding Privilege Escalation].
-* You must be able to de-escalate privileges from root to users such as: AWX, PostgreSQL, EDA, or Pulp.
+* You must be able to de-escalate privileges from root to users such as: AWX, PostgreSQL, {EDAName}, or Pulp.
 
 include::platform/ref-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR backports the changes from #1288 to the 2.4 branch.