### PR TITLE
AAP-15176: fixes broken links in release notes

### DIFF
--- a/downstream/titles/release-notes/topics/new-features-oct-2020.adoc
+++ b/downstream/titles/release-notes/topics/new-features-oct-2020.adoc
@@ -5,4 +5,4 @@ This Red Hat Automation Analytics release includes the following features:
 
 * The *Job Explorer* provides a detailed view of jobs run on Ansible Tower clusters across your organizations.
 You can access the Job Explorer by directly clicking on the navigation tab or using the drill-down view available across each of the application’s charts.
-See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/evaluating_your_automation_controller_job_runs_using_the_job_explorer/index[Evaluating your {ControllerName} jobs runs using the Job Explorer] to learn more.
+See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html/evaluating_your_automation_controller_job_runs_using_the_job_explorer/index[Evaluating your Ansible Tower job runs using the Job Explorer] to learn more.

--- a/downstream/titles/release-notes/topics/tower-intro-382.adoc
+++ b/downstream/titles/release-notes/topics/tower-intro-382.adoc
@@ -1,13 +1,13 @@
 [[tower-382-intro]]
 = Ansible Tower 3.8.2
 
-.Bux fixes and enhancements
+.Bug fixes and enhancements
 
 * Upgraded to the latest oVirt inventory plugin to resolve a number of inventory syncing issues that can occur on RHEL7
 * Upgraded to the latest theforeman.foreman inventory plugin to resolve a few bugs and performance regressions
-* Upgraded to a more recent version of Django to address https://access.redhat.com/security/cve/cve-2021-3281[CVE-2021-3281]
-* Upgraded to a more recent version of autobahn to address https://access.redhat.com/security/cve/cve-2021-35678[CVE-2020-35678]
-* Fixed a security issue that allowed a malicious playbook author to elevate to the awx user from outside the isolated environment https:https://access.redhat.com/security/cve/cve-2021-2025[CVE-2021-20253]
+* Upgraded to a more recent version of Django to address link:https://access.redhat.com/security/cve/cve-2021-3281[CVE-2021-3281]
+* Upgraded to a more recent version of autobahn to address link:https://access.redhat.com/security/cve/cve-2020-35678[CVE-2020-35678]
+* Fixed a security issue that allowed a malicious playbook author to elevate to the awx user from outside the isolated environment link:https://access.redhat.com/security/cve/cve-2021-20253[CVE-2021-20253]
 * Fixed several issues related to how Tower rotates its log files
 * Fixed the installer to no longer prevent Tower from installing on RHEL8 with certain non-en_US.UTF-8 locales
 * Fixed unanticipated delays in certain playbook output


### PR DESCRIPTION
This PR fixes broken links in release notes from Oct 2020. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info.