### PR TITLE
Backport-2.2-1234 Added new note and link to Chapt 8.4 in the Server Admin Guide

### DIFF
--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -13,7 +13,7 @@
 
 [NOTE]
 ====
-When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
+When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
 ====
 
 . Using the dropdown menu labeled _Add provider_, select your LDAP provider to proceed to the LDAP configuration page.
@@ -22,10 +22,10 @@ The following table lists the available options for your LDAP configuration:
 [cols="a,a"]
 |===
 h|Configuration Option  h|Description
-|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
-|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
+|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
+|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/configuring_authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/configuring_authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -10,16 +10,22 @@
 .Procedure
 . Log in to {AAPCentralAuth} as an SSO admin user.
 . From the navigation bar, select menu:Configure section[User Federation].
+
+[NOTE]
+====
+When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
+====
+
 . Using the dropdown menu labeled _Add provider_, select your LDAP provider to proceed to the LDAP configuration page.
 
 The following table lists the available options for your LDAP configuration:
 [cols="a,a"]
 |===
 h|Configuration Option  h|Description
-|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#storage_mode[this section] for more information.
-|Edit mode| Determines the types of modifications that admins can make on user metadata. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation#edit_mode[this section] for more information.
+|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
+|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/authentication#kerberos[this section] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -13,7 +13,7 @@
 
 [NOTE]
 ====
-When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
+When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
 ====
 
 . Using the dropdown menu labeled _Add provider_, select your LDAP provider to proceed to the LDAP configuration page.
@@ -22,10 +22,10 @@ The following table lists the available options for your LDAP configuration:
 [cols="a,a"]
 |===
 h|Configuration Option  h|Description
-|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
-|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
+|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
+|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -27,5 +27,5 @@ h|Configuration Option  h|Description
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/configuring_authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -27,5 +27,5 @@ h|Configuration Option  h|Description
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -27,5 +27,5 @@ h|Configuration Option  h|Description
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/configuring_authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
 |===


### PR DESCRIPTION
- Added a note to "Chapter 2 Adding a User Storage Provider (LDAP/Kerberos) to Ansible Automation Platform Central Authentication" in the [Installing and Configuring Central Authentication for the Ansible Automation Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/installing_and_configuring_central_authentication_for_the_ansible_automation_platform/index). Links to Chapter 8 of the [Server Administration Guide](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/clients#protocol-mappers).

- Also, updated links in the table so that they contain the right format (link:https:...)

- Lastly, updated all the instances of "this section" to the actual titles of the sections referred to.