### PR TITLE
Document installer variable for max_connections

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -95,6 +95,7 @@ Default = `awx`.
 
 `/path/to/pgsql.key`
 | *`postgres_use_ssl`* | If postgres is to use SSL.
+| *`postgres_max_connections`* | Max database connections setting to apply, if using installer-managed postgres. See the administration guide for help selecting a value.
 | *`receptor_listener_port`* | Port to use for recptor connection.
 
 Default = 27199.


### PR DESCRIPTION
This is a follow-up change after @kdelee made a change to the installer that allows users to set this variable.

The content I reference in the administration guide will be https://github.com/RedHatInsights/red-hat-ansible-automation-platform-documentation/pull/1099, but first put upstream, which should eventually make it back here.