### PR TITLE
AAP-14883 add URL to link reference

### DIFF
--- a/downstream/modules/platform/ref-converting-playbook-examples.adoc
+++ b/downstream/modules/platform/ref-converting-playbook-examples.adoc
@@ -83,7 +83,7 @@ bash-4.4#
 
 You are now inside the running execution environment container.
 
-Look at the permissions, you will see that *awx* has become ‘root’, but this is not really root as in the superuser, as you are using rootless Podman, which maps users into a kernel namespace similar to a sandbox. Learn more about How does rootless Podman work? for shadow-utils.
+Look at the permissions, you will see that *awx* has become ‘root’, but this is not really root as in the superuser, as you are using rootless Podman, which maps users into a kernel namespace similar to a sandbox. Learn more about link:https://opensource.com/article/19/2/how-does-rootless-podman-work[How does rootless Podman work?] for shadow-utils.
 
 ----
 bash-4.4# ls -la /mydata/


### PR DESCRIPTION
This PR fixes a missing link in the AAP Migration and Upgrade Guide version 2.4. This change was requested in [AAP-14883](https://issues.redhat.com/browse/AAP-14883)